### PR TITLE
Add AWS team as owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,11 @@ approvers:
 - jsafrane
 - nckturner
 - micahhausler
+- mcrute
+- gyuho
+- d-nishi
+- M00nF1sh
+- leakingtapan
 reviewers:
 - gnufied
 - jsafrane
@@ -13,3 +18,8 @@ reviewers:
 - chrislovecnm
 - nckturner
 - micahhausler
+- mcrute
+- gyuho
+- d-nishi
+- M00nF1sh
+- leakingtapan


### PR DESCRIPTION
Adds the AWS team as reviewers and approvers for the AWS cloud provider.

/kind cleanup
/sig aws