### PR TITLE
Copy latest version of in-tree provider

### DIFF
--- a/pkg/cloudprovider/providers/aws/BUILD
+++ b/pkg/cloudprovider/providers/aws/BUILD
@@ -1,0 +1,105 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "aws.go",
+        "aws_fakes.go",
+        "aws_instancegroups.go",
+        "aws_loadbalancer.go",
+        "aws_metrics.go",
+        "aws_routes.go",
+        "aws_utils.go",
+        "device_allocator.go",
+        "instances.go",
+        "log_handler.go",
+        "regions.go",
+        "retry_handler.go",
+        "sets_ippermissions.go",
+        "tags.go",
+        "volumes.go",
+    ],
+    importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/aws",
+    deps = [
+        "//pkg/api/v1/service:go_default_library",
+        "//pkg/controller:go_default_library",
+        "//pkg/credentialprovider/aws:go_default_library",
+        "//pkg/kubelet/apis:go_default_library",
+        "//pkg/volume:go_default_library",
+        "//pkg/volume/util:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/record:go_default_library",
+        "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/awserr:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/credentials:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/credentials/stscreds:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/ec2metadata:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/request:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/autoscaling:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/elb:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/elbv2:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/kms:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/sts:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/gopkg.in/gcfg.v1:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "aws_loadbalancer_test.go",
+        "aws_test.go",
+        "device_allocator_test.go",
+        "instances_test.go",
+        "regions_test.go",
+        "retry_handler_test.go",
+        "tags_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/kubelet/apis:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/elb:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/mock:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/pkg/cloudprovider/providers/aws/OWNERS
+++ b/pkg/cloudprovider/providers/aws/OWNERS
@@ -1,0 +1,13 @@
+approvers:
+- justinsb
+- zmerlynn
+- gnufied
+- jsafrane
+reviewers:
+- gnufied
+- jsafrane
+- justinsb
+- zmerlynn
+- chrislovecnm
+- nckturner
+- micahhausler

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1,0 +1,4384 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/sts"
+	gcfg "gopkg.in/gcfg.v1"
+	"k8s.io/klog"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/kubernetes/pkg/api/v1/service"
+	"k8s.io/kubernetes/pkg/controller"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
+	"k8s.io/kubernetes/pkg/volume"
+	volumeutil "k8s.io/kubernetes/pkg/volume/util"
+)
+
+// NLBHealthCheckRuleDescription is the comment used on a security group rule to
+// indicate that it is used for health checks
+const NLBHealthCheckRuleDescription = "kubernetes.io/rule/nlb/health"
+
+// NLBClientRuleDescription is the comment used on a security group rule to
+// indicate that it is used for client traffic
+const NLBClientRuleDescription = "kubernetes.io/rule/nlb/client"
+
+// NLBMtuDiscoveryRuleDescription is the comment used on a security group rule
+// to indicate that it is used for mtu discovery
+const NLBMtuDiscoveryRuleDescription = "kubernetes.io/rule/nlb/mtu"
+
+// ProviderName is the name of this cloud provider.
+const ProviderName = "aws"
+
+// TagNameKubernetesService is the tag name we use to differentiate multiple
+// services. Used currently for ELBs only.
+const TagNameKubernetesService = "kubernetes.io/service-name"
+
+// TagNameSubnetInternalELB is the tag name used on a subnet to designate that
+// it should be used for internal ELBs
+const TagNameSubnetInternalELB = "kubernetes.io/role/internal-elb"
+
+// TagNameSubnetPublicELB is the tag name used on a subnet to designate that
+// it should be used for internet ELBs
+const TagNameSubnetPublicELB = "kubernetes.io/role/elb"
+
+// ServiceAnnotationLoadBalancerType is the annotation used on the service
+// to indicate what type of Load Balancer we want. Right now, the only accepted
+// value is "nlb"
+const ServiceAnnotationLoadBalancerType = "service.beta.kubernetes.io/aws-load-balancer-type"
+
+// ServiceAnnotationLoadBalancerInternal is the annotation used on the service
+// to indicate that we want an internal ELB.
+const ServiceAnnotationLoadBalancerInternal = "service.beta.kubernetes.io/aws-load-balancer-internal"
+
+// ServiceAnnotationLoadBalancerProxyProtocol is the annotation used on the
+// service to enable the proxy protocol on an ELB. Right now we only accept the
+// value "*" which means enable the proxy protocol on all ELB backends. In the
+// future we could adjust this to allow setting the proxy protocol only on
+// certain backends.
+const ServiceAnnotationLoadBalancerProxyProtocol = "service.beta.kubernetes.io/aws-load-balancer-proxy-protocol"
+
+// ServiceAnnotationLoadBalancerAccessLogEmitInterval is the annotation used to
+// specify access log emit interval.
+const ServiceAnnotationLoadBalancerAccessLogEmitInterval = "service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval"
+
+// ServiceAnnotationLoadBalancerAccessLogEnabled is the annotation used on the
+// service to enable or disable access logs.
+const ServiceAnnotationLoadBalancerAccessLogEnabled = "service.beta.kubernetes.io/aws-load-balancer-access-log-enabled"
+
+// ServiceAnnotationLoadBalancerAccessLogS3BucketName is the annotation used to
+// specify access log s3 bucket name.
+const ServiceAnnotationLoadBalancerAccessLogS3BucketName = "service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name"
+
+// ServiceAnnotationLoadBalancerAccessLogS3BucketPrefix is the annotation used
+// to specify access log s3 bucket prefix.
+const ServiceAnnotationLoadBalancerAccessLogS3BucketPrefix = "service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix"
+
+// ServiceAnnotationLoadBalancerConnectionDrainingEnabled is the annnotation
+// used on the service to enable or disable connection draining.
+const ServiceAnnotationLoadBalancerConnectionDrainingEnabled = "service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled"
+
+// ServiceAnnotationLoadBalancerConnectionDrainingTimeout is the annotation
+// used on the service to specify a connection draining timeout.
+const ServiceAnnotationLoadBalancerConnectionDrainingTimeout = "service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout"
+
+// ServiceAnnotationLoadBalancerConnectionIdleTimeout is the annotation used
+// on the service to specify the idle connection timeout.
+const ServiceAnnotationLoadBalancerConnectionIdleTimeout = "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"
+
+// ServiceAnnotationLoadBalancerCrossZoneLoadBalancingEnabled is the annotation
+// used on the service to enable or disable cross-zone load balancing.
+const ServiceAnnotationLoadBalancerCrossZoneLoadBalancingEnabled = "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"
+
+// ServiceAnnotationLoadBalancerExtraSecurityGroups is the annotation used
+// on the service to specify additional security groups to be added to ELB created
+const ServiceAnnotationLoadBalancerExtraSecurityGroups = "service.beta.kubernetes.io/aws-load-balancer-extra-security-groups"
+
+// ServiceAnnotationLoadBalancerSecurityGroups is the annotation used
+// on the service to specify the security groups to be added to ELB created. Differently from the annotation
+// "service.beta.kubernetes.io/aws-load-balancer-extra-security-groups", this replaces all other security groups previously assigned to the ELB.
+const ServiceAnnotationLoadBalancerSecurityGroups = "service.beta.kubernetes.io/aws-load-balancer-security-groups"
+
+// ServiceAnnotationLoadBalancerCertificate is the annotation used on the
+// service to request a secure listener. Value is a valid certificate ARN.
+// For more, see http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-listener-config.html
+// CertARN is an IAM or CM certificate ARN, e.g. arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012
+const ServiceAnnotationLoadBalancerCertificate = "service.beta.kubernetes.io/aws-load-balancer-ssl-cert"
+
+// ServiceAnnotationLoadBalancerSSLPorts is the annotation used on the service
+// to specify a comma-separated list of ports that will use SSL/HTTPS
+// listeners. Defaults to '*' (all).
+const ServiceAnnotationLoadBalancerSSLPorts = "service.beta.kubernetes.io/aws-load-balancer-ssl-ports"
+
+// ServiceAnnotationLoadBalancerSSLNegotiationPolicy is the annotation used on
+// the service to specify a SSL negotiation settings for the HTTPS/SSL listeners
+// of your load balancer. Defaults to AWS's default
+const ServiceAnnotationLoadBalancerSSLNegotiationPolicy = "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy"
+
+// ServiceAnnotationLoadBalancerBEProtocol is the annotation used on the service
+// to specify the protocol spoken by the backend (pod) behind a listener.
+// If `http` (default) or `https`, an HTTPS listener that terminates the
+//  connection and parses headers is created.
+// If set to `ssl` or `tcp`, a "raw" SSL listener is used.
+// If set to `http` and `aws-load-balancer-ssl-cert` is not used then
+// a HTTP listener is used.
+const ServiceAnnotationLoadBalancerBEProtocol = "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"
+
+// ServiceAnnotationLoadBalancerAdditionalTags is the annotation used on the service
+// to specify a comma-separated list of key-value pairs which will be recorded as
+// additional tags in the ELB.
+// For example: "Key1=Val1,Key2=Val2,KeyNoVal1=,KeyNoVal2"
+const ServiceAnnotationLoadBalancerAdditionalTags = "service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags"
+
+// ServiceAnnotationLoadBalancerHCHealthyThreshold is the annotation used on
+// the service to specify the number of successive successful health checks
+// required for a backend to be considered healthy for traffic.
+const ServiceAnnotationLoadBalancerHCHealthyThreshold = "service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold"
+
+// ServiceAnnotationLoadBalancerHCUnhealthyThreshold is the annotation used
+// on the service to specify the number of unsuccessful health checks
+// required for a backend to be considered unhealthy for traffic
+const ServiceAnnotationLoadBalancerHCUnhealthyThreshold = "service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold"
+
+// ServiceAnnotationLoadBalancerHCTimeout is the annotation used on the
+// service to specify, in seconds, how long to wait before marking a health
+// check as failed.
+const ServiceAnnotationLoadBalancerHCTimeout = "service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout"
+
+// ServiceAnnotationLoadBalancerHCInterval is the annotation used on the
+// service to specify, in seconds, the interval between health checks.
+const ServiceAnnotationLoadBalancerHCInterval = "service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval"
+
+// Event key when a volume is stuck on attaching state when being attached to a volume
+const volumeAttachmentStuck = "VolumeAttachmentStuck"
+
+// Indicates that a node has volumes stuck in attaching state and hence it is not fit for scheduling more pods
+const nodeWithImpairedVolumes = "NodeWithImpairedVolumes"
+
+const (
+	// volumeAttachmentConsecutiveErrorLimit is the number of consecutive errors we will ignore when waiting for a volume to attach/detach
+	volumeAttachmentStatusConsecutiveErrorLimit = 10
+	// most attach/detach operations on AWS finish within 1-4 seconds
+	// By using 1 second starting interval with a backoff of 1.8
+	// we get -  [1, 1.8, 3.24, 5.832000000000001, 10.4976]
+	// in total we wait for 2601 seconds
+	volumeAttachmentStatusInitialDelay = 1 * time.Second
+	volumeAttachmentStatusFactor       = 1.8
+	volumeAttachmentStatusSteps        = 13
+
+	// createTag* is configuration of exponential backoff for CreateTag call. We
+	// retry mainly because if we create an object, we cannot tag it until it is
+	// "fully created" (eventual consistency). Starting with 1 second, doubling
+	// it every step and taking 9 steps results in 255 second total waiting
+	// time.
+	createTagInitialDelay = 1 * time.Second
+	createTagFactor       = 2.0
+	createTagSteps        = 9
+
+	// encryptedCheck* is configuration of poll for created volume to check
+	// it has not been silently removed by AWS.
+	// On a random AWS account (shared among several developers) it took 4s on
+	// average.
+	encryptedCheckInterval = 1 * time.Second
+	encryptedCheckTimeout  = 30 * time.Second
+
+	// Number of node names that can be added to a filter. The AWS limit is 200
+	// but we are using a lower limit on purpose
+	filterNodeLimit = 150
+)
+
+// awsTagNameMasterRoles is a set of well-known AWS tag names that indicate the instance is a master
+// The major consequence is that it is then not considered for AWS zone discovery for dynamic volume creation.
+var awsTagNameMasterRoles = sets.NewString("kubernetes.io/role/master", "k8s.io/role/master")
+
+// Maps from backend protocol to ELB protocol
+var backendProtocolMapping = map[string]string{
+	"https": "https",
+	"http":  "https",
+	"ssl":   "ssl",
+	"tcp":   "ssl",
+}
+
+// MaxReadThenCreateRetries sets the maximum number of attempts we will make when
+// we read to see if something exists and then try to create it if we didn't find it.
+// This can fail once in a consistent system if done in parallel
+// In an eventually consistent system, it could fail unboundedly
+const MaxReadThenCreateRetries = 30
+
+// DefaultVolumeType specifies which storage to use for newly created Volumes
+// TODO: Remove when user/admin can configure volume types and thus we don't
+// need hardcoded defaults.
+const DefaultVolumeType = "gp2"
+
+// Used to call recognizeWellKnownRegions just once
+var once sync.Once
+
+// AWS implements PVLabeler.
+var _ cloudprovider.PVLabeler = (*Cloud)(nil)
+
+// Services is an abstraction over AWS, to allow mocking/other implementations
+type Services interface {
+	Compute(region string) (EC2, error)
+	LoadBalancing(region string) (ELB, error)
+	LoadBalancingV2(region string) (ELBV2, error)
+	Autoscaling(region string) (ASG, error)
+	Metadata() (EC2Metadata, error)
+	KeyManagement(region string) (KMS, error)
+}
+
+// EC2 is an abstraction over AWS', to allow mocking/other implementations
+// Note that the DescribeX functions return a list, so callers don't need to deal with paging
+// TODO: Should we rename this to AWS (EBS & ELB are not technically part of EC2)
+type EC2 interface {
+	// Query EC2 for instances matching the filter
+	DescribeInstances(request *ec2.DescribeInstancesInput) ([]*ec2.Instance, error)
+
+	// Attach a volume to an instance
+	AttachVolume(*ec2.AttachVolumeInput) (*ec2.VolumeAttachment, error)
+	// Detach a volume from an instance it is attached to
+	DetachVolume(request *ec2.DetachVolumeInput) (resp *ec2.VolumeAttachment, err error)
+	// Lists volumes
+	DescribeVolumes(request *ec2.DescribeVolumesInput) ([]*ec2.Volume, error)
+	// Create an EBS volume
+	CreateVolume(request *ec2.CreateVolumeInput) (resp *ec2.Volume, err error)
+	// Delete an EBS volume
+	DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error)
+
+	ModifyVolume(*ec2.ModifyVolumeInput) (*ec2.ModifyVolumeOutput, error)
+
+	DescribeVolumeModifications(*ec2.DescribeVolumesModificationsInput) ([]*ec2.VolumeModification, error)
+
+	DescribeSecurityGroups(request *ec2.DescribeSecurityGroupsInput) ([]*ec2.SecurityGroup, error)
+
+	CreateSecurityGroup(*ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error)
+	DeleteSecurityGroup(request *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error)
+
+	AuthorizeSecurityGroupIngress(*ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error)
+	RevokeSecurityGroupIngress(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error)
+
+	DescribeSubnets(*ec2.DescribeSubnetsInput) ([]*ec2.Subnet, error)
+
+	CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
+
+	DescribeRouteTables(request *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error)
+	CreateRoute(request *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error)
+	DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error)
+
+	ModifyInstanceAttribute(request *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error)
+
+	DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
+}
+
+// ELB is a simple pass-through of AWS' ELB client interface, which allows for testing
+type ELB interface {
+	CreateLoadBalancer(*elb.CreateLoadBalancerInput) (*elb.CreateLoadBalancerOutput, error)
+	DeleteLoadBalancer(*elb.DeleteLoadBalancerInput) (*elb.DeleteLoadBalancerOutput, error)
+	DescribeLoadBalancers(*elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error)
+	AddTags(*elb.AddTagsInput) (*elb.AddTagsOutput, error)
+	RegisterInstancesWithLoadBalancer(*elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error)
+	DeregisterInstancesFromLoadBalancer(*elb.DeregisterInstancesFromLoadBalancerInput) (*elb.DeregisterInstancesFromLoadBalancerOutput, error)
+	CreateLoadBalancerPolicy(*elb.CreateLoadBalancerPolicyInput) (*elb.CreateLoadBalancerPolicyOutput, error)
+	SetLoadBalancerPoliciesForBackendServer(*elb.SetLoadBalancerPoliciesForBackendServerInput) (*elb.SetLoadBalancerPoliciesForBackendServerOutput, error)
+	SetLoadBalancerPoliciesOfListener(input *elb.SetLoadBalancerPoliciesOfListenerInput) (*elb.SetLoadBalancerPoliciesOfListenerOutput, error)
+	DescribeLoadBalancerPolicies(input *elb.DescribeLoadBalancerPoliciesInput) (*elb.DescribeLoadBalancerPoliciesOutput, error)
+
+	DetachLoadBalancerFromSubnets(*elb.DetachLoadBalancerFromSubnetsInput) (*elb.DetachLoadBalancerFromSubnetsOutput, error)
+	AttachLoadBalancerToSubnets(*elb.AttachLoadBalancerToSubnetsInput) (*elb.AttachLoadBalancerToSubnetsOutput, error)
+
+	CreateLoadBalancerListeners(*elb.CreateLoadBalancerListenersInput) (*elb.CreateLoadBalancerListenersOutput, error)
+	DeleteLoadBalancerListeners(*elb.DeleteLoadBalancerListenersInput) (*elb.DeleteLoadBalancerListenersOutput, error)
+
+	ApplySecurityGroupsToLoadBalancer(*elb.ApplySecurityGroupsToLoadBalancerInput) (*elb.ApplySecurityGroupsToLoadBalancerOutput, error)
+
+	ConfigureHealthCheck(*elb.ConfigureHealthCheckInput) (*elb.ConfigureHealthCheckOutput, error)
+
+	DescribeLoadBalancerAttributes(*elb.DescribeLoadBalancerAttributesInput) (*elb.DescribeLoadBalancerAttributesOutput, error)
+	ModifyLoadBalancerAttributes(*elb.ModifyLoadBalancerAttributesInput) (*elb.ModifyLoadBalancerAttributesOutput, error)
+}
+
+// ELBV2 is a simple pass-through of AWS' ELBV2 client interface, which allows for testing
+type ELBV2 interface {
+	AddTags(input *elbv2.AddTagsInput) (*elbv2.AddTagsOutput, error)
+
+	CreateLoadBalancer(*elbv2.CreateLoadBalancerInput) (*elbv2.CreateLoadBalancerOutput, error)
+	DescribeLoadBalancers(*elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error)
+	DeleteLoadBalancer(*elbv2.DeleteLoadBalancerInput) (*elbv2.DeleteLoadBalancerOutput, error)
+
+	ModifyLoadBalancerAttributes(*elbv2.ModifyLoadBalancerAttributesInput) (*elbv2.ModifyLoadBalancerAttributesOutput, error)
+	DescribeLoadBalancerAttributes(*elbv2.DescribeLoadBalancerAttributesInput) (*elbv2.DescribeLoadBalancerAttributesOutput, error)
+
+	CreateTargetGroup(*elbv2.CreateTargetGroupInput) (*elbv2.CreateTargetGroupOutput, error)
+	DescribeTargetGroups(*elbv2.DescribeTargetGroupsInput) (*elbv2.DescribeTargetGroupsOutput, error)
+	ModifyTargetGroup(*elbv2.ModifyTargetGroupInput) (*elbv2.ModifyTargetGroupOutput, error)
+	DeleteTargetGroup(*elbv2.DeleteTargetGroupInput) (*elbv2.DeleteTargetGroupOutput, error)
+
+	DescribeTargetHealth(input *elbv2.DescribeTargetHealthInput) (*elbv2.DescribeTargetHealthOutput, error)
+
+	DescribeTargetGroupAttributes(*elbv2.DescribeTargetGroupAttributesInput) (*elbv2.DescribeTargetGroupAttributesOutput, error)
+	ModifyTargetGroupAttributes(*elbv2.ModifyTargetGroupAttributesInput) (*elbv2.ModifyTargetGroupAttributesOutput, error)
+
+	RegisterTargets(*elbv2.RegisterTargetsInput) (*elbv2.RegisterTargetsOutput, error)
+	DeregisterTargets(*elbv2.DeregisterTargetsInput) (*elbv2.DeregisterTargetsOutput, error)
+
+	CreateListener(*elbv2.CreateListenerInput) (*elbv2.CreateListenerOutput, error)
+	DescribeListeners(*elbv2.DescribeListenersInput) (*elbv2.DescribeListenersOutput, error)
+	DeleteListener(*elbv2.DeleteListenerInput) (*elbv2.DeleteListenerOutput, error)
+	ModifyListener(*elbv2.ModifyListenerInput) (*elbv2.ModifyListenerOutput, error)
+
+	WaitUntilLoadBalancersDeleted(*elbv2.DescribeLoadBalancersInput) error
+}
+
+// ASG is a simple pass-through of the Autoscaling client interface, which
+// allows for testing.
+type ASG interface {
+	UpdateAutoScalingGroup(*autoscaling.UpdateAutoScalingGroupInput) (*autoscaling.UpdateAutoScalingGroupOutput, error)
+	DescribeAutoScalingGroups(*autoscaling.DescribeAutoScalingGroupsInput) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
+}
+
+// KMS is a simple pass-through of the Key Management Service client interface,
+// which allows for testing.
+type KMS interface {
+	DescribeKey(*kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error)
+}
+
+// EC2Metadata is an abstraction over the AWS metadata service.
+type EC2Metadata interface {
+	// Query the EC2 metadata service (used to discover instance-id etc)
+	GetMetadata(path string) (string, error)
+}
+
+// AWS volume types
+const (
+	// Provisioned IOPS SSD
+	VolumeTypeIO1 = "io1"
+	// General Purpose SSD
+	VolumeTypeGP2 = "gp2"
+	// Cold HDD (sc1)
+	VolumeTypeSC1 = "sc1"
+	// Throughput Optimized HDD
+	VolumeTypeST1 = "st1"
+)
+
+// AWS provisioning limits.
+// Source: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html
+const (
+	MinTotalIOPS = 100
+	MaxTotalIOPS = 20000
+)
+
+// VolumeOptions specifies capacity and tags for a volume.
+type VolumeOptions struct {
+	CapacityGB       int
+	Tags             map[string]string
+	VolumeType       string
+	AvailabilityZone string
+	// IOPSPerGB x CapacityGB will give total IOPS of the volume to create.
+	// Calculated total IOPS will be capped at MaxTotalIOPS.
+	IOPSPerGB int
+	Encrypted bool
+	// fully qualified resource name to the key to use for encryption.
+	// example: arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef
+	KmsKeyID string
+}
+
+// Volumes is an interface for managing cloud-provisioned volumes
+// TODO: Allow other clouds to implement this
+type Volumes interface {
+	// Attach the disk to the node with the specified NodeName
+	// nodeName can be empty to mean "the instance on which we are running"
+	// Returns the device (e.g. /dev/xvdf) where we attached the volume
+	AttachDisk(diskName KubernetesVolumeID, nodeName types.NodeName) (string, error)
+	// Detach the disk from the node with the specified NodeName
+	// nodeName can be empty to mean "the instance on which we are running"
+	// Returns the device where the volume was attached
+	DetachDisk(diskName KubernetesVolumeID, nodeName types.NodeName) (string, error)
+
+	// Create a volume with the specified options
+	CreateDisk(volumeOptions *VolumeOptions) (volumeName KubernetesVolumeID, err error)
+	// Delete the specified volume
+	// Returns true iff the volume was deleted
+	// If the was not found, returns (false, nil)
+	DeleteDisk(volumeName KubernetesVolumeID) (bool, error)
+
+	// Get labels to apply to volume on creation
+	GetVolumeLabels(volumeName KubernetesVolumeID) (map[string]string, error)
+
+	// Get volume's disk path from volume name
+	// return the device path where the volume is attached
+	GetDiskPath(volumeName KubernetesVolumeID) (string, error)
+
+	// Check if the volume is already attached to the node with the specified NodeName
+	DiskIsAttached(diskName KubernetesVolumeID, nodeName types.NodeName) (bool, error)
+
+	// Check if disks specified in argument map are still attached to their respective nodes.
+	DisksAreAttached(map[types.NodeName][]KubernetesVolumeID) (map[types.NodeName]map[KubernetesVolumeID]bool, error)
+
+	// Expand the disk to new size
+	ResizeDisk(diskName KubernetesVolumeID, oldSize resource.Quantity, newSize resource.Quantity) (resource.Quantity, error)
+}
+
+// InstanceGroups is an interface for managing cloud-managed instance groups / autoscaling instance groups
+// TODO: Allow other clouds to implement this
+type InstanceGroups interface {
+	// Set the size to the fixed size
+	ResizeInstanceGroup(instanceGroupName string, size int) error
+	// Queries the cloud provider for information about the specified instance group
+	DescribeInstanceGroup(instanceGroupName string) (InstanceGroupInfo, error)
+}
+
+// InstanceGroupInfo is returned by InstanceGroups.Describe, and exposes information about the group.
+type InstanceGroupInfo interface {
+	// The number of instances currently running under control of this group
+	CurrentSize() (int, error)
+}
+
+// Cloud is an implementation of Interface, LoadBalancer and Instances for Amazon Web Services.
+type Cloud struct {
+	ec2      EC2
+	elb      ELB
+	elbv2    ELBV2
+	asg      ASG
+	kms      KMS
+	metadata EC2Metadata
+	cfg      *CloudConfig
+	region   string
+	vpcID    string
+
+	tagging awsTagging
+
+	// The AWS instance that we are running on
+	// Note that we cache some state in awsInstance (mountpoints), so we must preserve the instance
+	selfAWSInstance *awsInstance
+
+	instanceCache instanceCache
+
+	clientBuilder    controller.ControllerClientBuilder
+	kubeClient       clientset.Interface
+	eventBroadcaster record.EventBroadcaster
+	eventRecorder    record.EventRecorder
+
+	// We keep an active list of devices we have assigned but not yet
+	// attached, to avoid a race condition where we assign a device mapping
+	// and then get a second request before we attach the volume
+	attachingMutex sync.Mutex
+	attaching      map[types.NodeName]map[mountDevice]EBSVolumeID
+
+	// state of our device allocator for each node
+	deviceAllocators map[types.NodeName]DeviceAllocator
+}
+
+var _ Volumes = &Cloud{}
+
+// CloudConfig wraps the settings for the AWS cloud provider.
+type CloudConfig struct {
+	Global struct {
+		// TODO: Is there any use for this?  We can get it from the instance metadata service
+		// Maybe if we're not running on AWS, e.g. bootstrap; for now it is not very useful
+		Zone string
+
+		// The AWS VPC flag enables the possibility to run the master components
+		// on a different aws account, on a different cloud provider or on-premises.
+		// If the flag is set also the KubernetesClusterTag must be provided
+		VPC string
+		// SubnetID enables using a specific subnet to use for ELB's
+		SubnetID string
+		// RouteTableID enables using a specific RouteTable
+		RouteTableID string
+
+		// RoleARN is the IAM role to assume when interaction with AWS APIs.
+		RoleARN string
+
+		// KubernetesClusterTag is the legacy cluster id we'll use to identify our cluster resources
+		KubernetesClusterTag string
+		// KubernetesClusterID is the cluster id we'll use to identify our cluster resources
+		KubernetesClusterID string
+
+		//The aws provider creates an inbound rule per load balancer on the node security
+		//group. However, this can run into the AWS security group rule limit of 50 if
+		//many LoadBalancers are created.
+		//
+		//This flag disables the automatic ingress creation. It requires that the user
+		//has setup a rule that allows inbound traffic on kubelet ports from the
+		//local VPC subnet (so load balancers can access it). E.g. 10.82.0.0/16 30000-32000.
+		DisableSecurityGroupIngress bool
+
+		//AWS has a hard limit of 500 security groups. For large clusters creating a security group for each ELB
+		//can cause the max number of security groups to be reached. If this is set instead of creating a new
+		//Security group for each ELB this security group will be used instead.
+		ElbSecurityGroup string
+
+		//During the instantiation of an new AWS cloud provider, the detected region
+		//is validated against a known set of regions.
+		//
+		//In a non-standard, AWS like environment (e.g. Eucalyptus), this check may
+		//be undesirable.  Setting this to true will disable the check and provide
+		//a warning that the check was skipped.  Please note that this is an
+		//experimental feature and work-in-progress for the moment.  If you find
+		//yourself in an non-AWS cloud and open an issue, please indicate that in the
+		//issue body.
+		DisableStrictZoneCheck bool
+	}
+}
+
+// awsSdkEC2 is an implementation of the EC2 interface, backed by aws-sdk-go
+type awsSdkEC2 struct {
+	ec2 *ec2.EC2
+}
+
+type awsSDKProvider struct {
+	creds *credentials.Credentials
+
+	mutex          sync.Mutex
+	regionDelayers map[string]*CrossRequestRetryDelay
+}
+
+func newAWSSDKProvider(creds *credentials.Credentials) *awsSDKProvider {
+	return &awsSDKProvider{
+		creds:          creds,
+		regionDelayers: make(map[string]*CrossRequestRetryDelay),
+	}
+}
+
+func (p *awsSDKProvider) addHandlers(regionName string, h *request.Handlers) {
+	h.Sign.PushFrontNamed(request.NamedHandler{
+		Name: "k8s/logger",
+		Fn:   awsHandlerLogger,
+	})
+
+	delayer := p.getCrossRequestRetryDelay(regionName)
+	if delayer != nil {
+		h.Sign.PushFrontNamed(request.NamedHandler{
+			Name: "k8s/delay-presign",
+			Fn:   delayer.BeforeSign,
+		})
+
+		h.AfterRetry.PushFrontNamed(request.NamedHandler{
+			Name: "k8s/delay-afterretry",
+			Fn:   delayer.AfterRetry,
+		})
+	}
+
+	p.addAPILoggingHandlers(h)
+}
+
+func (p *awsSDKProvider) addAPILoggingHandlers(h *request.Handlers) {
+	h.Send.PushBackNamed(request.NamedHandler{
+		Name: "k8s/api-request",
+		Fn:   awsSendHandlerLogger,
+	})
+
+	h.ValidateResponse.PushFrontNamed(request.NamedHandler{
+		Name: "k8s/api-validate-response",
+		Fn:   awsValidateResponseHandlerLogger,
+	})
+}
+
+// Get a CrossRequestRetryDelay, scoped to the region, not to the request.
+// This means that when we hit a limit on a call, we will delay _all_ calls to the API.
+// We do this to protect the AWS account from becoming overloaded and effectively locked.
+// We also log when we hit request limits.
+// Note that this delays the current goroutine; this is bad behaviour and will
+// likely cause k8s to become slow or unresponsive for cloud operations.
+// However, this throttle is intended only as a last resort.  When we observe
+// this throttling, we need to address the root cause (e.g. add a delay to a
+// controller retry loop)
+func (p *awsSDKProvider) getCrossRequestRetryDelay(regionName string) *CrossRequestRetryDelay {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	delayer, found := p.regionDelayers[regionName]
+	if !found {
+		delayer = NewCrossRequestRetryDelay()
+		p.regionDelayers[regionName] = delayer
+	}
+	return delayer
+}
+
+func (p *awsSDKProvider) Compute(regionName string) (EC2, error) {
+	awsConfig := &aws.Config{
+		Region:      &regionName,
+		Credentials: p.creds,
+	}
+	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
+
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize AWS session: %v", err)
+	}
+	service := ec2.New(sess)
+
+	p.addHandlers(regionName, &service.Handlers)
+
+	ec2 := &awsSdkEC2{
+		ec2: service,
+	}
+	return ec2, nil
+}
+
+func (p *awsSDKProvider) LoadBalancing(regionName string) (ELB, error) {
+	awsConfig := &aws.Config{
+		Region:      &regionName,
+		Credentials: p.creds,
+	}
+	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
+
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize AWS session: %v", err)
+	}
+	elbClient := elb.New(sess)
+	p.addHandlers(regionName, &elbClient.Handlers)
+
+	return elbClient, nil
+}
+
+func (p *awsSDKProvider) LoadBalancingV2(regionName string) (ELBV2, error) {
+	awsConfig := &aws.Config{
+		Region:      &regionName,
+		Credentials: p.creds,
+	}
+	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
+
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize AWS session: %v", err)
+	}
+	elbClient := elbv2.New(sess)
+
+	p.addHandlers(regionName, &elbClient.Handlers)
+
+	return elbClient, nil
+}
+
+func (p *awsSDKProvider) Autoscaling(regionName string) (ASG, error) {
+	awsConfig := &aws.Config{
+		Region:      &regionName,
+		Credentials: p.creds,
+	}
+	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
+
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize AWS session: %v", err)
+	}
+	client := autoscaling.New(sess)
+
+	p.addHandlers(regionName, &client.Handlers)
+
+	return client, nil
+}
+
+func (p *awsSDKProvider) Metadata() (EC2Metadata, error) {
+	sess, err := session.NewSession(&aws.Config{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize AWS session: %v", err)
+	}
+	client := ec2metadata.New(sess)
+	p.addAPILoggingHandlers(&client.Handlers)
+	return client, nil
+}
+
+func (p *awsSDKProvider) KeyManagement(regionName string) (KMS, error) {
+	awsConfig := &aws.Config{
+		Region:      &regionName,
+		Credentials: p.creds,
+	}
+	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
+
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize AWS session: %v", err)
+	}
+	kmsClient := kms.New(sess)
+
+	p.addHandlers(regionName, &kmsClient.Handlers)
+
+	return kmsClient, nil
+}
+
+func newEc2Filter(name string, values ...string) *ec2.Filter {
+	filter := &ec2.Filter{
+		Name: aws.String(name),
+	}
+	for _, value := range values {
+		filter.Values = append(filter.Values, aws.String(value))
+	}
+	return filter
+}
+
+// AddSSHKeyToAllInstances is currently not implemented.
+func (c *Cloud) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
+	return cloudprovider.NotImplemented
+}
+
+// CurrentNodeName returns the name of the current node
+func (c *Cloud) CurrentNodeName(ctx context.Context, hostname string) (types.NodeName, error) {
+	return c.selfAWSInstance.nodeName, nil
+}
+
+// Implementation of EC2.Instances
+func (s *awsSdkEC2) DescribeInstances(request *ec2.DescribeInstancesInput) ([]*ec2.Instance, error) {
+	// Instances are paged
+	results := []*ec2.Instance{}
+	var nextToken *string
+	requestTime := time.Now()
+	for {
+		response, err := s.ec2.DescribeInstances(request)
+		if err != nil {
+			recordAWSMetric("describe_instance", 0, err)
+			return nil, fmt.Errorf("error listing AWS instances: %q", err)
+		}
+
+		for _, reservation := range response.Reservations {
+			results = append(results, reservation.Instances...)
+		}
+
+		nextToken = response.NextToken
+		if aws.StringValue(nextToken) == "" {
+			break
+		}
+		request.NextToken = nextToken
+	}
+	timeTaken := time.Since(requestTime).Seconds()
+	recordAWSMetric("describe_instance", timeTaken, nil)
+	return results, nil
+}
+
+// Implements EC2.DescribeSecurityGroups
+func (s *awsSdkEC2) DescribeSecurityGroups(request *ec2.DescribeSecurityGroupsInput) ([]*ec2.SecurityGroup, error) {
+	// Security groups are not paged
+	response, err := s.ec2.DescribeSecurityGroups(request)
+	if err != nil {
+		return nil, fmt.Errorf("error listing AWS security groups: %q", err)
+	}
+	return response.SecurityGroups, nil
+}
+
+func (s *awsSdkEC2) AttachVolume(request *ec2.AttachVolumeInput) (*ec2.VolumeAttachment, error) {
+	requestTime := time.Now()
+	resp, err := s.ec2.AttachVolume(request)
+	timeTaken := time.Since(requestTime).Seconds()
+	recordAWSMetric("attach_volume", timeTaken, err)
+	return resp, err
+}
+
+func (s *awsSdkEC2) DetachVolume(request *ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error) {
+	requestTime := time.Now()
+	resp, err := s.ec2.DetachVolume(request)
+	timeTaken := time.Since(requestTime).Seconds()
+	recordAWSMetric("detach_volume", timeTaken, err)
+	return resp, err
+}
+
+func (s *awsSdkEC2) DescribeVolumes(request *ec2.DescribeVolumesInput) ([]*ec2.Volume, error) {
+	// Volumes are paged
+	results := []*ec2.Volume{}
+	var nextToken *string
+	requestTime := time.Now()
+	for {
+		response, err := s.ec2.DescribeVolumes(request)
+
+		if err != nil {
+			recordAWSMetric("describe_volume", 0, err)
+			return nil, err
+		}
+
+		results = append(results, response.Volumes...)
+
+		nextToken = response.NextToken
+		if aws.StringValue(nextToken) == "" {
+			break
+		}
+		request.NextToken = nextToken
+	}
+	timeTaken := time.Since(requestTime).Seconds()
+	recordAWSMetric("describe_volume", timeTaken, nil)
+	return results, nil
+}
+
+func (s *awsSdkEC2) CreateVolume(request *ec2.CreateVolumeInput) (*ec2.Volume, error) {
+	requestTime := time.Now()
+	resp, err := s.ec2.CreateVolume(request)
+	timeTaken := time.Since(requestTime).Seconds()
+	recordAWSMetric("create_volume", timeTaken, err)
+	return resp, err
+}
+
+func (s *awsSdkEC2) DeleteVolume(request *ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error) {
+	requestTime := time.Now()
+	resp, err := s.ec2.DeleteVolume(request)
+	timeTaken := time.Since(requestTime).Seconds()
+	recordAWSMetric("delete_volume", timeTaken, err)
+	return resp, err
+}
+
+func (s *awsSdkEC2) ModifyVolume(request *ec2.ModifyVolumeInput) (*ec2.ModifyVolumeOutput, error) {
+	requestTime := time.Now()
+	resp, err := s.ec2.ModifyVolume(request)
+	timeTaken := time.Since(requestTime).Seconds()
+	recordAWSMetric("modify_volume", timeTaken, err)
+	return resp, err
+}
+
+func (s *awsSdkEC2) DescribeVolumeModifications(request *ec2.DescribeVolumesModificationsInput) ([]*ec2.VolumeModification, error) {
+	requestTime := time.Now()
+	results := []*ec2.VolumeModification{}
+	var nextToken *string
+	for {
+		resp, err := s.ec2.DescribeVolumesModifications(request)
+		if err != nil {
+			recordAWSMetric("describe_volume_modification", 0, err)
+			return nil, fmt.Errorf("error listing volume modifictions : %v", err)
+		}
+		results = append(results, resp.VolumesModifications...)
+		nextToken = resp.NextToken
+		if aws.StringValue(nextToken) == "" {
+			break
+		}
+		request.NextToken = nextToken
+	}
+	timeTaken := time.Since(requestTime).Seconds()
+	recordAWSMetric("describe_volume_modification", timeTaken, nil)
+	return results, nil
+}
+
+func (s *awsSdkEC2) DescribeSubnets(request *ec2.DescribeSubnetsInput) ([]*ec2.Subnet, error) {
+	// Subnets are not paged
+	response, err := s.ec2.DescribeSubnets(request)
+	if err != nil {
+		return nil, fmt.Errorf("error listing AWS subnets: %q", err)
+	}
+	return response.Subnets, nil
+}
+
+func (s *awsSdkEC2) CreateSecurityGroup(request *ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
+	return s.ec2.CreateSecurityGroup(request)
+}
+
+func (s *awsSdkEC2) DeleteSecurityGroup(request *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+	return s.ec2.DeleteSecurityGroup(request)
+}
+
+func (s *awsSdkEC2) AuthorizeSecurityGroupIngress(request *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	return s.ec2.AuthorizeSecurityGroupIngress(request)
+}
+
+func (s *awsSdkEC2) RevokeSecurityGroupIngress(request *ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	return s.ec2.RevokeSecurityGroupIngress(request)
+}
+
+func (s *awsSdkEC2) CreateTags(request *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
+	requestTime := time.Now()
+	resp, err := s.ec2.CreateTags(request)
+	timeTaken := time.Since(requestTime).Seconds()
+	recordAWSMetric("create_tags", timeTaken, err)
+	return resp, err
+}
+
+func (s *awsSdkEC2) DescribeRouteTables(request *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error) {
+	// Not paged
+	response, err := s.ec2.DescribeRouteTables(request)
+	if err != nil {
+		return nil, fmt.Errorf("error listing AWS route tables: %q", err)
+	}
+	return response.RouteTables, nil
+}
+
+func (s *awsSdkEC2) CreateRoute(request *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
+	return s.ec2.CreateRoute(request)
+}
+
+func (s *awsSdkEC2) DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
+	return s.ec2.DeleteRoute(request)
+}
+
+func (s *awsSdkEC2) ModifyInstanceAttribute(request *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
+	return s.ec2.ModifyInstanceAttribute(request)
+}
+
+func (s *awsSdkEC2) DescribeVpcs(request *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	return s.ec2.DescribeVpcs(request)
+}
+
+func init() {
+	registerMetrics()
+	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
+		cfg, err := readAWSCloudConfig(config)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read AWS cloud provider config file: %v", err)
+		}
+
+		sess, err := session.NewSession(&aws.Config{})
+		if err != nil {
+			return nil, fmt.Errorf("unable to initialize AWS session: %v", err)
+		}
+
+		var provider credentials.Provider
+		if cfg.Global.RoleARN == "" {
+			provider = &ec2rolecreds.EC2RoleProvider{
+				Client: ec2metadata.New(sess),
+			}
+		} else {
+			klog.Infof("Using AWS assumed role %v", cfg.Global.RoleARN)
+			provider = &stscreds.AssumeRoleProvider{
+				Client:  sts.New(sess),
+				RoleARN: cfg.Global.RoleARN,
+			}
+		}
+
+		creds := credentials.NewChainCredentials(
+			[]credentials.Provider{
+				&credentials.EnvProvider{},
+				provider,
+				&credentials.SharedCredentialsProvider{},
+			})
+
+		aws := newAWSSDKProvider(creds)
+		return newAWSCloud(*cfg, aws)
+	})
+}
+
+// readAWSCloudConfig reads an instance of AWSCloudConfig from config reader.
+func readAWSCloudConfig(config io.Reader) (*CloudConfig, error) {
+	var cfg CloudConfig
+	var err error
+
+	if config != nil {
+		err = gcfg.ReadInto(&cfg, config)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &cfg, nil
+}
+
+func updateConfigZone(cfg *CloudConfig, metadata EC2Metadata) error {
+	if cfg.Global.Zone == "" {
+		if metadata != nil {
+			klog.Info("Zone not specified in configuration file; querying AWS metadata service")
+			var err error
+			cfg.Global.Zone, err = getAvailabilityZone(metadata)
+			if err != nil {
+				return err
+			}
+		}
+		if cfg.Global.Zone == "" {
+			return fmt.Errorf("no zone specified in configuration file")
+		}
+	}
+
+	return nil
+}
+
+func getAvailabilityZone(metadata EC2Metadata) (string, error) {
+	return metadata.GetMetadata("placement/availability-zone")
+}
+
+// Derives the region from a valid az name.
+// Returns an error if the az is known invalid (empty)
+func azToRegion(az string) (string, error) {
+	if len(az) < 1 {
+		return "", fmt.Errorf("invalid (empty) AZ")
+	}
+	region := az[:len(az)-1]
+	return region, nil
+}
+
+// newAWSCloud creates a new instance of AWSCloud.
+// AWSProvider and instanceId are primarily for tests
+func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
+	// We have some state in the Cloud object - in particular the attaching map
+	// Log so that if we are building multiple Cloud objects, it is obvious!
+	klog.Infof("Building AWS cloudprovider")
+
+	metadata, err := awsServices.Metadata()
+	if err != nil {
+		return nil, fmt.Errorf("error creating AWS metadata client: %q", err)
+	}
+
+	err = updateConfigZone(&cfg, metadata)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
+	}
+
+	zone := cfg.Global.Zone
+	if len(zone) <= 1 {
+		return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
+	}
+	regionName, err := azToRegion(zone)
+	if err != nil {
+		return nil, err
+	}
+
+	// Trust that if we get a region from configuration or AWS metadata that it is valid,
+	// and register ECR providers
+	recognizeRegion(regionName)
+
+	if !cfg.Global.DisableStrictZoneCheck {
+		valid := isRegionValid(regionName)
+		if !valid {
+			// This _should_ now be unreachable, given we call RecognizeRegion
+			return nil, fmt.Errorf("not a valid AWS zone (unknown region): %s", zone)
+		}
+	} else {
+		klog.Warningf("Strict AWS zone checking is disabled.  Proceeding with zone: %s", zone)
+	}
+
+	ec2, err := awsServices.Compute(regionName)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AWS EC2 client: %v", err)
+	}
+
+	elb, err := awsServices.LoadBalancing(regionName)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AWS ELB client: %v", err)
+	}
+
+	elbv2, err := awsServices.LoadBalancingV2(regionName)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AWS ELBV2 client: %v", err)
+	}
+
+	asg, err := awsServices.Autoscaling(regionName)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AWS autoscaling client: %v", err)
+	}
+
+	kms, err := awsServices.KeyManagement(regionName)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AWS key management client: %v", err)
+	}
+
+	awsCloud := &Cloud{
+		ec2:      ec2,
+		elb:      elb,
+		elbv2:    elbv2,
+		asg:      asg,
+		metadata: metadata,
+		kms:      kms,
+		cfg:      &cfg,
+		region:   regionName,
+
+		attaching:        make(map[types.NodeName]map[mountDevice]EBSVolumeID),
+		deviceAllocators: make(map[types.NodeName]DeviceAllocator),
+	}
+	awsCloud.instanceCache.cloud = awsCloud
+
+	tagged := cfg.Global.KubernetesClusterTag != "" || cfg.Global.KubernetesClusterID != ""
+	if cfg.Global.VPC != "" && (cfg.Global.SubnetID != "" || cfg.Global.RoleARN != "") && tagged {
+		// When the master is running on a different AWS account, cloud provider or on-premise
+		// build up a dummy instance and use the VPC from the nodes account
+		klog.Info("Master is configured to run on a different AWS account, different cloud provider or on-premises")
+		awsCloud.selfAWSInstance = &awsInstance{
+			nodeName: "master-dummy",
+			vpcID:    cfg.Global.VPC,
+			subnetID: cfg.Global.SubnetID,
+		}
+		awsCloud.vpcID = cfg.Global.VPC
+	} else {
+		selfAWSInstance, err := awsCloud.buildSelfAWSInstance()
+		if err != nil {
+			return nil, err
+		}
+		awsCloud.selfAWSInstance = selfAWSInstance
+		awsCloud.vpcID = selfAWSInstance.vpcID
+	}
+
+	if cfg.Global.KubernetesClusterTag != "" || cfg.Global.KubernetesClusterID != "" {
+		if err := awsCloud.tagging.init(cfg.Global.KubernetesClusterTag, cfg.Global.KubernetesClusterID); err != nil {
+			return nil, err
+		}
+	} else {
+		// TODO: Clean up double-API query
+		info, err := awsCloud.selfAWSInstance.describeInstance()
+		if err != nil {
+			return nil, err
+		}
+		if err := awsCloud.tagging.initFromTags(info.Tags); err != nil {
+			return nil, err
+		}
+	}
+
+	// Register regions, in particular for ECR credentials
+	once.Do(func() {
+		recognizeWellKnownRegions()
+	})
+
+	return awsCloud, nil
+}
+
+// Initialize passes a Kubernetes clientBuilder interface to the cloud provider
+func (c *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
+	c.clientBuilder = clientBuilder
+	c.kubeClient = clientBuilder.ClientOrDie("aws-cloud-provider")
+	c.eventBroadcaster = record.NewBroadcaster()
+	c.eventBroadcaster.StartLogging(klog.Infof)
+	c.eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: c.kubeClient.CoreV1().Events("")})
+	c.eventRecorder = c.eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "aws-cloud-provider"})
+}
+
+// Clusters returns the list of clusters.
+func (c *Cloud) Clusters() (cloudprovider.Clusters, bool) {
+	return nil, false
+}
+
+// ProviderName returns the cloud provider ID.
+func (c *Cloud) ProviderName() string {
+	return ProviderName
+}
+
+// LoadBalancer returns an implementation of LoadBalancer for Amazon Web Services.
+func (c *Cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	return c, true
+}
+
+// Instances returns an implementation of Instances for Amazon Web Services.
+func (c *Cloud) Instances() (cloudprovider.Instances, bool) {
+	return c, true
+}
+
+// Zones returns an implementation of Zones for Amazon Web Services.
+func (c *Cloud) Zones() (cloudprovider.Zones, bool) {
+	return c, true
+}
+
+// Routes returns an implementation of Routes for Amazon Web Services.
+func (c *Cloud) Routes() (cloudprovider.Routes, bool) {
+	return c, true
+}
+
+// HasClusterID returns true if the cluster has a clusterID
+func (c *Cloud) HasClusterID() bool {
+	return len(c.tagging.clusterID()) > 0
+}
+
+// NodeAddresses is an implementation of Instances.NodeAddresses.
+func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.NodeAddress, error) {
+	if c.selfAWSInstance.nodeName == name || len(name) == 0 {
+		addresses := []v1.NodeAddress{}
+
+		macs, err := c.metadata.GetMetadata("network/interfaces/macs/")
+		if err != nil {
+			return nil, fmt.Errorf("error querying AWS metadata for %q: %q", "network/interfaces/macs", err)
+		}
+
+		for _, macID := range strings.Split(macs, "\n") {
+			if macID == "" {
+				continue
+			}
+			macPath := path.Join("network/interfaces/macs/", macID, "local-ipv4s")
+			internalIPs, err := c.metadata.GetMetadata(macPath)
+			if err != nil {
+				return nil, fmt.Errorf("error querying AWS metadata for %q: %q", macPath, err)
+			}
+			for _, internalIP := range strings.Split(internalIPs, "\n") {
+				if internalIP == "" {
+					continue
+				}
+				addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIP})
+			}
+		}
+
+		externalIP, err := c.metadata.GetMetadata("public-ipv4")
+		if err != nil {
+			//TODO: It would be nice to be able to determine the reason for the failure,
+			// but the AWS client masks all failures with the same error description.
+			klog.V(4).Info("Could not determine public IP from AWS metadata.")
+		} else {
+			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: externalIP})
+		}
+
+		internalDNS, err := c.metadata.GetMetadata("local-hostname")
+		if err != nil || len(internalDNS) == 0 {
+			//TODO: It would be nice to be able to determine the reason for the failure,
+			// but the AWS client masks all failures with the same error description.
+			klog.V(4).Info("Could not determine private DNS from AWS metadata.")
+		} else {
+			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalDNS, Address: internalDNS})
+			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeHostName, Address: internalDNS})
+		}
+
+		externalDNS, err := c.metadata.GetMetadata("public-hostname")
+		if err != nil || len(externalDNS) == 0 {
+			//TODO: It would be nice to be able to determine the reason for the failure,
+			// but the AWS client masks all failures with the same error description.
+			klog.V(4).Info("Could not determine public DNS from AWS metadata.")
+		} else {
+			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalDNS, Address: externalDNS})
+		}
+
+		return addresses, nil
+	}
+
+	instance, err := c.getInstanceByNodeName(name)
+	if err != nil {
+		return nil, fmt.Errorf("getInstanceByNodeName failed for %q with %q", name, err)
+	}
+	return extractNodeAddresses(instance)
+}
+
+// extractNodeAddresses maps the instance information from EC2 to an array of NodeAddresses
+func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
+	// Not clear if the order matters here, but we might as well indicate a sensible preference order
+
+	if instance == nil {
+		return nil, fmt.Errorf("nil instance passed to extractNodeAddresses")
+	}
+
+	addresses := []v1.NodeAddress{}
+
+	// handle internal network interfaces
+	for _, networkInterface := range instance.NetworkInterfaces {
+		// skip network interfaces that are not currently in use
+		if aws.StringValue(networkInterface.Status) != ec2.NetworkInterfaceStatusInUse {
+			continue
+		}
+
+		for _, internalIP := range networkInterface.PrivateIpAddresses {
+			if ipAddress := aws.StringValue(internalIP.PrivateIpAddress); ipAddress != "" {
+				ip := net.ParseIP(ipAddress)
+				if ip == nil {
+					return nil, fmt.Errorf("EC2 instance had invalid private address: %s (%q)", aws.StringValue(instance.InstanceId), ipAddress)
+				}
+				addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: ip.String()})
+			}
+		}
+	}
+
+	// TODO: Other IP addresses (multiple ips)?
+	publicIPAddress := aws.StringValue(instance.PublicIpAddress)
+	if publicIPAddress != "" {
+		ip := net.ParseIP(publicIPAddress)
+		if ip == nil {
+			return nil, fmt.Errorf("EC2 instance had invalid public address: %s (%s)", aws.StringValue(instance.InstanceId), publicIPAddress)
+		}
+		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: ip.String()})
+	}
+
+	privateDNSName := aws.StringValue(instance.PrivateDnsName)
+	if privateDNSName != "" {
+		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalDNS, Address: privateDNSName})
+		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeHostName, Address: privateDNSName})
+	}
+
+	publicDNSName := aws.StringValue(instance.PublicDnsName)
+	if publicDNSName != "" {
+		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalDNS, Address: publicDNSName})
+	}
+
+	return addresses, nil
+}
+
+// NodeAddressesByProviderID returns the node addresses of an instances with the specified unique providerID
+// This method will not be called from the node that is requesting this ID. i.e. metadata service
+// and other local methods cannot be used here
+func (c *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
+	instanceID, err := kubernetesInstanceID(providerID).mapToAWSInstanceID()
+	if err != nil {
+		return nil, err
+	}
+
+	instance, err := describeInstance(c.ec2, instanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractNodeAddresses(instance)
+}
+
+// InstanceExistsByProviderID returns true if the instance with the given provider id still exists.
+// If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
+func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
+	instanceID, err := kubernetesInstanceID(providerID).mapToAWSInstanceID()
+	if err != nil {
+		return false, err
+	}
+
+	request := &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{instanceID.awsString()},
+	}
+
+	instances, err := c.ec2.DescribeInstances(request)
+	if err != nil {
+		return false, err
+	}
+	if len(instances) == 0 {
+		return false, nil
+	}
+	if len(instances) > 1 {
+		return false, fmt.Errorf("multiple instances found for instance: %s", instanceID)
+	}
+
+	state := instances[0].State.Name
+	if *state == ec2.InstanceStateNameTerminated {
+		klog.Warningf("the instance %s is terminated", instanceID)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// InstanceShutdownByProviderID returns true if the instance is in safe state to detach volumes
+func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
+	instanceID, err := kubernetesInstanceID(providerID).mapToAWSInstanceID()
+	if err != nil {
+		return false, err
+	}
+
+	request := &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{instanceID.awsString()},
+	}
+
+	instances, err := c.ec2.DescribeInstances(request)
+	if err != nil {
+		return false, err
+	}
+	if len(instances) == 0 {
+		klog.Warningf("the instance %s does not exist anymore", providerID)
+		// returns false, because otherwise node is not deleted from cluster
+		// false means that it will continue to check InstanceExistsByProviderID
+		return false, nil
+	}
+	if len(instances) > 1 {
+		return false, fmt.Errorf("multiple instances found for instance: %s", instanceID)
+	}
+
+	instance := instances[0]
+	if instance.State != nil {
+		state := aws.StringValue(instance.State.Name)
+		// valid state for detaching volumes
+		if state == ec2.InstanceStateNameStopped {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// InstanceID returns the cloud provider ID of the node with the specified nodeName.
+func (c *Cloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
+	// In the future it is possible to also return an endpoint as:
+	// <endpoint>/<zone>/<instanceid>
+	if c.selfAWSInstance.nodeName == nodeName {
+		return "/" + c.selfAWSInstance.availabilityZone + "/" + c.selfAWSInstance.awsID, nil
+	}
+	inst, err := c.getInstanceByNodeName(nodeName)
+	if err != nil {
+		if err == cloudprovider.InstanceNotFound {
+			// The Instances interface requires that we return InstanceNotFound (without wrapping)
+			return "", err
+		}
+		return "", fmt.Errorf("getInstanceByNodeName failed for %q with %q", nodeName, err)
+	}
+	return "/" + aws.StringValue(inst.Placement.AvailabilityZone) + "/" + aws.StringValue(inst.InstanceId), nil
+}
+
+// InstanceTypeByProviderID returns the cloudprovider instance type of the node with the specified unique providerID
+// This method will not be called from the node that is requesting this ID. i.e. metadata service
+// and other local methods cannot be used here
+func (c *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
+	instanceID, err := kubernetesInstanceID(providerID).mapToAWSInstanceID()
+	if err != nil {
+		return "", err
+	}
+
+	instance, err := describeInstance(c.ec2, instanceID)
+	if err != nil {
+		return "", err
+	}
+
+	return aws.StringValue(instance.InstanceType), nil
+}
+
+// InstanceType returns the type of the node with the specified nodeName.
+func (c *Cloud) InstanceType(ctx context.Context, nodeName types.NodeName) (string, error) {
+	if c.selfAWSInstance.nodeName == nodeName {
+		return c.selfAWSInstance.instanceType, nil
+	}
+	inst, err := c.getInstanceByNodeName(nodeName)
+	if err != nil {
+		return "", fmt.Errorf("getInstanceByNodeName failed for %q with %q", nodeName, err)
+	}
+	return aws.StringValue(inst.InstanceType), nil
+}
+
+// GetCandidateZonesForDynamicVolume retrieves  a list of all the zones in which nodes are running
+// It currently involves querying all instances
+func (c *Cloud) GetCandidateZonesForDynamicVolume() (sets.String, error) {
+	// We don't currently cache this; it is currently used only in volume
+	// creation which is expected to be a comparatively rare occurrence.
+
+	// TODO: Caching / expose v1.Nodes to the cloud provider?
+	// TODO: We could also query for subnets, I think
+
+	filters := []*ec2.Filter{newEc2Filter("instance-state-name", "running")}
+
+	instances, err := c.describeInstances(filters)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(instances) == 0 {
+		return nil, fmt.Errorf("no instances returned")
+	}
+
+	zones := sets.NewString()
+
+	for _, instance := range instances {
+		// We skip over master nodes, if the installation tool labels them with one of the well-known master labels
+		// This avoids creating a volume in a zone where only the master is running - e.g. #34583
+		// This is a short-term workaround until the scheduler takes care of zone selection
+		master := false
+		for _, tag := range instance.Tags {
+			tagKey := aws.StringValue(tag.Key)
+			if awsTagNameMasterRoles.Has(tagKey) {
+				master = true
+			}
+		}
+
+		if master {
+			klog.V(4).Infof("Ignoring master instance %q in zone discovery", aws.StringValue(instance.InstanceId))
+			continue
+		}
+
+		if instance.Placement != nil {
+			zone := aws.StringValue(instance.Placement.AvailabilityZone)
+			zones.Insert(zone)
+		}
+	}
+
+	klog.V(2).Infof("Found instances in zones %s", zones)
+	return zones, nil
+}
+
+// GetZone implements Zones.GetZone
+func (c *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
+	return cloudprovider.Zone{
+		FailureDomain: c.selfAWSInstance.availabilityZone,
+		Region:        c.region,
+	}, nil
+}
+
+// GetZoneByProviderID implements Zones.GetZoneByProviderID
+// This is particularly useful in external cloud providers where the kubelet
+// does not initialize node data.
+func (c *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
+	instanceID, err := kubernetesInstanceID(providerID).mapToAWSInstanceID()
+	if err != nil {
+		return cloudprovider.Zone{}, err
+	}
+	instance, err := c.getInstanceByID(string(instanceID))
+	if err != nil {
+		return cloudprovider.Zone{}, err
+	}
+
+	zone := cloudprovider.Zone{
+		FailureDomain: *(instance.Placement.AvailabilityZone),
+		Region:        c.region,
+	}
+
+	return zone, nil
+}
+
+// GetZoneByNodeName implements Zones.GetZoneByNodeName
+// This is particularly useful in external cloud providers where the kubelet
+// does not initialize node data.
+func (c *Cloud) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
+	instance, err := c.getInstanceByNodeName(nodeName)
+	if err != nil {
+		return cloudprovider.Zone{}, err
+	}
+	zone := cloudprovider.Zone{
+		FailureDomain: *(instance.Placement.AvailabilityZone),
+		Region:        c.region,
+	}
+
+	return zone, nil
+
+}
+
+// Used to represent a mount device for attaching an EBS volume
+// This should be stored as a single letter (i.e. c, not sdc or /dev/sdc)
+type mountDevice string
+
+type awsInstance struct {
+	ec2 EC2
+
+	// id in AWS
+	awsID string
+
+	// node name in k8s
+	nodeName types.NodeName
+
+	// availability zone the instance resides in
+	availabilityZone string
+
+	// ID of VPC the instance resides in
+	vpcID string
+
+	// ID of subnet the instance resides in
+	subnetID string
+
+	// instance type
+	instanceType string
+}
+
+// newAWSInstance creates a new awsInstance object
+func newAWSInstance(ec2Service EC2, instance *ec2.Instance) *awsInstance {
+	az := ""
+	if instance.Placement != nil {
+		az = aws.StringValue(instance.Placement.AvailabilityZone)
+	}
+	self := &awsInstance{
+		ec2:              ec2Service,
+		awsID:            aws.StringValue(instance.InstanceId),
+		nodeName:         mapInstanceToNodeName(instance),
+		availabilityZone: az,
+		instanceType:     aws.StringValue(instance.InstanceType),
+		vpcID:            aws.StringValue(instance.VpcId),
+		subnetID:         aws.StringValue(instance.SubnetId),
+	}
+
+	return self
+}
+
+// Gets the full information about this instance from the EC2 API
+func (i *awsInstance) describeInstance() (*ec2.Instance, error) {
+	return describeInstance(i.ec2, awsInstanceID(i.awsID))
+}
+
+// Gets the mountDevice already assigned to the volume, or assigns an unused mountDevice.
+// If the volume is already assigned, this will return the existing mountDevice with alreadyAttached=true.
+// Otherwise the mountDevice is assigned by finding the first available mountDevice, and it is returned with alreadyAttached=false.
+func (c *Cloud) getMountDevice(
+	i *awsInstance,
+	info *ec2.Instance,
+	volumeID EBSVolumeID,
+	assign bool) (assigned mountDevice, alreadyAttached bool, err error) {
+
+	deviceMappings := map[mountDevice]EBSVolumeID{}
+	for _, blockDevice := range info.BlockDeviceMappings {
+		name := aws.StringValue(blockDevice.DeviceName)
+		if strings.HasPrefix(name, "/dev/sd") {
+			name = name[7:]
+		}
+		if strings.HasPrefix(name, "/dev/xvd") {
+			name = name[8:]
+		}
+		if len(name) < 1 || len(name) > 2 {
+			klog.Warningf("Unexpected EBS DeviceName: %q", aws.StringValue(blockDevice.DeviceName))
+		}
+		deviceMappings[mountDevice(name)] = EBSVolumeID(aws.StringValue(blockDevice.Ebs.VolumeId))
+	}
+
+	// We lock to prevent concurrent mounts from conflicting
+	// We may still conflict if someone calls the API concurrently,
+	// but the AWS API will then fail one of the two attach operations
+	c.attachingMutex.Lock()
+	defer c.attachingMutex.Unlock()
+
+	for mountDevice, volume := range c.attaching[i.nodeName] {
+		deviceMappings[mountDevice] = volume
+	}
+
+	// Check to see if this volume is already assigned a device on this machine
+	for mountDevice, mappingVolumeID := range deviceMappings {
+		if volumeID == mappingVolumeID {
+			if assign {
+				klog.Warningf("Got assignment call for already-assigned volume: %s@%s", mountDevice, mappingVolumeID)
+			}
+			return mountDevice, true, nil
+		}
+	}
+
+	if !assign {
+		return mountDevice(""), false, nil
+	}
+
+	// Find the next unused device name
+	deviceAllocator := c.deviceAllocators[i.nodeName]
+	if deviceAllocator == nil {
+		// we want device names with two significant characters, starting with /dev/xvdbb
+		// the allowed range is /dev/xvd[b-c][a-z]
+		// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
+		deviceAllocator = NewDeviceAllocator()
+		c.deviceAllocators[i.nodeName] = deviceAllocator
+	}
+	// We need to lock deviceAllocator to prevent possible race with Deprioritize function
+	deviceAllocator.Lock()
+	defer deviceAllocator.Unlock()
+
+	chosen, err := deviceAllocator.GetNext(deviceMappings)
+	if err != nil {
+		klog.Warningf("Could not assign a mount device.  mappings=%v, error: %v", deviceMappings, err)
+		return "", false, fmt.Errorf("too many EBS volumes attached to node %s", i.nodeName)
+	}
+
+	attaching := c.attaching[i.nodeName]
+	if attaching == nil {
+		attaching = make(map[mountDevice]EBSVolumeID)
+		c.attaching[i.nodeName] = attaching
+	}
+	attaching[chosen] = volumeID
+	klog.V(2).Infof("Assigned mount device %s -> volume %s", chosen, volumeID)
+
+	return chosen, false, nil
+}
+
+// endAttaching removes the entry from the "attachments in progress" map
+// It returns true if it was found (and removed), false otherwise
+func (c *Cloud) endAttaching(i *awsInstance, volumeID EBSVolumeID, mountDevice mountDevice) bool {
+	c.attachingMutex.Lock()
+	defer c.attachingMutex.Unlock()
+
+	existingVolumeID, found := c.attaching[i.nodeName][mountDevice]
+	if !found {
+		return false
+	}
+	if volumeID != existingVolumeID {
+		// This actually can happen, because getMountDevice combines the attaching map with the volumes
+		// attached to the instance (as reported by the EC2 API).  So if endAttaching comes after
+		// a 10 second poll delay, we might well have had a concurrent request to allocate a mountpoint,
+		// which because we allocate sequentially is _very_ likely to get the immediately freed volume
+		klog.Infof("endAttaching on device %q assigned to different volume: %q vs %q", mountDevice, volumeID, existingVolumeID)
+		return false
+	}
+	klog.V(2).Infof("Releasing in-process attachment entry: %s -> volume %s", mountDevice, volumeID)
+	delete(c.attaching[i.nodeName], mountDevice)
+	return true
+}
+
+type awsDisk struct {
+	ec2 EC2
+
+	// Name in k8s
+	name KubernetesVolumeID
+	// id in AWS
+	awsID EBSVolumeID
+}
+
+func newAWSDisk(aws *Cloud, name KubernetesVolumeID) (*awsDisk, error) {
+	awsID, err := name.MapToAWSVolumeID()
+	if err != nil {
+		return nil, err
+	}
+	disk := &awsDisk{ec2: aws.ec2, name: name, awsID: awsID}
+	return disk, nil
+}
+
+// Helper function for describeVolume callers. Tries to retype given error to AWS error
+// and returns true in case the AWS error is "InvalidVolume.NotFound", false otherwise
+func isAWSErrorVolumeNotFound(err error) bool {
+	if err != nil {
+		if awsError, ok := err.(awserr.Error); ok {
+			// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
+			if awsError.Code() == "InvalidVolume.NotFound" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Gets the full information about this volume from the EC2 API
+func (d *awsDisk) describeVolume() (*ec2.Volume, error) {
+	volumeID := d.awsID
+
+	request := &ec2.DescribeVolumesInput{
+		VolumeIds: []*string{volumeID.awsString()},
+	}
+
+	volumes, err := d.ec2.DescribeVolumes(request)
+	if err != nil {
+		return nil, err
+	}
+	if len(volumes) == 0 {
+		return nil, fmt.Errorf("no volumes found")
+	}
+	if len(volumes) > 1 {
+		return nil, fmt.Errorf("multiple volumes found")
+	}
+	return volumes[0], nil
+}
+
+func (d *awsDisk) describeVolumeModification() (*ec2.VolumeModification, error) {
+	volumeID := d.awsID
+	request := &ec2.DescribeVolumesModificationsInput{
+		VolumeIds: []*string{volumeID.awsString()},
+	}
+	volumeMods, err := d.ec2.DescribeVolumeModifications(request)
+
+	if err != nil {
+		return nil, fmt.Errorf("error describing volume modification %s with %v", volumeID, err)
+	}
+
+	if len(volumeMods) == 0 {
+		return nil, fmt.Errorf("no volume modifications found for %s", volumeID)
+	}
+	lastIndex := len(volumeMods) - 1
+	return volumeMods[lastIndex], nil
+}
+
+func (d *awsDisk) modifyVolume(requestGiB int64) (int64, error) {
+	volumeID := d.awsID
+
+	request := &ec2.ModifyVolumeInput{
+		VolumeId: volumeID.awsString(),
+		Size:     aws.Int64(requestGiB),
+	}
+	output, err := d.ec2.ModifyVolume(request)
+	if err != nil {
+		modifyError := fmt.Errorf("AWS modifyVolume failed for %s with %v", volumeID, err)
+		return requestGiB, modifyError
+	}
+
+	volumeModification := output.VolumeModification
+
+	if aws.StringValue(volumeModification.ModificationState) == ec2.VolumeModificationStateCompleted {
+		return aws.Int64Value(volumeModification.TargetSize), nil
+	}
+
+	backoff := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2,
+		Steps:    10,
+	}
+
+	checkForResize := func() (bool, error) {
+		volumeModification, err := d.describeVolumeModification()
+
+		if err != nil {
+			return false, err
+		}
+
+		// According to https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring_mods.html
+		// Size changes usually take a few seconds to complete and take effect after a volume is in the Optimizing state.
+		if aws.StringValue(volumeModification.ModificationState) == ec2.VolumeModificationStateOptimizing {
+			return true, nil
+		}
+		return false, nil
+	}
+	waitWithErr := wait.ExponentialBackoff(backoff, checkForResize)
+	return requestGiB, waitWithErr
+}
+
+// applyUnSchedulableTaint applies a unschedulable taint to a node after verifying
+// if node has become unusable because of volumes getting stuck in attaching state.
+func (c *Cloud) applyUnSchedulableTaint(nodeName types.NodeName, reason string) {
+	node, fetchErr := c.kubeClient.CoreV1().Nodes().Get(string(nodeName), metav1.GetOptions{})
+	if fetchErr != nil {
+		klog.Errorf("Error fetching node %s with %v", nodeName, fetchErr)
+		return
+	}
+
+	taint := &v1.Taint{
+		Key:    nodeWithImpairedVolumes,
+		Value:  "true",
+		Effect: v1.TaintEffectNoSchedule,
+	}
+	err := controller.AddOrUpdateTaintOnNode(c.kubeClient, string(nodeName), taint)
+	if err != nil {
+		klog.Errorf("Error applying taint to node %s with error %v", nodeName, err)
+		return
+	}
+	c.eventRecorder.Eventf(node, v1.EventTypeWarning, volumeAttachmentStuck, reason)
+}
+
+// waitForAttachmentStatus polls until the attachment status is the expected value
+// On success, it returns the last attachment state.
+func (d *awsDisk) waitForAttachmentStatus(status string) (*ec2.VolumeAttachment, error) {
+	backoff := wait.Backoff{
+		Duration: volumeAttachmentStatusInitialDelay,
+		Factor:   volumeAttachmentStatusFactor,
+		Steps:    volumeAttachmentStatusSteps,
+	}
+
+	// Because of rate limiting, we often see errors from describeVolume
+	// So we tolerate a limited number of failures.
+	// But once we see more than 10 errors in a row, we return the error
+	describeErrorCount := 0
+	var attachment *ec2.VolumeAttachment
+
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		info, err := d.describeVolume()
+		if err != nil {
+			// The VolumeNotFound error is special -- we don't need to wait for it to repeat
+			if isAWSErrorVolumeNotFound(err) {
+				if status == "detached" {
+					// The disk doesn't exist, assume it's detached, log warning and stop waiting
+					klog.Warningf("Waiting for volume %q to be detached but the volume does not exist", d.awsID)
+					stateStr := "detached"
+					attachment = &ec2.VolumeAttachment{
+						State: &stateStr,
+					}
+					return true, nil
+				}
+				if status == "attached" {
+					// The disk doesn't exist, complain, give up waiting and report error
+					klog.Warningf("Waiting for volume %q to be attached but the volume does not exist", d.awsID)
+					return false, err
+				}
+			}
+			describeErrorCount++
+			if describeErrorCount > volumeAttachmentStatusConsecutiveErrorLimit {
+				// report the error
+				return false, err
+			}
+
+			klog.Warningf("Ignoring error from describe volume for volume %q; will retry: %q", d.awsID, err)
+			return false, nil
+		}
+
+		describeErrorCount = 0
+
+		if len(info.Attachments) > 1 {
+			// Shouldn't happen; log so we know if it is
+			klog.Warningf("Found multiple attachments for volume %q: %v", d.awsID, info)
+		}
+		attachmentStatus := ""
+		for _, a := range info.Attachments {
+			if attachmentStatus != "" {
+				// Shouldn't happen; log so we know if it is
+				klog.Warningf("Found multiple attachments for volume %q: %v", d.awsID, info)
+			}
+			if a.State != nil {
+				attachment = a
+				attachmentStatus = *a.State
+			} else {
+				// Shouldn't happen; log so we know if it is
+				klog.Warningf("Ignoring nil attachment state for volume %q: %v", d.awsID, a)
+			}
+		}
+		if attachmentStatus == "" {
+			attachmentStatus = "detached"
+		}
+		if attachmentStatus == status {
+			// Attachment is in requested state, finish waiting
+			return true, nil
+		}
+		// continue waiting
+		klog.V(2).Infof("Waiting for volume %q state: actual=%s, desired=%s", d.awsID, attachmentStatus, status)
+		return false, nil
+	})
+
+	return attachment, err
+}
+
+// Deletes the EBS disk
+func (d *awsDisk) deleteVolume() (bool, error) {
+	request := &ec2.DeleteVolumeInput{VolumeId: d.awsID.awsString()}
+	_, err := d.ec2.DeleteVolume(request)
+	if err != nil {
+		if isAWSErrorVolumeNotFound(err) {
+			return false, nil
+		}
+		if awsError, ok := err.(awserr.Error); ok {
+			if awsError.Code() == "VolumeInUse" {
+				return false, volume.NewDeletedVolumeInUseError(err.Error())
+			}
+		}
+		return false, fmt.Errorf("error deleting EBS volume %q: %q", d.awsID, err)
+	}
+	return true, nil
+}
+
+// Builds the awsInstance for the EC2 instance on which we are running.
+// This is called when the AWSCloud is initialized, and should not be called otherwise (because the awsInstance for the local instance is a singleton with drive mapping state)
+func (c *Cloud) buildSelfAWSInstance() (*awsInstance, error) {
+	if c.selfAWSInstance != nil {
+		panic("do not call buildSelfAWSInstance directly")
+	}
+	instanceID, err := c.metadata.GetMetadata("instance-id")
+	if err != nil {
+		return nil, fmt.Errorf("error fetching instance-id from ec2 metadata service: %q", err)
+	}
+
+	// We want to fetch the hostname via the EC2 metadata service
+	// (`GetMetadata("local-hostname")`): But see #11543 - we need to use
+	// the EC2 API to get the privateDnsName in case of a private DNS zone
+	// e.g. mydomain.io, because the metadata service returns the wrong
+	// hostname.  Once we're doing that, we might as well get all our
+	// information from the instance returned by the EC2 API - it is a
+	// single API call to get all the information, and it means we don't
+	// have two code paths.
+	instance, err := c.getInstanceByID(instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("error finding instance %s: %q", instanceID, err)
+	}
+	return newAWSInstance(c.ec2, instance), nil
+}
+
+// wrapAttachError wraps the error returned by an AttachVolume request with
+// additional information, if needed and possible.
+func wrapAttachError(err error, disk *awsDisk, instance string) error {
+	if awsError, ok := err.(awserr.Error); ok {
+		if awsError.Code() == "VolumeInUse" {
+			info, err := disk.describeVolume()
+			if err != nil {
+				klog.Errorf("Error describing volume %q: %q", disk.awsID, err)
+			} else {
+				for _, a := range info.Attachments {
+					if disk.awsID != EBSVolumeID(aws.StringValue(a.VolumeId)) {
+						klog.Warningf("Expected to get attachment info of volume %q but instead got info of %q", disk.awsID, aws.StringValue(a.VolumeId))
+					} else if aws.StringValue(a.State) == "attached" {
+						return fmt.Errorf("Error attaching EBS volume %q to instance %q: %q. The volume is currently attached to instance %q", disk.awsID, instance, awsError, aws.StringValue(a.InstanceId))
+					}
+				}
+			}
+		}
+	}
+	return fmt.Errorf("Error attaching EBS volume %q to instance %q: %q", disk.awsID, instance, err)
+}
+
+// AttachDisk implements Volumes.AttachDisk
+func (c *Cloud) AttachDisk(diskName KubernetesVolumeID, nodeName types.NodeName) (string, error) {
+	disk, err := newAWSDisk(c, diskName)
+	if err != nil {
+		return "", err
+	}
+
+	awsInstance, info, err := c.getFullInstance(nodeName)
+	if err != nil {
+		return "", fmt.Errorf("error finding instance %s: %q", nodeName, err)
+	}
+
+	// mountDevice will hold the device where we should try to attach the disk
+	var mountDevice mountDevice
+	// alreadyAttached is true if we have already called AttachVolume on this disk
+	var alreadyAttached bool
+
+	// attachEnded is set to true if the attach operation completed
+	// (successfully or not), and is thus no longer in progress
+	attachEnded := false
+	defer func() {
+		if attachEnded {
+			if !c.endAttaching(awsInstance, disk.awsID, mountDevice) {
+				klog.Errorf("endAttaching called for disk %q when attach not in progress", disk.awsID)
+			}
+		}
+	}()
+
+	mountDevice, alreadyAttached, err = c.getMountDevice(awsInstance, info, disk.awsID, true)
+	if err != nil {
+		return "", err
+	}
+
+	// Inside the instance, the mountpoint always looks like /dev/xvdX (?)
+	hostDevice := "/dev/xvd" + string(mountDevice)
+	// We are using xvd names (so we are HVM only)
+	// See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
+	ec2Device := "/dev/xvd" + string(mountDevice)
+
+	if !alreadyAttached {
+		available, err := c.checkIfAvailable(disk, "attaching", awsInstance.awsID)
+		if err != nil {
+			klog.Error(err)
+		}
+
+		if !available {
+			attachEnded = true
+			return "", err
+		}
+		request := &ec2.AttachVolumeInput{
+			Device:     aws.String(ec2Device),
+			InstanceId: aws.String(awsInstance.awsID),
+			VolumeId:   disk.awsID.awsString(),
+		}
+
+		attachResponse, err := c.ec2.AttachVolume(request)
+		if err != nil {
+			attachEnded = true
+			// TODO: Check if the volume was concurrently attached?
+			return "", wrapAttachError(err, disk, awsInstance.awsID)
+		}
+		if da, ok := c.deviceAllocators[awsInstance.nodeName]; ok {
+			da.Deprioritize(mountDevice)
+		}
+		klog.V(2).Infof("AttachVolume volume=%q instance=%q request returned %v", disk.awsID, awsInstance.awsID, attachResponse)
+	}
+
+	attachment, err := disk.waitForAttachmentStatus("attached")
+
+	if err != nil {
+		if err == wait.ErrWaitTimeout {
+			c.applyUnSchedulableTaint(nodeName, "Volume stuck in attaching state - node needs reboot to fix impaired state.")
+		}
+		return "", err
+	}
+
+	// The attach operation has finished
+	attachEnded = true
+
+	// Double check the attachment to be 100% sure we attached the correct volume at the correct mountpoint
+	// It could happen otherwise that we see the volume attached from a previous/separate AttachVolume call,
+	// which could theoretically be against a different device (or even instance).
+	if attachment == nil {
+		// Impossible?
+		return "", fmt.Errorf("unexpected state: attachment nil after attached %q to %q", diskName, nodeName)
+	}
+	if ec2Device != aws.StringValue(attachment.Device) {
+		return "", fmt.Errorf("disk attachment of %q to %q failed: requested device %q but found %q", diskName, nodeName, ec2Device, aws.StringValue(attachment.Device))
+	}
+	if awsInstance.awsID != aws.StringValue(attachment.InstanceId) {
+		return "", fmt.Errorf("disk attachment of %q to %q failed: requested instance %q but found %q", diskName, nodeName, awsInstance.awsID, aws.StringValue(attachment.InstanceId))
+	}
+
+	return hostDevice, nil
+}
+
+// DetachDisk implements Volumes.DetachDisk
+func (c *Cloud) DetachDisk(diskName KubernetesVolumeID, nodeName types.NodeName) (string, error) {
+	diskInfo, attached, err := c.checkIfAttachedToNode(diskName, nodeName)
+	if err != nil {
+		if isAWSErrorVolumeNotFound(err) {
+			// Someone deleted the volume being detached; complain, but do nothing else and return success
+			klog.Warningf("DetachDisk %s called for node %s but volume does not exist; assuming the volume is detached", diskName, nodeName)
+			return "", nil
+		}
+
+		return "", err
+	}
+
+	if !attached && diskInfo.ec2Instance != nil {
+		klog.Warningf("DetachDisk %s called for node %s but volume is attached to node %s", diskName, nodeName, diskInfo.nodeName)
+		return "", nil
+	}
+
+	if !attached {
+		return "", nil
+	}
+
+	awsInstance := newAWSInstance(c.ec2, diskInfo.ec2Instance)
+
+	mountDevice, alreadyAttached, err := c.getMountDevice(awsInstance, diskInfo.ec2Instance, diskInfo.disk.awsID, false)
+	if err != nil {
+		return "", err
+	}
+
+	if !alreadyAttached {
+		klog.Warningf("DetachDisk called on non-attached disk: %s", diskName)
+		// TODO: Continue?  Tolerate non-attached error from the AWS DetachVolume call?
+	}
+
+	request := ec2.DetachVolumeInput{
+		InstanceId: &awsInstance.awsID,
+		VolumeId:   diskInfo.disk.awsID.awsString(),
+	}
+
+	response, err := c.ec2.DetachVolume(&request)
+	if err != nil {
+		return "", fmt.Errorf("error detaching EBS volume %q from %q: %q", diskInfo.disk.awsID, awsInstance.awsID, err)
+	}
+
+	if response == nil {
+		return "", errors.New("no response from DetachVolume")
+	}
+
+	attachment, err := diskInfo.disk.waitForAttachmentStatus("detached")
+	if err != nil {
+		return "", err
+	}
+	if da, ok := c.deviceAllocators[awsInstance.nodeName]; ok {
+		da.Deprioritize(mountDevice)
+	}
+	if attachment != nil {
+		// We expect it to be nil, it is (maybe) interesting if it is not
+		klog.V(2).Infof("waitForAttachmentStatus returned non-nil attachment with state=detached: %v", attachment)
+	}
+
+	if mountDevice != "" {
+		c.endAttaching(awsInstance, diskInfo.disk.awsID, mountDevice)
+		// We don't check the return value - we don't really expect the attachment to have been
+		// in progress, though it might have been
+	}
+
+	hostDevicePath := "/dev/xvd" + string(mountDevice)
+	return hostDevicePath, err
+}
+
+// CreateDisk implements Volumes.CreateDisk
+func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (KubernetesVolumeID, error) {
+	var createType string
+	var iops int64
+	switch volumeOptions.VolumeType {
+	case VolumeTypeGP2, VolumeTypeSC1, VolumeTypeST1:
+		createType = volumeOptions.VolumeType
+
+	case VolumeTypeIO1:
+		// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html
+		// for IOPS constraints. AWS will throw an error if IOPS per GB gets out
+		// of supported bounds, no need to check it here.
+		createType = volumeOptions.VolumeType
+		iops = int64(volumeOptions.CapacityGB * volumeOptions.IOPSPerGB)
+
+		// Cap at min/max total IOPS, AWS would throw an error if it gets too
+		// low/high.
+		if iops < MinTotalIOPS {
+			iops = MinTotalIOPS
+		}
+		if iops > MaxTotalIOPS {
+			iops = MaxTotalIOPS
+		}
+
+	case "":
+		createType = DefaultVolumeType
+
+	default:
+		return "", fmt.Errorf("invalid AWS VolumeType %q", volumeOptions.VolumeType)
+	}
+
+	request := &ec2.CreateVolumeInput{}
+	request.AvailabilityZone = aws.String(volumeOptions.AvailabilityZone)
+	request.Size = aws.Int64(int64(volumeOptions.CapacityGB))
+	request.VolumeType = aws.String(createType)
+	request.Encrypted = aws.Bool(volumeOptions.Encrypted)
+	if len(volumeOptions.KmsKeyID) > 0 {
+		request.KmsKeyId = aws.String(volumeOptions.KmsKeyID)
+		request.Encrypted = aws.Bool(true)
+	}
+	if iops > 0 {
+		request.Iops = aws.Int64(iops)
+	}
+
+	tags := volumeOptions.Tags
+	tags = c.tagging.buildTags(ResourceLifecycleOwned, tags)
+
+	var tagList []*ec2.Tag
+	for k, v := range tags {
+		tagList = append(tagList, &ec2.Tag{
+			Key: aws.String(k), Value: aws.String(v),
+		})
+	}
+	request.TagSpecifications = append(request.TagSpecifications, &ec2.TagSpecification{
+		Tags:         tagList,
+		ResourceType: aws.String(ec2.ResourceTypeVolume),
+	})
+
+	response, err := c.ec2.CreateVolume(request)
+	if err != nil {
+		return "", err
+	}
+
+	awsID := EBSVolumeID(aws.StringValue(response.VolumeId))
+	if awsID == "" {
+		return "", fmt.Errorf("VolumeID was not returned by CreateVolume")
+	}
+	volumeName := KubernetesVolumeID("aws://" + aws.StringValue(response.AvailabilityZone) + "/" + string(awsID))
+
+	// AWS has a bad habbit of reporting success when creating a volume with
+	// encryption keys that either don't exists or have wrong permissions.
+	// Such volume lives for couple of seconds and then it's silently deleted
+	// by AWS. There is no other check to ensure that given KMS key is correct,
+	// because Kubernetes may have limited permissions to the key.
+	if len(volumeOptions.KmsKeyID) > 0 {
+		err := c.waitUntilVolumeAvailable(volumeName)
+		if err != nil {
+			if isAWSErrorVolumeNotFound(err) {
+				err = fmt.Errorf("failed to create encrypted volume: the volume disappeared after creation, most likely due to inaccessible KMS encryption key")
+			}
+			return "", err
+		}
+	}
+
+	return volumeName, nil
+}
+
+func (c *Cloud) waitUntilVolumeAvailable(volumeName KubernetesVolumeID) error {
+	disk, err := newAWSDisk(c, volumeName)
+	if err != nil {
+		// Unreachable code
+		return err
+	}
+
+	err = wait.Poll(encryptedCheckInterval, encryptedCheckTimeout, func() (done bool, err error) {
+		vol, err := disk.describeVolume()
+		if err != nil {
+			return true, err
+		}
+		if vol.State != nil {
+			switch *vol.State {
+			case "available":
+				// The volume is Available, it won't be deleted now.
+				return true, nil
+			case "creating":
+				return false, nil
+			default:
+				return true, fmt.Errorf("unexpected State of newly created AWS EBS volume %s: %q", volumeName, *vol.State)
+			}
+		}
+		return false, nil
+	})
+	return err
+}
+
+// DeleteDisk implements Volumes.DeleteDisk
+func (c *Cloud) DeleteDisk(volumeName KubernetesVolumeID) (bool, error) {
+	awsDisk, err := newAWSDisk(c, volumeName)
+	if err != nil {
+		return false, err
+	}
+	available, err := c.checkIfAvailable(awsDisk, "deleting", "")
+	if err != nil {
+		if isAWSErrorVolumeNotFound(err) {
+			klog.V(2).Infof("Volume %s not found when deleting it, assuming it's deleted", awsDisk.awsID)
+			return false, nil
+		}
+		klog.Error(err)
+	}
+
+	if !available {
+		return false, err
+	}
+
+	return awsDisk.deleteVolume()
+}
+
+func (c *Cloud) checkIfAvailable(disk *awsDisk, opName string, instance string) (bool, error) {
+	info, err := disk.describeVolume()
+
+	if err != nil {
+		klog.Errorf("Error describing volume %q: %q", disk.awsID, err)
+		// if for some reason we can not describe volume we will return error
+		return false, err
+	}
+
+	volumeState := aws.StringValue(info.State)
+	opError := fmt.Sprintf("Error %s EBS volume %q", opName, disk.awsID)
+	if len(instance) != 0 {
+		opError = fmt.Sprintf("%q to instance %q", opError, instance)
+	}
+
+	// Only available volumes can be attached or deleted
+	if volumeState != "available" {
+		// Volume is attached somewhere else and we can not attach it here
+		if len(info.Attachments) > 0 {
+			attachment := info.Attachments[0]
+			instanceID := aws.StringValue(attachment.InstanceId)
+			attachedInstance, ierr := c.getInstanceByID(instanceID)
+			attachErr := fmt.Sprintf("%s since volume is currently attached to %q", opError, instanceID)
+			if ierr != nil {
+				klog.Error(attachErr)
+				return false, errors.New(attachErr)
+			}
+			devicePath := aws.StringValue(attachment.Device)
+			nodeName := mapInstanceToNodeName(attachedInstance)
+
+			danglingErr := volumeutil.NewDanglingError(attachErr, nodeName, devicePath)
+			return false, danglingErr
+		}
+
+		attachErr := fmt.Errorf("%s since volume is in %q state", opError, volumeState)
+		return false, attachErr
+	}
+
+	return true, nil
+}
+
+// GetLabelsForVolume gets the volume labels for a volume
+func (c *Cloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error) {
+	// Ignore any volumes that are being provisioned
+	if pv.Spec.AWSElasticBlockStore.VolumeID == volume.ProvisionedVolumeName {
+		return nil, nil
+	}
+
+	spec := KubernetesVolumeID(pv.Spec.AWSElasticBlockStore.VolumeID)
+	labels, err := c.GetVolumeLabels(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return labels, nil
+}
+
+// GetVolumeLabels implements Volumes.GetVolumeLabels
+func (c *Cloud) GetVolumeLabels(volumeName KubernetesVolumeID) (map[string]string, error) {
+	awsDisk, err := newAWSDisk(c, volumeName)
+	if err != nil {
+		return nil, err
+	}
+	info, err := awsDisk.describeVolume()
+	if err != nil {
+		return nil, err
+	}
+	labels := make(map[string]string)
+	az := aws.StringValue(info.AvailabilityZone)
+	if az == "" {
+		return nil, fmt.Errorf("volume did not have AZ information: %q", aws.StringValue(info.VolumeId))
+	}
+
+	labels[kubeletapis.LabelZoneFailureDomain] = az
+	region, err := azToRegion(az)
+	if err != nil {
+		return nil, err
+	}
+	labels[kubeletapis.LabelZoneRegion] = region
+
+	return labels, nil
+}
+
+// GetDiskPath implements Volumes.GetDiskPath
+func (c *Cloud) GetDiskPath(volumeName KubernetesVolumeID) (string, error) {
+	awsDisk, err := newAWSDisk(c, volumeName)
+	if err != nil {
+		return "", err
+	}
+	info, err := awsDisk.describeVolume()
+	if err != nil {
+		return "", err
+	}
+	if len(info.Attachments) == 0 {
+		return "", fmt.Errorf("No attachment to volume %s", volumeName)
+	}
+	return aws.StringValue(info.Attachments[0].Device), nil
+}
+
+// DiskIsAttached implements Volumes.DiskIsAttached
+func (c *Cloud) DiskIsAttached(diskName KubernetesVolumeID, nodeName types.NodeName) (bool, error) {
+	_, attached, err := c.checkIfAttachedToNode(diskName, nodeName)
+	if err != nil {
+		if isAWSErrorVolumeNotFound(err) {
+			// The disk doesn't exist, can't be attached
+			klog.Warningf("DiskIsAttached called for volume %s on node %s but the volume does not exist", diskName, nodeName)
+			return false, nil
+		}
+
+		return true, err
+	}
+
+	return attached, nil
+}
+
+// DisksAreAttached returns a map of nodes and Kubernetes volume IDs indicating
+// if the volumes are attached to the node
+func (c *Cloud) DisksAreAttached(nodeDisks map[types.NodeName][]KubernetesVolumeID) (map[types.NodeName]map[KubernetesVolumeID]bool, error) {
+	attached := make(map[types.NodeName]map[KubernetesVolumeID]bool)
+
+	if len(nodeDisks) == 0 {
+		return attached, nil
+	}
+
+	nodeNames := []string{}
+	for nodeName, diskNames := range nodeDisks {
+		for _, diskName := range diskNames {
+			setNodeDisk(attached, diskName, nodeName, false)
+		}
+		nodeNames = append(nodeNames, mapNodeNameToPrivateDNSName(nodeName))
+	}
+
+	// Note that we get instances regardless of state.
+	// This means there might be multiple nodes with the same node names.
+	awsInstances, err := c.getInstancesByNodeNames(nodeNames)
+	if err != nil {
+		// When there is an error fetching instance information
+		// it is safer to return nil and let volume information not be touched.
+		return nil, err
+	}
+
+	if len(awsInstances) == 0 {
+		klog.V(2).Infof("DisksAreAttached found no instances matching node names; will assume disks not attached")
+		return attached, nil
+	}
+
+	// Note that we check that the volume is attached to the correct node, not that it is attached to _a_ node
+	for _, awsInstance := range awsInstances {
+		nodeName := mapInstanceToNodeName(awsInstance)
+
+		diskNames := nodeDisks[nodeName]
+		if len(diskNames) == 0 {
+			continue
+		}
+
+		awsInstanceState := "<nil>"
+		if awsInstance != nil && awsInstance.State != nil {
+			awsInstanceState = aws.StringValue(awsInstance.State.Name)
+		}
+		if awsInstanceState == "terminated" {
+			// Instance is terminated, safe to assume volumes not attached
+			// Note that we keep volumes attached to instances in other states (most notably, stopped)
+			continue
+		}
+
+		idToDiskName := make(map[EBSVolumeID]KubernetesVolumeID)
+		for _, diskName := range diskNames {
+			volumeID, err := diskName.MapToAWSVolumeID()
+			if err != nil {
+				return nil, fmt.Errorf("error mapping volume spec %q to aws id: %v", diskName, err)
+			}
+			idToDiskName[volumeID] = diskName
+		}
+
+		for _, blockDevice := range awsInstance.BlockDeviceMappings {
+			volumeID := EBSVolumeID(aws.StringValue(blockDevice.Ebs.VolumeId))
+			diskName, found := idToDiskName[volumeID]
+			if found {
+				// Disk is still attached to node
+				setNodeDisk(attached, diskName, nodeName, true)
+			}
+		}
+	}
+
+	return attached, nil
+}
+
+// ResizeDisk resizes an EBS volume in GiB increments, it will round up to the
+// next GiB if arguments are not provided in even GiB increments
+func (c *Cloud) ResizeDisk(
+	diskName KubernetesVolumeID,
+	oldSize resource.Quantity,
+	newSize resource.Quantity) (resource.Quantity, error) {
+	awsDisk, err := newAWSDisk(c, diskName)
+	if err != nil {
+		return oldSize, err
+	}
+
+	volumeInfo, err := awsDisk.describeVolume()
+	if err != nil {
+		descErr := fmt.Errorf("AWS.ResizeDisk Error describing volume %s with %v", diskName, err)
+		return oldSize, descErr
+	}
+	// AWS resizes in chunks of GiB (not GB)
+	requestGiB := volumeutil.RoundUpToGiB(newSize)
+	newSizeQuant := resource.MustParse(fmt.Sprintf("%dGi", requestGiB))
+
+	// If disk already if of greater or equal size than requested we return
+	if aws.Int64Value(volumeInfo.Size) >= requestGiB {
+		return newSizeQuant, nil
+	}
+	_, err = awsDisk.modifyVolume(requestGiB)
+
+	if err != nil {
+		return oldSize, err
+	}
+	return newSizeQuant, nil
+}
+
+// Gets the current load balancer state
+func (c *Cloud) describeLoadBalancer(name string) (*elb.LoadBalancerDescription, error) {
+	request := &elb.DescribeLoadBalancersInput{}
+	request.LoadBalancerNames = []*string{&name}
+
+	response, err := c.elb.DescribeLoadBalancers(request)
+	if err != nil {
+		if awsError, ok := err.(awserr.Error); ok {
+			if awsError.Code() == "LoadBalancerNotFound" {
+				return nil, nil
+			}
+		}
+		return nil, err
+	}
+
+	var ret *elb.LoadBalancerDescription
+	for _, loadBalancer := range response.LoadBalancerDescriptions {
+		if ret != nil {
+			klog.Errorf("Found multiple load balancers with name: %s", name)
+		}
+		ret = loadBalancer
+	}
+	return ret, nil
+}
+
+func (c *Cloud) addLoadBalancerTags(loadBalancerName string, requested map[string]string) error {
+	var tags []*elb.Tag
+	for k, v := range requested {
+		tag := &elb.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+		tags = append(tags, tag)
+	}
+
+	request := &elb.AddTagsInput{}
+	request.LoadBalancerNames = []*string{&loadBalancerName}
+	request.Tags = tags
+
+	_, err := c.elb.AddTags(request)
+	if err != nil {
+		return fmt.Errorf("error adding tags to load balancer: %v", err)
+	}
+	return nil
+}
+
+// Gets the current load balancer state
+func (c *Cloud) describeLoadBalancerv2(name string) (*elbv2.LoadBalancer, error) {
+	request := &elbv2.DescribeLoadBalancersInput{
+		Names: []*string{aws.String(name)},
+	}
+
+	response, err := c.elbv2.DescribeLoadBalancers(request)
+	if err != nil {
+		if awsError, ok := err.(awserr.Error); ok {
+			if awsError.Code() == elbv2.ErrCodeLoadBalancerNotFoundException {
+				return nil, nil
+			}
+		}
+		return nil, fmt.Errorf("Error describing load balancer: %q", err)
+	}
+
+	// AWS will not return 2 load balancers with the same name _and_ type.
+	for i := range response.LoadBalancers {
+		if aws.StringValue(response.LoadBalancers[i].Type) == elbv2.LoadBalancerTypeEnumNetwork {
+			return response.LoadBalancers[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("NLB '%s' could not be found", name)
+}
+
+// Retrieves instance's vpc id from metadata
+func (c *Cloud) findVPCID() (string, error) {
+	macs, err := c.metadata.GetMetadata("network/interfaces/macs/")
+	if err != nil {
+		return "", fmt.Errorf("Could not list interfaces of the instance: %q", err)
+	}
+
+	// loop over interfaces, first vpc id returned wins
+	for _, macPath := range strings.Split(macs, "\n") {
+		if len(macPath) == 0 {
+			continue
+		}
+		url := fmt.Sprintf("network/interfaces/macs/%svpc-id", macPath)
+		vpcID, err := c.metadata.GetMetadata(url)
+		if err != nil {
+			continue
+		}
+		return vpcID, nil
+	}
+	return "", fmt.Errorf("Could not find VPC ID in instance metadata")
+}
+
+// Retrieves the specified security group from the AWS API, or returns nil if not found
+func (c *Cloud) findSecurityGroup(securityGroupID string) (*ec2.SecurityGroup, error) {
+	describeSecurityGroupsRequest := &ec2.DescribeSecurityGroupsInput{
+		GroupIds: []*string{&securityGroupID},
+	}
+	// We don't apply our tag filters because we are retrieving by ID
+
+	groups, err := c.ec2.DescribeSecurityGroups(describeSecurityGroupsRequest)
+	if err != nil {
+		klog.Warningf("Error retrieving security group: %q", err)
+		return nil, err
+	}
+
+	if len(groups) == 0 {
+		return nil, nil
+	}
+	if len(groups) != 1 {
+		// This should not be possible - ids should be unique
+		return nil, fmt.Errorf("multiple security groups found with same id %q", securityGroupID)
+	}
+	group := groups[0]
+	return group, nil
+}
+
+func isEqualIntPointer(l, r *int64) bool {
+	if l == nil {
+		return r == nil
+	}
+	if r == nil {
+		return l == nil
+	}
+	return *l == *r
+}
+
+func isEqualStringPointer(l, r *string) bool {
+	if l == nil {
+		return r == nil
+	}
+	if r == nil {
+		return l == nil
+	}
+	return *l == *r
+}
+
+func ipPermissionExists(newPermission, existing *ec2.IpPermission, compareGroupUserIDs bool) bool {
+	if !isEqualIntPointer(newPermission.FromPort, existing.FromPort) {
+		return false
+	}
+	if !isEqualIntPointer(newPermission.ToPort, existing.ToPort) {
+		return false
+	}
+	if !isEqualStringPointer(newPermission.IpProtocol, existing.IpProtocol) {
+		return false
+	}
+	// Check only if newPermission is a subset of existing. Usually it has zero or one elements.
+	// Not doing actual CIDR math yet; not clear it's needed, either.
+	klog.V(4).Infof("Comparing %v to %v", newPermission, existing)
+	if len(newPermission.IpRanges) > len(existing.IpRanges) {
+		return false
+	}
+
+	for j := range newPermission.IpRanges {
+		found := false
+		for k := range existing.IpRanges {
+			if isEqualStringPointer(newPermission.IpRanges[j].CidrIp, existing.IpRanges[k].CidrIp) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	for _, leftPair := range newPermission.UserIdGroupPairs {
+		found := false
+		for _, rightPair := range existing.UserIdGroupPairs {
+			if isEqualUserGroupPair(leftPair, rightPair, compareGroupUserIDs) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isEqualUserGroupPair(l, r *ec2.UserIdGroupPair, compareGroupUserIDs bool) bool {
+	klog.V(2).Infof("Comparing %v to %v", *l.GroupId, *r.GroupId)
+	if isEqualStringPointer(l.GroupId, r.GroupId) {
+		if compareGroupUserIDs {
+			if isEqualStringPointer(l.UserId, r.UserId) {
+				return true
+			}
+		} else {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Makes sure the security group ingress is exactly the specified permissions
+// Returns true if and only if changes were made
+// The security group must already exist
+func (c *Cloud) setSecurityGroupIngress(securityGroupID string, permissions IPPermissionSet) (bool, error) {
+	// We do not want to make changes to the Global defined SG
+	if securityGroupID == c.cfg.Global.ElbSecurityGroup {
+		return false, nil
+	}
+
+	group, err := c.findSecurityGroup(securityGroupID)
+	if err != nil {
+		klog.Warningf("Error retrieving security group %q", err)
+		return false, err
+	}
+
+	if group == nil {
+		return false, fmt.Errorf("security group not found: %s", securityGroupID)
+	}
+
+	klog.V(2).Infof("Existing security group ingress: %s %v", securityGroupID, group.IpPermissions)
+
+	actual := NewIPPermissionSet(group.IpPermissions...)
+
+	// EC2 groups rules together, for example combining:
+	//
+	// { Port=80, Range=[A] } and { Port=80, Range=[B] }
+	//
+	// into { Port=80, Range=[A,B] }
+	//
+	// We have to ungroup them, because otherwise the logic becomes really
+	// complicated, and also because if we have Range=[A,B] and we try to
+	// add Range=[A] then EC2 complains about a duplicate rule.
+	permissions = permissions.Ungroup()
+	actual = actual.Ungroup()
+
+	remove := actual.Difference(permissions)
+	add := permissions.Difference(actual)
+
+	if add.Len() == 0 && remove.Len() == 0 {
+		return false, nil
+	}
+
+	// TODO: There is a limit in VPC of 100 rules per security group, so we
+	// probably should try grouping or combining to fit under this limit.
+	// But this is only used on the ELB security group currently, so it
+	// would require (ports * CIDRS) > 100.  Also, it isn't obvious exactly
+	// how removing single permissions from compound rules works, and we
+	// don't want to accidentally open more than intended while we're
+	// applying changes.
+	if add.Len() != 0 {
+		klog.V(2).Infof("Adding security group ingress: %s %v", securityGroupID, add.List())
+
+		request := &ec2.AuthorizeSecurityGroupIngressInput{}
+		request.GroupId = &securityGroupID
+		request.IpPermissions = add.List()
+		_, err = c.ec2.AuthorizeSecurityGroupIngress(request)
+		if err != nil {
+			return false, fmt.Errorf("error authorizing security group ingress: %q", err)
+		}
+	}
+	if remove.Len() != 0 {
+		klog.V(2).Infof("Remove security group ingress: %s %v", securityGroupID, remove.List())
+
+		request := &ec2.RevokeSecurityGroupIngressInput{}
+		request.GroupId = &securityGroupID
+		request.IpPermissions = remove.List()
+		_, err = c.ec2.RevokeSecurityGroupIngress(request)
+		if err != nil {
+			return false, fmt.Errorf("error revoking security group ingress: %q", err)
+		}
+	}
+
+	return true, nil
+}
+
+// Makes sure the security group includes the specified permissions
+// Returns true if and only if changes were made
+// The security group must already exist
+func (c *Cloud) addSecurityGroupIngress(securityGroupID string, addPermissions []*ec2.IpPermission) (bool, error) {
+	// We do not want to make changes to the Global defined SG
+	if securityGroupID == c.cfg.Global.ElbSecurityGroup {
+		return false, nil
+	}
+
+	group, err := c.findSecurityGroup(securityGroupID)
+	if err != nil {
+		klog.Warningf("Error retrieving security group: %q", err)
+		return false, err
+	}
+
+	if group == nil {
+		return false, fmt.Errorf("security group not found: %s", securityGroupID)
+	}
+
+	klog.V(2).Infof("Existing security group ingress: %s %v", securityGroupID, group.IpPermissions)
+
+	changes := []*ec2.IpPermission{}
+	for _, addPermission := range addPermissions {
+		hasUserID := false
+		for i := range addPermission.UserIdGroupPairs {
+			if addPermission.UserIdGroupPairs[i].UserId != nil {
+				hasUserID = true
+			}
+		}
+
+		found := false
+		for _, groupPermission := range group.IpPermissions {
+			if ipPermissionExists(addPermission, groupPermission, hasUserID) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			changes = append(changes, addPermission)
+		}
+	}
+
+	if len(changes) == 0 {
+		return false, nil
+	}
+
+	klog.V(2).Infof("Adding security group ingress: %s %v", securityGroupID, changes)
+
+	request := &ec2.AuthorizeSecurityGroupIngressInput{}
+	request.GroupId = &securityGroupID
+	request.IpPermissions = changes
+	_, err = c.ec2.AuthorizeSecurityGroupIngress(request)
+	if err != nil {
+		klog.Warningf("Error authorizing security group ingress %q", err)
+		return false, fmt.Errorf("error authorizing security group ingress: %q", err)
+	}
+
+	return true, nil
+}
+
+// Makes sure the security group no longer includes the specified permissions
+// Returns true if and only if changes were made
+// If the security group no longer exists, will return (false, nil)
+func (c *Cloud) removeSecurityGroupIngress(securityGroupID string, removePermissions []*ec2.IpPermission) (bool, error) {
+	// We do not want to make changes to the Global defined SG
+	if securityGroupID == c.cfg.Global.ElbSecurityGroup {
+		return false, nil
+	}
+
+	group, err := c.findSecurityGroup(securityGroupID)
+	if err != nil {
+		klog.Warningf("Error retrieving security group: %q", err)
+		return false, err
+	}
+
+	if group == nil {
+		klog.Warning("Security group not found: ", securityGroupID)
+		return false, nil
+	}
+
+	changes := []*ec2.IpPermission{}
+	for _, removePermission := range removePermissions {
+		hasUserID := false
+		for i := range removePermission.UserIdGroupPairs {
+			if removePermission.UserIdGroupPairs[i].UserId != nil {
+				hasUserID = true
+			}
+		}
+
+		var found *ec2.IpPermission
+		for _, groupPermission := range group.IpPermissions {
+			if ipPermissionExists(removePermission, groupPermission, hasUserID) {
+				found = removePermission
+				break
+			}
+		}
+
+		if found != nil {
+			changes = append(changes, found)
+		}
+	}
+
+	if len(changes) == 0 {
+		return false, nil
+	}
+
+	klog.V(2).Infof("Removing security group ingress: %s %v", securityGroupID, changes)
+
+	request := &ec2.RevokeSecurityGroupIngressInput{}
+	request.GroupId = &securityGroupID
+	request.IpPermissions = changes
+	_, err = c.ec2.RevokeSecurityGroupIngress(request)
+	if err != nil {
+		klog.Warningf("Error revoking security group ingress: %q", err)
+		return false, err
+	}
+
+	return true, nil
+}
+
+// Makes sure the security group exists.
+// For multi-cluster isolation, name must be globally unique, for example derived from the service UUID.
+// Additional tags can be specified
+// Returns the security group id or error
+func (c *Cloud) ensureSecurityGroup(name string, description string, additionalTags map[string]string) (string, error) {
+	groupID := ""
+	attempt := 0
+	for {
+		attempt++
+
+		request := &ec2.DescribeSecurityGroupsInput{}
+		filters := []*ec2.Filter{
+			newEc2Filter("group-name", name),
+			newEc2Filter("vpc-id", c.vpcID),
+		}
+		// Note that we do _not_ add our tag filters; group-name + vpc-id is the EC2 primary key.
+		// However, we do check that it matches our tags.
+		// If it doesn't have any tags, we tag it; this is how we recover if we failed to tag before.
+		// If it has a different cluster's tags, that is an error.
+		// This shouldn't happen because name is expected to be globally unique (UUID derived)
+		request.Filters = filters
+
+		securityGroups, err := c.ec2.DescribeSecurityGroups(request)
+		if err != nil {
+			return "", err
+		}
+
+		if len(securityGroups) >= 1 {
+			if len(securityGroups) > 1 {
+				klog.Warningf("Found multiple security groups with name: %q", name)
+			}
+			err := c.tagging.readRepairClusterTags(
+				c.ec2, aws.StringValue(securityGroups[0].GroupId),
+				ResourceLifecycleOwned, nil, securityGroups[0].Tags)
+			if err != nil {
+				return "", err
+			}
+
+			return aws.StringValue(securityGroups[0].GroupId), nil
+		}
+
+		createRequest := &ec2.CreateSecurityGroupInput{}
+		createRequest.VpcId = &c.vpcID
+		createRequest.GroupName = &name
+		createRequest.Description = &description
+
+		createResponse, err := c.ec2.CreateSecurityGroup(createRequest)
+		if err != nil {
+			ignore := false
+			switch err := err.(type) {
+			case awserr.Error:
+				if err.Code() == "InvalidGroup.Duplicate" && attempt < MaxReadThenCreateRetries {
+					klog.V(2).Infof("Got InvalidGroup.Duplicate while creating security group (race?); will retry")
+					ignore = true
+				}
+			}
+			if !ignore {
+				klog.Errorf("Error creating security group: %q", err)
+				return "", err
+			}
+			time.Sleep(1 * time.Second)
+		} else {
+			groupID = aws.StringValue(createResponse.GroupId)
+			break
+		}
+	}
+	if groupID == "" {
+		return "", fmt.Errorf("created security group, but id was not returned: %s", name)
+	}
+
+	err := c.tagging.createTags(c.ec2, groupID, ResourceLifecycleOwned, additionalTags)
+	if err != nil {
+		// If we retry, ensureClusterTags will recover from this - it
+		// will add the missing tags.  We could delete the security
+		// group here, but that doesn't feel like the right thing, as
+		// the caller is likely to retry the create
+		return "", fmt.Errorf("error tagging security group: %q", err)
+	}
+	return groupID, nil
+}
+
+// Finds the value for a given tag.
+func findTag(tags []*ec2.Tag, key string) (string, bool) {
+	for _, tag := range tags {
+		if aws.StringValue(tag.Key) == key {
+			return aws.StringValue(tag.Value), true
+		}
+	}
+	return "", false
+}
+
+// Finds the subnets associated with the cluster, by matching tags.
+// For maximal backwards compatibility, if no subnets are tagged, it will fall-back to the current subnet.
+// However, in future this will likely be treated as an error.
+func (c *Cloud) findSubnets() ([]*ec2.Subnet, error) {
+	request := &ec2.DescribeSubnetsInput{}
+	filters := []*ec2.Filter{newEc2Filter("vpc-id", c.vpcID)}
+	request.Filters = c.tagging.addFilters(filters)
+
+	subnets, err := c.ec2.DescribeSubnets(request)
+	if err != nil {
+		return nil, fmt.Errorf("error describing subnets: %q", err)
+	}
+
+	var matches []*ec2.Subnet
+	for _, subnet := range subnets {
+		if c.tagging.hasClusterTag(subnet.Tags) {
+			matches = append(matches, subnet)
+		}
+	}
+
+	if len(matches) != 0 {
+		return matches, nil
+	}
+
+	// Fall back to the current instance subnets, if nothing is tagged
+	klog.Warningf("No tagged subnets found; will fall-back to the current subnet only.  This is likely to be an error in a future version of k8s.")
+
+	request = &ec2.DescribeSubnetsInput{}
+	filters = []*ec2.Filter{newEc2Filter("subnet-id", c.selfAWSInstance.subnetID)}
+	request.Filters = filters
+
+	subnets, err = c.ec2.DescribeSubnets(request)
+	if err != nil {
+		return nil, fmt.Errorf("error describing subnets: %q", err)
+	}
+
+	return subnets, nil
+}
+
+// Finds the subnets to use for an ELB we are creating.
+// Normal (Internet-facing) ELBs must use public subnets, so we skip private subnets.
+// Internal ELBs can use public or private subnets, but if we have a private subnet we should prefer that.
+func (c *Cloud) findELBSubnets(internalELB bool) ([]string, error) {
+	vpcIDFilter := newEc2Filter("vpc-id", c.vpcID)
+
+	subnets, err := c.findSubnets()
+	if err != nil {
+		return nil, err
+	}
+
+	rRequest := &ec2.DescribeRouteTablesInput{}
+	rRequest.Filters = []*ec2.Filter{vpcIDFilter}
+	rt, err := c.ec2.DescribeRouteTables(rRequest)
+	if err != nil {
+		return nil, fmt.Errorf("error describe route table: %q", err)
+	}
+
+	subnetsByAZ := make(map[string]*ec2.Subnet)
+	for _, subnet := range subnets {
+		az := aws.StringValue(subnet.AvailabilityZone)
+		id := aws.StringValue(subnet.SubnetId)
+		if az == "" || id == "" {
+			klog.Warningf("Ignoring subnet with empty az/id: %v", subnet)
+			continue
+		}
+
+		isPublic, err := isSubnetPublic(rt, id)
+		if err != nil {
+			return nil, err
+		}
+		if !internalELB && !isPublic {
+			klog.V(2).Infof("Ignoring private subnet for public ELB %q", id)
+			continue
+		}
+
+		existing := subnetsByAZ[az]
+		if existing == nil {
+			subnetsByAZ[az] = subnet
+			continue
+		}
+
+		// Try to break the tie using a tag
+		var tagName string
+		if internalELB {
+			tagName = TagNameSubnetInternalELB
+		} else {
+			tagName = TagNameSubnetPublicELB
+		}
+
+		_, existingHasTag := findTag(existing.Tags, tagName)
+		_, subnetHasTag := findTag(subnet.Tags, tagName)
+
+		if existingHasTag != subnetHasTag {
+			if subnetHasTag {
+				subnetsByAZ[az] = subnet
+			}
+			continue
+		}
+
+		// If we have two subnets for the same AZ we arbitrarily choose the one that is first lexicographically.
+		// TODO: Should this be an error.
+		if strings.Compare(*existing.SubnetId, *subnet.SubnetId) > 0 {
+			klog.Warningf("Found multiple subnets in AZ %q; choosing %q between subnets %q and %q", az, *subnet.SubnetId, *existing.SubnetId, *subnet.SubnetId)
+			subnetsByAZ[az] = subnet
+			continue
+		}
+
+		klog.Warningf("Found multiple subnets in AZ %q; choosing %q between subnets %q and %q", az, *existing.SubnetId, *existing.SubnetId, *subnet.SubnetId)
+		continue
+	}
+
+	var subnetIDs []string
+	for _, subnet := range subnetsByAZ {
+		subnetIDs = append(subnetIDs, aws.StringValue(subnet.SubnetId))
+	}
+
+	return subnetIDs, nil
+}
+
+func isSubnetPublic(rt []*ec2.RouteTable, subnetID string) (bool, error) {
+	var subnetTable *ec2.RouteTable
+	for _, table := range rt {
+		for _, assoc := range table.Associations {
+			if aws.StringValue(assoc.SubnetId) == subnetID {
+				subnetTable = table
+				break
+			}
+		}
+	}
+
+	if subnetTable == nil {
+		// If there is no explicit association, the subnet will be implicitly
+		// associated with the VPC's main routing table.
+		for _, table := range rt {
+			for _, assoc := range table.Associations {
+				if aws.BoolValue(assoc.Main) == true {
+					klog.V(4).Infof("Assuming implicit use of main routing table %s for %s",
+						aws.StringValue(table.RouteTableId), subnetID)
+					subnetTable = table
+					break
+				}
+			}
+		}
+	}
+
+	if subnetTable == nil {
+		return false, fmt.Errorf("Could not locate routing table for subnet %s", subnetID)
+	}
+
+	for _, route := range subnetTable.Routes {
+		// There is no direct way in the AWS API to determine if a subnet is public or private.
+		// A public subnet is one which has an internet gateway route
+		// we look for the gatewayId and make sure it has the prefix of igw to differentiate
+		// from the default in-subnet route which is called "local"
+		// or other virtual gateway (starting with vgv)
+		// or vpc peering connections (starting with pcx).
+		if strings.HasPrefix(aws.StringValue(route.GatewayId), "igw") {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+type portSets struct {
+	names   sets.String
+	numbers sets.Int64
+}
+
+// getPortSets returns a portSets structure representing port names and numbers
+// that the comma-separated string describes. If the input is empty or equal to
+// "*", a nil pointer is returned.
+func getPortSets(annotation string) (ports *portSets) {
+	if annotation != "" && annotation != "*" {
+		ports = &portSets{
+			sets.NewString(),
+			sets.NewInt64(),
+		}
+		portStringSlice := strings.Split(annotation, ",")
+		for _, item := range portStringSlice {
+			port, err := strconv.Atoi(item)
+			if err != nil {
+				ports.names.Insert(item)
+			} else {
+				ports.numbers.Insert(int64(port))
+			}
+		}
+	}
+	return
+}
+
+// buildELBSecurityGroupList returns list of SecurityGroups which should be
+// attached to ELB created by a service. List always consist of at least
+// 1 member which is an SG created for this service or a SG from the Global config.
+// Extra groups can be specified via annotation, as can extra tags for any
+// new groups. The annotation "ServiceAnnotationLoadBalancerSecurityGroups" allows for
+// setting the security groups specified.
+func (c *Cloud) buildELBSecurityGroupList(serviceName types.NamespacedName, loadBalancerName string, annotations map[string]string) ([]string, error) {
+	var err error
+	var securityGroupID string
+
+	if c.cfg.Global.ElbSecurityGroup != "" {
+		securityGroupID = c.cfg.Global.ElbSecurityGroup
+	} else {
+		// Create a security group for the load balancer
+		sgName := "k8s-elb-" + loadBalancerName
+		sgDescription := fmt.Sprintf("Security group for Kubernetes ELB %s (%v)", loadBalancerName, serviceName)
+		securityGroupID, err = c.ensureSecurityGroup(sgName, sgDescription, getLoadBalancerAdditionalTags(annotations))
+		if err != nil {
+			klog.Errorf("Error creating load balancer security group: %q", err)
+			return nil, err
+		}
+	}
+
+	sgList := []string{}
+
+	for _, extraSG := range strings.Split(annotations[ServiceAnnotationLoadBalancerSecurityGroups], ",") {
+		extraSG = strings.TrimSpace(extraSG)
+		if len(extraSG) > 0 {
+			sgList = append(sgList, extraSG)
+		}
+	}
+
+	// If no Security Groups have been specified with the ServiceAnnotationLoadBalancerSecurityGroups annotation, we add the default one.
+	if len(sgList) == 0 {
+		sgList = append(sgList, securityGroupID)
+	}
+
+	for _, extraSG := range strings.Split(annotations[ServiceAnnotationLoadBalancerExtraSecurityGroups], ",") {
+		extraSG = strings.TrimSpace(extraSG)
+		if len(extraSG) > 0 {
+			sgList = append(sgList, extraSG)
+		}
+	}
+
+	return sgList, nil
+}
+
+// buildListener creates a new listener from the given port, adding an SSL certificate
+// if indicated by the appropriate annotations.
+func buildListener(port v1.ServicePort, annotations map[string]string, sslPorts *portSets) (*elb.Listener, error) {
+	loadBalancerPort := int64(port.Port)
+	portName := strings.ToLower(port.Name)
+	instancePort := int64(port.NodePort)
+	protocol := strings.ToLower(string(port.Protocol))
+	instanceProtocol := protocol
+
+	listener := &elb.Listener{}
+	listener.InstancePort = &instancePort
+	listener.LoadBalancerPort = &loadBalancerPort
+	certID := annotations[ServiceAnnotationLoadBalancerCertificate]
+	if certID != "" && (sslPorts == nil || sslPorts.numbers.Has(loadBalancerPort) || sslPorts.names.Has(portName)) {
+		instanceProtocol = annotations[ServiceAnnotationLoadBalancerBEProtocol]
+		if instanceProtocol == "" {
+			protocol = "ssl"
+			instanceProtocol = "tcp"
+		} else {
+			protocol = backendProtocolMapping[instanceProtocol]
+			if protocol == "" {
+				return nil, fmt.Errorf("Invalid backend protocol %s for %s in %s", instanceProtocol, certID, ServiceAnnotationLoadBalancerBEProtocol)
+			}
+		}
+		listener.SSLCertificateId = &certID
+	} else if annotationProtocol := annotations[ServiceAnnotationLoadBalancerBEProtocol]; annotationProtocol == "http" {
+		instanceProtocol = annotationProtocol
+		protocol = "http"
+	}
+
+	listener.Protocol = &protocol
+	listener.InstanceProtocol = &instanceProtocol
+
+	return listener, nil
+}
+
+// EnsureLoadBalancer implements LoadBalancer.EnsureLoadBalancer
+func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiService *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
+	annotations := apiService.Annotations
+	klog.V(2).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v, %v, %v)",
+		clusterName, apiService.Namespace, apiService.Name, c.region, apiService.Spec.LoadBalancerIP, apiService.Spec.Ports, annotations)
+
+	if apiService.Spec.SessionAffinity != v1.ServiceAffinityNone {
+		// ELB supports sticky sessions, but only when configured for HTTP/HTTPS
+		return nil, fmt.Errorf("unsupported load balancer affinity: %v", apiService.Spec.SessionAffinity)
+	}
+
+	if len(apiService.Spec.Ports) == 0 {
+		return nil, fmt.Errorf("requested load balancer with no ports")
+	}
+
+	// Figure out what mappings we want on the load balancer
+	listeners := []*elb.Listener{}
+	v2Mappings := []nlbPortMapping{}
+
+	portList := getPortSets(annotations[ServiceAnnotationLoadBalancerSSLPorts])
+	for _, port := range apiService.Spec.Ports {
+		if port.Protocol != v1.ProtocolTCP {
+			return nil, fmt.Errorf("Only TCP LoadBalancer is supported for AWS ELB")
+		}
+		if port.NodePort == 0 {
+			klog.Errorf("Ignoring port without NodePort defined: %v", port)
+			continue
+		}
+
+		if isNLB(annotations) {
+			v2Mappings = append(v2Mappings, nlbPortMapping{
+				FrontendPort: int64(port.Port),
+				TrafficPort:  int64(port.NodePort),
+				// if externalTrafficPolicy == "Local", we'll override the
+				// health check later
+				HealthCheckPort:     int64(port.NodePort),
+				HealthCheckProtocol: elbv2.ProtocolEnumTcp,
+			})
+		}
+		listener, err := buildListener(port, annotations, portList)
+		if err != nil {
+			return nil, err
+		}
+		listeners = append(listeners, listener)
+	}
+
+	if apiService.Spec.LoadBalancerIP != "" {
+		return nil, fmt.Errorf("LoadBalancerIP cannot be specified for AWS ELB")
+	}
+
+	instances, err := c.findInstancesForELB(nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceRanges, err := service.GetLoadBalancerSourceRanges(apiService)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine if this is tagged as an Internal ELB
+	internalELB := false
+	internalAnnotation := apiService.Annotations[ServiceAnnotationLoadBalancerInternal]
+	if internalAnnotation == "false" {
+		internalELB = false
+	} else if internalAnnotation != "" {
+		internalELB = true
+	}
+
+	if isNLB(annotations) {
+
+		if path, healthCheckNodePort := service.GetServiceHealthCheckPathPort(apiService); path != "" {
+			for i := range v2Mappings {
+				v2Mappings[i].HealthCheckPort = int64(healthCheckNodePort)
+				v2Mappings[i].HealthCheckPath = path
+				v2Mappings[i].HealthCheckProtocol = elbv2.ProtocolEnumHttp
+			}
+		}
+
+		// Find the subnets that the ELB will live in
+		subnetIDs, err := c.findELBSubnets(internalELB)
+		if err != nil {
+			klog.Errorf("Error listing subnets in VPC: %q", err)
+			return nil, err
+		}
+		// Bail out early if there are no subnets
+		if len(subnetIDs) == 0 {
+			return nil, fmt.Errorf("could not find any suitable subnets for creating the ELB")
+		}
+
+		loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, apiService)
+		serviceName := types.NamespacedName{Namespace: apiService.Namespace, Name: apiService.Name}
+
+		instanceIDs := []string{}
+		for id := range instances {
+			instanceIDs = append(instanceIDs, string(id))
+		}
+
+		v2LoadBalancer, err := c.ensureLoadBalancerv2(
+			serviceName,
+			loadBalancerName,
+			v2Mappings,
+			instanceIDs,
+			subnetIDs,
+			internalELB,
+			annotations,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		sourceRangeCidrs := []string{}
+		for cidr := range sourceRanges {
+			sourceRangeCidrs = append(sourceRangeCidrs, cidr)
+		}
+		if len(sourceRangeCidrs) == 0 {
+			sourceRangeCidrs = append(sourceRangeCidrs, "0.0.0.0/0")
+		}
+
+		err = c.updateInstanceSecurityGroupsForNLB(v2Mappings, instances, loadBalancerName, sourceRangeCidrs)
+		if err != nil {
+			klog.Warningf("Error opening ingress rules for the load balancer to the instances: %q", err)
+			return nil, err
+		}
+
+		// We don't have an `ensureLoadBalancerInstances()` function for elbv2
+		// because `ensureLoadBalancerv2()` requires instance Ids
+
+		// TODO: Wait for creation?
+		return v2toStatus(v2LoadBalancer), nil
+	}
+
+	// Determine if we need to set the Proxy protocol policy
+	proxyProtocol := false
+	proxyProtocolAnnotation := apiService.Annotations[ServiceAnnotationLoadBalancerProxyProtocol]
+	if proxyProtocolAnnotation != "" {
+		if proxyProtocolAnnotation != "*" {
+			return nil, fmt.Errorf("annotation %q=%q detected, but the only value supported currently is '*'", ServiceAnnotationLoadBalancerProxyProtocol, proxyProtocolAnnotation)
+		}
+		proxyProtocol = true
+	}
+
+	// Some load balancer attributes are required, so defaults are set. These can be overridden by annotations.
+	loadBalancerAttributes := &elb.LoadBalancerAttributes{
+		AccessLog:              &elb.AccessLog{Enabled: aws.Bool(false)},
+		ConnectionDraining:     &elb.ConnectionDraining{Enabled: aws.Bool(false)},
+		ConnectionSettings:     &elb.ConnectionSettings{IdleTimeout: aws.Int64(60)},
+		CrossZoneLoadBalancing: &elb.CrossZoneLoadBalancing{Enabled: aws.Bool(false)},
+	}
+
+	// Determine if an access log emit interval has been specified
+	accessLogEmitIntervalAnnotation := annotations[ServiceAnnotationLoadBalancerAccessLogEmitInterval]
+	if accessLogEmitIntervalAnnotation != "" {
+		accessLogEmitInterval, err := strconv.ParseInt(accessLogEmitIntervalAnnotation, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing service annotation: %s=%s",
+				ServiceAnnotationLoadBalancerAccessLogEmitInterval,
+				accessLogEmitIntervalAnnotation,
+			)
+		}
+		loadBalancerAttributes.AccessLog.EmitInterval = &accessLogEmitInterval
+	}
+
+	// Determine if access log enabled/disabled has been specified
+	accessLogEnabledAnnotation := annotations[ServiceAnnotationLoadBalancerAccessLogEnabled]
+	if accessLogEnabledAnnotation != "" {
+		accessLogEnabled, err := strconv.ParseBool(accessLogEnabledAnnotation)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing service annotation: %s=%s",
+				ServiceAnnotationLoadBalancerAccessLogEnabled,
+				accessLogEnabledAnnotation,
+			)
+		}
+		loadBalancerAttributes.AccessLog.Enabled = &accessLogEnabled
+	}
+
+	// Determine if access log s3 bucket name has been specified
+	accessLogS3BucketNameAnnotation := annotations[ServiceAnnotationLoadBalancerAccessLogS3BucketName]
+	if accessLogS3BucketNameAnnotation != "" {
+		loadBalancerAttributes.AccessLog.S3BucketName = &accessLogS3BucketNameAnnotation
+	}
+
+	// Determine if access log s3 bucket prefix has been specified
+	accessLogS3BucketPrefixAnnotation := annotations[ServiceAnnotationLoadBalancerAccessLogS3BucketPrefix]
+	if accessLogS3BucketPrefixAnnotation != "" {
+		loadBalancerAttributes.AccessLog.S3BucketPrefix = &accessLogS3BucketPrefixAnnotation
+	}
+
+	// Determine if connection draining enabled/disabled has been specified
+	connectionDrainingEnabledAnnotation := annotations[ServiceAnnotationLoadBalancerConnectionDrainingEnabled]
+	if connectionDrainingEnabledAnnotation != "" {
+		connectionDrainingEnabled, err := strconv.ParseBool(connectionDrainingEnabledAnnotation)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing service annotation: %s=%s",
+				ServiceAnnotationLoadBalancerConnectionDrainingEnabled,
+				connectionDrainingEnabledAnnotation,
+			)
+		}
+		loadBalancerAttributes.ConnectionDraining.Enabled = &connectionDrainingEnabled
+	}
+
+	// Determine if connection draining timeout has been specified
+	connectionDrainingTimeoutAnnotation := annotations[ServiceAnnotationLoadBalancerConnectionDrainingTimeout]
+	if connectionDrainingTimeoutAnnotation != "" {
+		connectionDrainingTimeout, err := strconv.ParseInt(connectionDrainingTimeoutAnnotation, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing service annotation: %s=%s",
+				ServiceAnnotationLoadBalancerConnectionDrainingTimeout,
+				connectionDrainingTimeoutAnnotation,
+			)
+		}
+		loadBalancerAttributes.ConnectionDraining.Timeout = &connectionDrainingTimeout
+	}
+
+	// Determine if connection idle timeout has been specified
+	connectionIdleTimeoutAnnotation := annotations[ServiceAnnotationLoadBalancerConnectionIdleTimeout]
+	if connectionIdleTimeoutAnnotation != "" {
+		connectionIdleTimeout, err := strconv.ParseInt(connectionIdleTimeoutAnnotation, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing service annotation: %s=%s",
+				ServiceAnnotationLoadBalancerConnectionIdleTimeout,
+				connectionIdleTimeoutAnnotation,
+			)
+		}
+		loadBalancerAttributes.ConnectionSettings.IdleTimeout = &connectionIdleTimeout
+	}
+
+	// Determine if cross zone load balancing enabled/disabled has been specified
+	crossZoneLoadBalancingEnabledAnnotation := annotations[ServiceAnnotationLoadBalancerCrossZoneLoadBalancingEnabled]
+	if crossZoneLoadBalancingEnabledAnnotation != "" {
+		crossZoneLoadBalancingEnabled, err := strconv.ParseBool(crossZoneLoadBalancingEnabledAnnotation)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing service annotation: %s=%s",
+				ServiceAnnotationLoadBalancerCrossZoneLoadBalancingEnabled,
+				crossZoneLoadBalancingEnabledAnnotation,
+			)
+		}
+		loadBalancerAttributes.CrossZoneLoadBalancing.Enabled = &crossZoneLoadBalancingEnabled
+	}
+
+	// Find the subnets that the ELB will live in
+	subnetIDs, err := c.findELBSubnets(internalELB)
+	if err != nil {
+		klog.Errorf("Error listing subnets in VPC: %q", err)
+		return nil, err
+	}
+
+	// Bail out early if there are no subnets
+	if len(subnetIDs) == 0 {
+		return nil, fmt.Errorf("could not find any suitable subnets for creating the ELB")
+	}
+
+	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, apiService)
+	serviceName := types.NamespacedName{Namespace: apiService.Namespace, Name: apiService.Name}
+	securityGroupIDs, err := c.buildELBSecurityGroupList(serviceName, loadBalancerName, annotations)
+	if err != nil {
+		return nil, err
+	}
+	if len(securityGroupIDs) == 0 {
+		return nil, fmt.Errorf("[BUG] ELB can't have empty list of Security Groups to be assigned, this is a Kubernetes bug, please report")
+	}
+
+	{
+		ec2SourceRanges := []*ec2.IpRange{}
+		for _, sourceRange := range sourceRanges.StringSlice() {
+			ec2SourceRanges = append(ec2SourceRanges, &ec2.IpRange{CidrIp: aws.String(sourceRange)})
+		}
+
+		permissions := NewIPPermissionSet()
+		for _, port := range apiService.Spec.Ports {
+			portInt64 := int64(port.Port)
+			protocol := strings.ToLower(string(port.Protocol))
+
+			permission := &ec2.IpPermission{}
+			permission.FromPort = &portInt64
+			permission.ToPort = &portInt64
+			permission.IpRanges = ec2SourceRanges
+			permission.IpProtocol = &protocol
+
+			permissions.Insert(permission)
+		}
+
+		// Allow ICMP fragmentation packets, important for MTU discovery
+		{
+			permission := &ec2.IpPermission{
+				IpProtocol: aws.String("icmp"),
+				FromPort:   aws.Int64(3),
+				ToPort:     aws.Int64(4),
+				IpRanges:   ec2SourceRanges,
+			}
+
+			permissions.Insert(permission)
+		}
+		_, err = c.setSecurityGroupIngress(securityGroupIDs[0], permissions)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Build the load balancer itself
+	loadBalancer, err := c.ensureLoadBalancer(
+		serviceName,
+		loadBalancerName,
+		listeners,
+		subnetIDs,
+		securityGroupIDs,
+		internalELB,
+		proxyProtocol,
+		loadBalancerAttributes,
+		annotations,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if sslPolicyName, ok := annotations[ServiceAnnotationLoadBalancerSSLNegotiationPolicy]; ok {
+		err := c.ensureSSLNegotiationPolicy(loadBalancer, sslPolicyName)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, port := range c.getLoadBalancerTLSPorts(loadBalancer) {
+			err := c.setSSLNegotiationPolicy(loadBalancerName, sslPolicyName, port)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if path, healthCheckNodePort := service.GetServiceHealthCheckPathPort(apiService); path != "" {
+		klog.V(4).Infof("service %v (%v) needs health checks on :%d%s)", apiService.Name, loadBalancerName, healthCheckNodePort, path)
+		err = c.ensureLoadBalancerHealthCheck(loadBalancer, "HTTP", healthCheckNodePort, path, annotations)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to ensure health check for localized service %v on node port %v: %q", loadBalancerName, healthCheckNodePort, err)
+		}
+	} else {
+		klog.V(4).Infof("service %v does not need custom health checks", apiService.Name)
+		// We only configure a TCP health-check on the first port
+		var tcpHealthCheckPort int32
+		for _, listener := range listeners {
+			if listener.InstancePort == nil {
+				continue
+			}
+			tcpHealthCheckPort = int32(*listener.InstancePort)
+			break
+		}
+		// there must be no path on TCP health check
+		err = c.ensureLoadBalancerHealthCheck(loadBalancer, "TCP", tcpHealthCheckPort, "", annotations)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = c.updateInstanceSecurityGroupsForLoadBalancer(loadBalancer, instances)
+	if err != nil {
+		klog.Warningf("Error opening ingress rules for the load balancer to the instances: %q", err)
+		return nil, err
+	}
+
+	err = c.ensureLoadBalancerInstances(aws.StringValue(loadBalancer.LoadBalancerName), loadBalancer.Instances, instances)
+	if err != nil {
+		klog.Warningf("Error registering instances with the load balancer: %q", err)
+		return nil, err
+	}
+
+	klog.V(1).Infof("Loadbalancer %s (%v) has DNS name %s", loadBalancerName, serviceName, aws.StringValue(loadBalancer.DNSName))
+
+	// TODO: Wait for creation?
+
+	status := toStatus(loadBalancer)
+	return status, nil
+}
+
+// GetLoadBalancer is an implementation of LoadBalancer.GetLoadBalancer
+func (c *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
+	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
+
+	if isNLB(service.Annotations) {
+		lb, err := c.describeLoadBalancerv2(loadBalancerName)
+		if err != nil {
+			return nil, false, err
+		}
+		if lb == nil {
+			return nil, false, nil
+		}
+		return v2toStatus(lb), true, nil
+	}
+
+	lb, err := c.describeLoadBalancer(loadBalancerName)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if lb == nil {
+		return nil, false, nil
+	}
+
+	status := toStatus(lb)
+	return status, true, nil
+}
+
+// GetLoadBalancerName is an implementation of LoadBalancer.GetLoadBalancerName
+func (c *Cloud) GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
+	// TODO: replace DefaultLoadBalancerName to generate more meaningful loadbalancer names.
+	return cloudprovider.DefaultLoadBalancerName(service)
+}
+
+func toStatus(lb *elb.LoadBalancerDescription) *v1.LoadBalancerStatus {
+	status := &v1.LoadBalancerStatus{}
+
+	if aws.StringValue(lb.DNSName) != "" {
+		var ingress v1.LoadBalancerIngress
+		ingress.Hostname = aws.StringValue(lb.DNSName)
+		status.Ingress = []v1.LoadBalancerIngress{ingress}
+	}
+
+	return status
+}
+
+func v2toStatus(lb *elbv2.LoadBalancer) *v1.LoadBalancerStatus {
+	status := &v1.LoadBalancerStatus{}
+	if lb == nil {
+		klog.Error("[BUG] v2toStatus got nil input, this is a Kubernetes bug, please report")
+		return status
+	}
+
+	// We check for Active or Provisioning, the only successful statuses
+	if aws.StringValue(lb.DNSName) != "" && (aws.StringValue(lb.State.Code) == elbv2.LoadBalancerStateEnumActive ||
+		aws.StringValue(lb.State.Code) == elbv2.LoadBalancerStateEnumProvisioning) {
+		var ingress v1.LoadBalancerIngress
+		ingress.Hostname = aws.StringValue(lb.DNSName)
+		status.Ingress = []v1.LoadBalancerIngress{ingress}
+	}
+
+	return status
+}
+
+// Returns the first security group for an instance, or nil
+// We only create instances with one security group, so we don't expect multiple security groups.
+// However, if there are multiple security groups, we will choose the one tagged with our cluster filter.
+// Otherwise we will return an error.
+func findSecurityGroupForInstance(instance *ec2.Instance, taggedSecurityGroups map[string]*ec2.SecurityGroup) (*ec2.GroupIdentifier, error) {
+	instanceID := aws.StringValue(instance.InstanceId)
+
+	var tagged []*ec2.GroupIdentifier
+	var untagged []*ec2.GroupIdentifier
+	for _, group := range instance.SecurityGroups {
+		groupID := aws.StringValue(group.GroupId)
+		if groupID == "" {
+			klog.Warningf("Ignoring security group without id for instance %q: %v", instanceID, group)
+			continue
+		}
+		_, isTagged := taggedSecurityGroups[groupID]
+		if isTagged {
+			tagged = append(tagged, group)
+		} else {
+			untagged = append(untagged, group)
+		}
+	}
+
+	if len(tagged) > 0 {
+		// We create instances with one SG
+		// If users create multiple SGs, they must tag one of them as being k8s owned
+		if len(tagged) != 1 {
+			taggedGroups := ""
+			for _, v := range tagged {
+				taggedGroups += fmt.Sprintf("%s(%s) ", *v.GroupId, *v.GroupName)
+			}
+			return nil, fmt.Errorf("Multiple tagged security groups found for instance %s; ensure only the k8s security group is tagged; the tagged groups were %v", instanceID, taggedGroups)
+		}
+		return tagged[0], nil
+	}
+
+	if len(untagged) > 0 {
+		// For back-compat, we will allow a single untagged SG
+		if len(untagged) != 1 {
+			return nil, fmt.Errorf("Multiple untagged security groups found for instance %s; ensure the k8s security group is tagged", instanceID)
+		}
+		return untagged[0], nil
+	}
+
+	klog.Warningf("No security group found for instance %q", instanceID)
+	return nil, nil
+}
+
+// Return all the security groups that are tagged as being part of our cluster
+func (c *Cloud) getTaggedSecurityGroups() (map[string]*ec2.SecurityGroup, error) {
+	request := &ec2.DescribeSecurityGroupsInput{}
+	request.Filters = c.tagging.addFilters(nil)
+	groups, err := c.ec2.DescribeSecurityGroups(request)
+	if err != nil {
+		return nil, fmt.Errorf("error querying security groups: %q", err)
+	}
+
+	m := make(map[string]*ec2.SecurityGroup)
+	for _, group := range groups {
+		if !c.tagging.hasClusterTag(group.Tags) {
+			continue
+		}
+
+		id := aws.StringValue(group.GroupId)
+		if id == "" {
+			klog.Warningf("Ignoring group without id: %v", group)
+			continue
+		}
+		m[id] = group
+	}
+	return m, nil
+}
+
+// Open security group ingress rules on the instances so that the load balancer can talk to them
+// Will also remove any security groups ingress rules for the load balancer that are _not_ needed for allInstances
+func (c *Cloud) updateInstanceSecurityGroupsForLoadBalancer(lb *elb.LoadBalancerDescription, instances map[awsInstanceID]*ec2.Instance) error {
+	if c.cfg.Global.DisableSecurityGroupIngress {
+		return nil
+	}
+
+	// Determine the load balancer security group id
+	loadBalancerSecurityGroupID := ""
+	for _, securityGroup := range lb.SecurityGroups {
+		if aws.StringValue(securityGroup) == "" {
+			continue
+		}
+		if loadBalancerSecurityGroupID != "" {
+			// We create LBs with one SG
+			klog.Warningf("Multiple security groups for load balancer: %q", aws.StringValue(lb.LoadBalancerName))
+		}
+		loadBalancerSecurityGroupID = *securityGroup
+	}
+	if loadBalancerSecurityGroupID == "" {
+		return fmt.Errorf("Could not determine security group for load balancer: %s", aws.StringValue(lb.LoadBalancerName))
+	}
+
+	// Get the actual list of groups that allow ingress from the load-balancer
+	var actualGroups []*ec2.SecurityGroup
+	{
+		describeRequest := &ec2.DescribeSecurityGroupsInput{}
+		filters := []*ec2.Filter{
+			newEc2Filter("ip-permission.group-id", loadBalancerSecurityGroupID),
+		}
+		describeRequest.Filters = c.tagging.addFilters(filters)
+		response, err := c.ec2.DescribeSecurityGroups(describeRequest)
+		if err != nil {
+			return fmt.Errorf("error querying security groups for ELB: %q", err)
+		}
+		for _, sg := range response {
+			if !c.tagging.hasClusterTag(sg.Tags) {
+				continue
+			}
+			actualGroups = append(actualGroups, sg)
+		}
+	}
+
+	taggedSecurityGroups, err := c.getTaggedSecurityGroups()
+	if err != nil {
+		return fmt.Errorf("error querying for tagged security groups: %q", err)
+	}
+
+	// Open the firewall from the load balancer to the instance
+	// We don't actually have a trivial way to know in advance which security group the instance is in
+	// (it is probably the node security group, but we don't easily have that).
+	// However, we _do_ have the list of security groups on the instance records.
+
+	// Map containing the changes we want to make; true to add, false to remove
+	instanceSecurityGroupIds := map[string]bool{}
+
+	// Scan instances for groups we want open
+	for _, instance := range instances {
+		securityGroup, err := findSecurityGroupForInstance(instance, taggedSecurityGroups)
+		if err != nil {
+			return err
+		}
+
+		if securityGroup == nil {
+			klog.Warning("Ignoring instance without security group: ", aws.StringValue(instance.InstanceId))
+			continue
+		}
+		id := aws.StringValue(securityGroup.GroupId)
+		if id == "" {
+			klog.Warningf("found security group without id: %v", securityGroup)
+			continue
+		}
+
+		instanceSecurityGroupIds[id] = true
+	}
+
+	// Compare to actual groups
+	for _, actualGroup := range actualGroups {
+		actualGroupID := aws.StringValue(actualGroup.GroupId)
+		if actualGroupID == "" {
+			klog.Warning("Ignoring group without ID: ", actualGroup)
+			continue
+		}
+
+		adding, found := instanceSecurityGroupIds[actualGroupID]
+		if found && adding {
+			// We don't need to make a change; the permission is already in place
+			delete(instanceSecurityGroupIds, actualGroupID)
+		} else {
+			// This group is not needed by allInstances; delete it
+			instanceSecurityGroupIds[actualGroupID] = false
+		}
+	}
+
+	for instanceSecurityGroupID, add := range instanceSecurityGroupIds {
+		if add {
+			klog.V(2).Infof("Adding rule for traffic from the load balancer (%s) to instances (%s)", loadBalancerSecurityGroupID, instanceSecurityGroupID)
+		} else {
+			klog.V(2).Infof("Removing rule for traffic from the load balancer (%s) to instance (%s)", loadBalancerSecurityGroupID, instanceSecurityGroupID)
+		}
+		sourceGroupID := &ec2.UserIdGroupPair{}
+		sourceGroupID.GroupId = &loadBalancerSecurityGroupID
+
+		allProtocols := "-1"
+
+		permission := &ec2.IpPermission{}
+		permission.IpProtocol = &allProtocols
+		permission.UserIdGroupPairs = []*ec2.UserIdGroupPair{sourceGroupID}
+
+		permissions := []*ec2.IpPermission{permission}
+
+		if add {
+			changed, err := c.addSecurityGroupIngress(instanceSecurityGroupID, permissions)
+			if err != nil {
+				return err
+			}
+			if !changed {
+				klog.Warning("Allowing ingress was not needed; concurrent change? groupId=", instanceSecurityGroupID)
+			}
+		} else {
+			changed, err := c.removeSecurityGroupIngress(instanceSecurityGroupID, permissions)
+			if err != nil {
+				return err
+			}
+			if !changed {
+				klog.Warning("Revoking ingress was not needed; concurrent change? groupId=", instanceSecurityGroupID)
+			}
+		}
+	}
+
+	return nil
+}
+
+// EnsureLoadBalancerDeleted implements LoadBalancer.EnsureLoadBalancerDeleted.
+func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
+	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
+
+	if isNLB(service.Annotations) {
+		lb, err := c.describeLoadBalancerv2(loadBalancerName)
+		if err != nil {
+			return err
+		}
+		if lb == nil {
+			klog.Info("Load balancer already deleted: ", loadBalancerName)
+			return nil
+		}
+
+		// Delete the LoadBalancer and target groups
+		//
+		// Deleting a target group while associated with a load balancer will
+		// fail. We delete the loadbalancer first. This does leave the
+		// possibility of zombie target groups if DeleteLoadBalancer() fails
+		//
+		// * Get target groups for NLB
+		// * Delete Load Balancer
+		// * Delete target groups
+		// * Clean up SecurityGroupRules
+		{
+
+			targetGroups, err := c.elbv2.DescribeTargetGroups(
+				&elbv2.DescribeTargetGroupsInput{LoadBalancerArn: lb.LoadBalancerArn},
+			)
+			if err != nil {
+				return fmt.Errorf("Error listing target groups before deleting load balancer: %q", err)
+			}
+
+			_, err = c.elbv2.DeleteLoadBalancer(
+				&elbv2.DeleteLoadBalancerInput{LoadBalancerArn: lb.LoadBalancerArn},
+			)
+			if err != nil {
+				return fmt.Errorf("Error deleting load balancer %q: %v", loadBalancerName, err)
+			}
+
+			for _, group := range targetGroups.TargetGroups {
+				_, err := c.elbv2.DeleteTargetGroup(
+					&elbv2.DeleteTargetGroupInput{TargetGroupArn: group.TargetGroupArn},
+				)
+				if err != nil {
+					return fmt.Errorf("Error deleting target groups after deleting load balancer: %q", err)
+				}
+			}
+		}
+
+		{
+			var matchingGroups []*ec2.SecurityGroup
+			{
+				// Server side filter
+				describeRequest := &ec2.DescribeSecurityGroupsInput{}
+				filters := []*ec2.Filter{
+					newEc2Filter("ip-permission.protocol", "tcp"),
+				}
+				describeRequest.Filters = c.tagging.addFilters(filters)
+				response, err := c.ec2.DescribeSecurityGroups(describeRequest)
+				if err != nil {
+					return fmt.Errorf("Error querying security groups for NLB: %q", err)
+				}
+				for _, sg := range response {
+					if !c.tagging.hasClusterTag(sg.Tags) {
+						continue
+					}
+					matchingGroups = append(matchingGroups, sg)
+				}
+
+				// client-side filter out groups that don't have IP Rules we've
+				// annotated for this service
+				matchingGroups = filterForIPRangeDescription(matchingGroups, loadBalancerName)
+			}
+
+			{
+				clientRule := fmt.Sprintf("%s=%s", NLBClientRuleDescription, loadBalancerName)
+				mtuRule := fmt.Sprintf("%s=%s", NLBMtuDiscoveryRuleDescription, loadBalancerName)
+				healthRule := fmt.Sprintf("%s=%s", NLBHealthCheckRuleDescription, loadBalancerName)
+
+				for i := range matchingGroups {
+					removes := []*ec2.IpPermission{}
+					for j := range matchingGroups[i].IpPermissions {
+
+						v4rangesToRemove := []*ec2.IpRange{}
+						v6rangesToRemove := []*ec2.Ipv6Range{}
+
+						// Find IpPermission that contains k8s description
+						// If we removed the whole IpPermission, it could contain other non-k8s specified ranges
+						for k := range matchingGroups[i].IpPermissions[j].IpRanges {
+							description := aws.StringValue(matchingGroups[i].IpPermissions[j].IpRanges[k].Description)
+							if description == clientRule || description == mtuRule || description == healthRule {
+								v4rangesToRemove = append(v4rangesToRemove, matchingGroups[i].IpPermissions[j].IpRanges[k])
+							}
+						}
+
+						// Find IpPermission that contains k8s description
+						// If we removed the whole IpPermission, it could contain other non-k8s specified rangesk
+						for k := range matchingGroups[i].IpPermissions[j].Ipv6Ranges {
+							description := aws.StringValue(matchingGroups[i].IpPermissions[j].Ipv6Ranges[k].Description)
+							if description == clientRule || description == mtuRule || description == healthRule {
+								v6rangesToRemove = append(v6rangesToRemove, matchingGroups[i].IpPermissions[j].Ipv6Ranges[k])
+							}
+						}
+
+						// ipv4 and ipv6 removals cannot be included in the same permission
+						if len(v4rangesToRemove) > 0 {
+							// create a new *IpPermission to not accidentally remove UserIdGroupPairs
+							removedPermission := &ec2.IpPermission{
+								FromPort:   matchingGroups[i].IpPermissions[j].FromPort,
+								IpProtocol: matchingGroups[i].IpPermissions[j].IpProtocol,
+								IpRanges:   v4rangesToRemove,
+								ToPort:     matchingGroups[i].IpPermissions[j].ToPort,
+							}
+							removes = append(removes, removedPermission)
+						}
+						if len(v6rangesToRemove) > 0 {
+							// create a new *IpPermission to not accidentally remove UserIdGroupPairs
+							removedPermission := &ec2.IpPermission{
+								FromPort:   matchingGroups[i].IpPermissions[j].FromPort,
+								IpProtocol: matchingGroups[i].IpPermissions[j].IpProtocol,
+								Ipv6Ranges: v6rangesToRemove,
+								ToPort:     matchingGroups[i].IpPermissions[j].ToPort,
+							}
+							removes = append(removes, removedPermission)
+						}
+
+					}
+					if len(removes) > 0 {
+						changed, err := c.removeSecurityGroupIngress(aws.StringValue(matchingGroups[i].GroupId), removes)
+						if err != nil {
+							return err
+						}
+						if !changed {
+							klog.Warning("Revoking ingress was not needed; concurrent change? groupId=", *matchingGroups[i].GroupId)
+						}
+					}
+
+				}
+
+			}
+
+		}
+		return nil
+	}
+
+	lb, err := c.describeLoadBalancer(loadBalancerName)
+	if err != nil {
+		return err
+	}
+
+	if lb == nil {
+		klog.Info("Load balancer already deleted: ", loadBalancerName)
+		return nil
+	}
+
+	{
+		// De-authorize the load balancer security group from the instances security group
+		err = c.updateInstanceSecurityGroupsForLoadBalancer(lb, nil)
+		if err != nil {
+			klog.Errorf("Error deregistering load balancer from instance security groups: %q", err)
+			return err
+		}
+	}
+
+	{
+		// Delete the load balancer itself
+		request := &elb.DeleteLoadBalancerInput{}
+		request.LoadBalancerName = lb.LoadBalancerName
+
+		_, err = c.elb.DeleteLoadBalancer(request)
+		if err != nil {
+			// TODO: Check if error was because load balancer was concurrently deleted
+			klog.Errorf("Error deleting load balancer: %q", err)
+			return err
+		}
+	}
+
+	{
+		// Delete the security group(s) for the load balancer
+		// Note that this is annoying: the load balancer disappears from the API immediately, but it is still
+		// deleting in the background.  We get a DependencyViolation until the load balancer has deleted itself
+
+		// Collect the security groups to delete
+		securityGroupIDs := map[string]struct{}{}
+		for _, securityGroupID := range lb.SecurityGroups {
+			if *securityGroupID == c.cfg.Global.ElbSecurityGroup {
+				//We don't want to delete a security group that was defined in the Cloud Configurationn.
+				continue
+			}
+			if aws.StringValue(securityGroupID) == "" {
+				klog.Warning("Ignoring empty security group in ", service.Name)
+				continue
+			}
+			securityGroupIDs[*securityGroupID] = struct{}{}
+		}
+
+		// Loop through and try to delete them
+		timeoutAt := time.Now().Add(time.Second * 600)
+		for {
+			for securityGroupID := range securityGroupIDs {
+				request := &ec2.DeleteSecurityGroupInput{}
+				request.GroupId = &securityGroupID
+				_, err := c.ec2.DeleteSecurityGroup(request)
+				if err == nil {
+					delete(securityGroupIDs, securityGroupID)
+				} else {
+					ignore := false
+					if awsError, ok := err.(awserr.Error); ok {
+						if awsError.Code() == "DependencyViolation" {
+							klog.V(2).Infof("Ignoring DependencyViolation while deleting load-balancer security group (%s), assuming because LB is in process of deleting", securityGroupID)
+							ignore = true
+						}
+					}
+					if !ignore {
+						return fmt.Errorf("error while deleting load balancer security group (%s): %q", securityGroupID, err)
+					}
+				}
+			}
+
+			if len(securityGroupIDs) == 0 {
+				klog.V(2).Info("Deleted all security groups for load balancer: ", service.Name)
+				break
+			}
+
+			if time.Now().After(timeoutAt) {
+				ids := []string{}
+				for id := range securityGroupIDs {
+					ids = append(ids, id)
+				}
+
+				return fmt.Errorf("timed out deleting ELB: %s. Could not delete security groups %v", service.Name, strings.Join(ids, ","))
+			}
+
+			klog.V(2).Info("Waiting for load-balancer to delete so we can delete security groups: ", service.Name)
+
+			time.Sleep(10 * time.Second)
+		}
+	}
+
+	return nil
+}
+
+// UpdateLoadBalancer implements LoadBalancer.UpdateLoadBalancer
+func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
+	instances, err := c.findInstancesForELB(nodes)
+	if err != nil {
+		return err
+	}
+
+	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
+	if isNLB(service.Annotations) {
+		lb, err := c.describeLoadBalancerv2(loadBalancerName)
+		if err != nil {
+			return err
+		}
+		if lb == nil {
+			return fmt.Errorf("Load balancer not found")
+		}
+		_, err = c.EnsureLoadBalancer(ctx, clusterName, service, nodes)
+		return err
+	}
+	lb, err := c.describeLoadBalancer(loadBalancerName)
+	if err != nil {
+		return err
+	}
+
+	if lb == nil {
+		return fmt.Errorf("Load balancer not found")
+	}
+
+	if sslPolicyName, ok := service.Annotations[ServiceAnnotationLoadBalancerSSLNegotiationPolicy]; ok {
+		err := c.ensureSSLNegotiationPolicy(lb, sslPolicyName)
+		if err != nil {
+			return err
+		}
+		for _, port := range c.getLoadBalancerTLSPorts(lb) {
+			err := c.setSSLNegotiationPolicy(loadBalancerName, sslPolicyName, port)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	err = c.ensureLoadBalancerInstances(aws.StringValue(lb.LoadBalancerName), lb.Instances, instances)
+	if err != nil {
+		return nil
+	}
+
+	err = c.updateInstanceSecurityGroupsForLoadBalancer(lb, instances)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Returns the instance with the specified ID
+func (c *Cloud) getInstanceByID(instanceID string) (*ec2.Instance, error) {
+	instances, err := c.getInstancesByIDs([]*string{&instanceID})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(instances) == 0 {
+		return nil, cloudprovider.InstanceNotFound
+	}
+	if len(instances) > 1 {
+		return nil, fmt.Errorf("multiple instances found for instance: %s", instanceID)
+	}
+
+	return instances[instanceID], nil
+}
+
+func (c *Cloud) getInstancesByIDs(instanceIDs []*string) (map[string]*ec2.Instance, error) {
+	instancesByID := make(map[string]*ec2.Instance)
+	if len(instanceIDs) == 0 {
+		return instancesByID, nil
+	}
+
+	request := &ec2.DescribeInstancesInput{
+		InstanceIds: instanceIDs,
+	}
+
+	instances, err := c.ec2.DescribeInstances(request)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, instance := range instances {
+		instanceID := aws.StringValue(instance.InstanceId)
+		if instanceID == "" {
+			continue
+		}
+
+		instancesByID[instanceID] = instance
+	}
+
+	return instancesByID, nil
+}
+
+func (c *Cloud) getInstancesByNodeNames(nodeNames []string, states ...string) ([]*ec2.Instance, error) {
+	names := aws.StringSlice(nodeNames)
+	ec2Instances := []*ec2.Instance{}
+
+	for i := 0; i < len(names); i += filterNodeLimit {
+		end := i + filterNodeLimit
+		if end > len(names) {
+			end = len(names)
+		}
+
+		nameSlice := names[i:end]
+
+		nodeNameFilter := &ec2.Filter{
+			Name:   aws.String("private-dns-name"),
+			Values: nameSlice,
+		}
+
+		filters := []*ec2.Filter{nodeNameFilter}
+		if len(states) > 0 {
+			filters = append(filters, newEc2Filter("instance-state-name", states...))
+		}
+
+		instances, err := c.describeInstances(filters)
+		if err != nil {
+			klog.V(2).Infof("Failed to describe instances %v", nodeNames)
+			return nil, err
+		}
+		ec2Instances = append(ec2Instances, instances...)
+	}
+
+	if len(ec2Instances) == 0 {
+		klog.V(3).Infof("Failed to find any instances %v", nodeNames)
+		return nil, nil
+	}
+	return ec2Instances, nil
+}
+
+// TODO: Move to instanceCache
+func (c *Cloud) describeInstances(filters []*ec2.Filter) ([]*ec2.Instance, error) {
+	filters = c.tagging.addFilters(filters)
+	request := &ec2.DescribeInstancesInput{
+		Filters: filters,
+	}
+
+	response, err := c.ec2.DescribeInstances(request)
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []*ec2.Instance
+	for _, instance := range response {
+		if c.tagging.hasClusterTag(instance.Tags) {
+			matches = append(matches, instance)
+		}
+	}
+	return matches, nil
+}
+
+// mapNodeNameToPrivateDNSName maps a k8s NodeName to an AWS Instance PrivateDNSName
+// This is a simple string cast
+func mapNodeNameToPrivateDNSName(nodeName types.NodeName) string {
+	return string(nodeName)
+}
+
+// mapInstanceToNodeName maps a EC2 instance to a k8s NodeName, by extracting the PrivateDNSName
+func mapInstanceToNodeName(i *ec2.Instance) types.NodeName {
+	return types.NodeName(aws.StringValue(i.PrivateDnsName))
+}
+
+var aliveFilter = []string{
+	ec2.InstanceStateNamePending,
+	ec2.InstanceStateNameRunning,
+	ec2.InstanceStateNameShuttingDown,
+	ec2.InstanceStateNameStopping,
+	ec2.InstanceStateNameStopped,
+}
+
+// Returns the instance with the specified node name
+// Returns nil if it does not exist
+func (c *Cloud) findInstanceByNodeName(nodeName types.NodeName) (*ec2.Instance, error) {
+	privateDNSName := mapNodeNameToPrivateDNSName(nodeName)
+	filters := []*ec2.Filter{
+		newEc2Filter("private-dns-name", privateDNSName),
+		// exclude instances in "terminated" state
+		newEc2Filter("instance-state-name", aliveFilter...),
+	}
+
+	instances, err := c.describeInstances(filters)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(instances) == 0 {
+		return nil, nil
+	}
+	if len(instances) > 1 {
+		return nil, fmt.Errorf("multiple instances found for name: %s", nodeName)
+	}
+	return instances[0], nil
+}
+
+// Returns the instance with the specified node name
+// Like findInstanceByNodeName, but returns error if node not found
+func (c *Cloud) getInstanceByNodeName(nodeName types.NodeName) (*ec2.Instance, error) {
+	instance, err := c.findInstanceByNodeName(nodeName)
+	if err == nil && instance == nil {
+		return nil, cloudprovider.InstanceNotFound
+	}
+	return instance, err
+}
+
+func (c *Cloud) getFullInstance(nodeName types.NodeName) (*awsInstance, *ec2.Instance, error) {
+	if nodeName == "" {
+		instance, err := c.getInstanceByID(c.selfAWSInstance.awsID)
+		return c.selfAWSInstance, instance, err
+	}
+	instance, err := c.getInstanceByNodeName(nodeName)
+	if err != nil {
+		return nil, nil, err
+	}
+	awsInstance := newAWSInstance(c.ec2, instance)
+	return awsInstance, instance, err
+}
+
+func setNodeDisk(
+	nodeDiskMap map[types.NodeName]map[KubernetesVolumeID]bool,
+	volumeID KubernetesVolumeID,
+	nodeName types.NodeName,
+	check bool) {
+
+	volumeMap := nodeDiskMap[nodeName]
+
+	if volumeMap == nil {
+		volumeMap = make(map[KubernetesVolumeID]bool)
+		nodeDiskMap[nodeName] = volumeMap
+	}
+	volumeMap[volumeID] = check
+}

--- a/pkg/cloudprovider/providers/aws/aws_fakes.go
+++ b/pkg/cloudprovider/providers/aws/aws_fakes.go
@@ -1,0 +1,670 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"k8s.io/klog"
+)
+
+// FakeAWSServices is an fake AWS session used for testing
+type FakeAWSServices struct {
+	region                      string
+	instances                   []*ec2.Instance
+	selfInstance                *ec2.Instance
+	networkInterfacesMacs       []string
+	networkInterfacesPrivateIPs [][]string
+	networkInterfacesVpcIDs     []string
+
+	ec2      FakeEC2
+	elb      ELB
+	elbv2    ELBV2
+	asg      *FakeASG
+	metadata *FakeMetadata
+	kms      *FakeKMS
+}
+
+// NewFakeAWSServices creates a new FakeAWSServices
+func NewFakeAWSServices(clusterID string) *FakeAWSServices {
+	s := &FakeAWSServices{}
+	s.region = "us-east-1"
+	s.ec2 = &FakeEC2Impl{aws: s}
+	s.elb = &FakeELB{aws: s}
+	s.elbv2 = &FakeELBV2{aws: s}
+	s.asg = &FakeASG{aws: s}
+	s.metadata = &FakeMetadata{aws: s}
+	s.kms = &FakeKMS{aws: s}
+
+	s.networkInterfacesMacs = []string{"aa:bb:cc:dd:ee:00", "aa:bb:cc:dd:ee:01"}
+	s.networkInterfacesVpcIDs = []string{"vpc-mac0", "vpc-mac1"}
+
+	selfInstance := &ec2.Instance{}
+	selfInstance.InstanceId = aws.String("i-self")
+	selfInstance.Placement = &ec2.Placement{
+		AvailabilityZone: aws.String("us-east-1a"),
+	}
+	selfInstance.PrivateDnsName = aws.String("ip-172-20-0-100.ec2.internal")
+	selfInstance.PrivateIpAddress = aws.String("192.168.0.1")
+	selfInstance.PublicIpAddress = aws.String("1.2.3.4")
+	s.selfInstance = selfInstance
+	s.instances = []*ec2.Instance{selfInstance}
+
+	var tag ec2.Tag
+	tag.Key = aws.String(TagNameKubernetesClusterLegacy)
+	tag.Value = aws.String(clusterID)
+	selfInstance.Tags = []*ec2.Tag{&tag}
+
+	return s
+}
+
+// WithAz sets the ec2 placement availability zone
+func (s *FakeAWSServices) WithAz(az string) *FakeAWSServices {
+	if s.selfInstance.Placement == nil {
+		s.selfInstance.Placement = &ec2.Placement{}
+	}
+	s.selfInstance.Placement.AvailabilityZone = aws.String(az)
+	return s
+}
+
+// Compute returns a fake EC2 client
+func (s *FakeAWSServices) Compute(region string) (EC2, error) {
+	return s.ec2, nil
+}
+
+// LoadBalancing returns a fake ELB client
+func (s *FakeAWSServices) LoadBalancing(region string) (ELB, error) {
+	return s.elb, nil
+}
+
+// LoadBalancingV2 returns a fake ELBV2 client
+func (s *FakeAWSServices) LoadBalancingV2(region string) (ELBV2, error) {
+	return s.elbv2, nil
+}
+
+// Autoscaling returns a fake ASG client
+func (s *FakeAWSServices) Autoscaling(region string) (ASG, error) {
+	return s.asg, nil
+}
+
+// Metadata returns a fake EC2Metadata client
+func (s *FakeAWSServices) Metadata() (EC2Metadata, error) {
+	return s.metadata, nil
+}
+
+// KeyManagement returns a fake KMS client
+func (s *FakeAWSServices) KeyManagement(region string) (KMS, error) {
+	return s.kms, nil
+}
+
+// FakeEC2 is a fake EC2 client used for testing
+type FakeEC2 interface {
+	EC2
+	CreateSubnet(*ec2.Subnet) (*ec2.CreateSubnetOutput, error)
+	RemoveSubnets()
+	CreateRouteTable(*ec2.RouteTable) (*ec2.CreateRouteTableOutput, error)
+	RemoveRouteTables()
+}
+
+// FakeEC2Impl is an implementation of the FakeEC2 interface used for testing
+type FakeEC2Impl struct {
+	aws                      *FakeAWSServices
+	Subnets                  []*ec2.Subnet
+	DescribeSubnetsInput     *ec2.DescribeSubnetsInput
+	RouteTables              []*ec2.RouteTable
+	DescribeRouteTablesInput *ec2.DescribeRouteTablesInput
+}
+
+// DescribeInstances returns fake instance descriptions
+func (ec2i *FakeEC2Impl) DescribeInstances(request *ec2.DescribeInstancesInput) ([]*ec2.Instance, error) {
+	matches := []*ec2.Instance{}
+	for _, instance := range ec2i.aws.instances {
+		if request.InstanceIds != nil {
+			if instance.InstanceId == nil {
+				klog.Warning("Instance with no instance id: ", instance)
+				continue
+			}
+
+			found := false
+			for _, instanceID := range request.InstanceIds {
+				if *instanceID == *instance.InstanceId {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		if request.Filters != nil {
+			allMatch := true
+			for _, filter := range request.Filters {
+				if !instanceMatchesFilter(instance, filter) {
+					allMatch = false
+					break
+				}
+			}
+			if !allMatch {
+				continue
+			}
+		}
+		matches = append(matches, instance)
+	}
+
+	return matches, nil
+}
+
+// AttachVolume is not implemented but is required for interface conformance
+func (ec2i *FakeEC2Impl) AttachVolume(request *ec2.AttachVolumeInput) (resp *ec2.VolumeAttachment, err error) {
+	panic("Not implemented")
+}
+
+// DetachVolume is not implemented but is required for interface conformance
+func (ec2i *FakeEC2Impl) DetachVolume(request *ec2.DetachVolumeInput) (resp *ec2.VolumeAttachment, err error) {
+	panic("Not implemented")
+}
+
+// DescribeVolumes is not implemented but is required for interface conformance
+func (ec2i *FakeEC2Impl) DescribeVolumes(request *ec2.DescribeVolumesInput) ([]*ec2.Volume, error) {
+	panic("Not implemented")
+}
+
+// CreateVolume is not implemented but is required for interface conformance
+func (ec2i *FakeEC2Impl) CreateVolume(request *ec2.CreateVolumeInput) (resp *ec2.Volume, err error) {
+	panic("Not implemented")
+}
+
+// DeleteVolume is not implemented but is required for interface conformance
+func (ec2i *FakeEC2Impl) DeleteVolume(request *ec2.DeleteVolumeInput) (resp *ec2.DeleteVolumeOutput, err error) {
+	panic("Not implemented")
+}
+
+// DescribeSecurityGroups is not implemented but is required for interface
+// conformance
+func (ec2i *FakeEC2Impl) DescribeSecurityGroups(request *ec2.DescribeSecurityGroupsInput) ([]*ec2.SecurityGroup, error) {
+	panic("Not implemented")
+}
+
+// CreateSecurityGroup is not implemented but is required for interface
+// conformance
+func (ec2i *FakeEC2Impl) CreateSecurityGroup(*ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
+	panic("Not implemented")
+}
+
+// DeleteSecurityGroup is not implemented but is required for interface
+// conformance
+func (ec2i *FakeEC2Impl) DeleteSecurityGroup(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+	panic("Not implemented")
+}
+
+// AuthorizeSecurityGroupIngress is not implemented but is required for
+// interface conformance
+func (ec2i *FakeEC2Impl) AuthorizeSecurityGroupIngress(*ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	panic("Not implemented")
+}
+
+// RevokeSecurityGroupIngress is not implemented but is required for interface
+// conformance
+func (ec2i *FakeEC2Impl) RevokeSecurityGroupIngress(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeVolumeModifications is not implemented but is required for interface
+// conformance
+func (ec2i *FakeEC2Impl) DescribeVolumeModifications(*ec2.DescribeVolumesModificationsInput) ([]*ec2.VolumeModification, error) {
+	panic("Not implemented")
+}
+
+// ModifyVolume is not implemented but is required for interface conformance
+func (ec2i *FakeEC2Impl) ModifyVolume(*ec2.ModifyVolumeInput) (*ec2.ModifyVolumeOutput, error) {
+	panic("Not implemented")
+}
+
+// CreateSubnet creates fake subnets
+func (ec2i *FakeEC2Impl) CreateSubnet(request *ec2.Subnet) (*ec2.CreateSubnetOutput, error) {
+	ec2i.Subnets = append(ec2i.Subnets, request)
+	response := &ec2.CreateSubnetOutput{
+		Subnet: request,
+	}
+	return response, nil
+}
+
+// DescribeSubnets returns fake subnet descriptions
+func (ec2i *FakeEC2Impl) DescribeSubnets(request *ec2.DescribeSubnetsInput) ([]*ec2.Subnet, error) {
+	ec2i.DescribeSubnetsInput = request
+	return ec2i.Subnets, nil
+}
+
+// RemoveSubnets clears subnets on client
+func (ec2i *FakeEC2Impl) RemoveSubnets() {
+	ec2i.Subnets = ec2i.Subnets[:0]
+}
+
+// CreateTags is not implemented but is required for interface conformance
+func (ec2i *FakeEC2Impl) CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeRouteTables returns fake route table descriptions
+func (ec2i *FakeEC2Impl) DescribeRouteTables(request *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error) {
+	ec2i.DescribeRouteTablesInput = request
+	return ec2i.RouteTables, nil
+}
+
+// CreateRouteTable creates fake route tables
+func (ec2i *FakeEC2Impl) CreateRouteTable(request *ec2.RouteTable) (*ec2.CreateRouteTableOutput, error) {
+	ec2i.RouteTables = append(ec2i.RouteTables, request)
+	response := &ec2.CreateRouteTableOutput{
+		RouteTable: request,
+	}
+	return response, nil
+}
+
+// RemoveRouteTables clears route tables on client
+func (ec2i *FakeEC2Impl) RemoveRouteTables() {
+	ec2i.RouteTables = ec2i.RouteTables[:0]
+}
+
+// CreateRoute is not implemented but is required for interface conformance
+func (ec2i *FakeEC2Impl) CreateRoute(request *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
+	panic("Not implemented")
+}
+
+// DeleteRoute is not implemented but is required for interface conformance
+func (ec2i *FakeEC2Impl) DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
+	panic("Not implemented")
+}
+
+// ModifyInstanceAttribute is not implemented but is required for interface
+// conformance
+func (ec2i *FakeEC2Impl) ModifyInstanceAttribute(request *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeVpcs returns fake VPC descriptions
+func (ec2i *FakeEC2Impl) DescribeVpcs(request *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	return &ec2.DescribeVpcsOutput{Vpcs: []*ec2.Vpc{{CidrBlock: aws.String("172.20.0.0/16")}}}, nil
+}
+
+// FakeMetadata is a fake EC2 metadata service client used for testing
+type FakeMetadata struct {
+	aws *FakeAWSServices
+}
+
+// GetMetadata returns fake EC2 metadata for testing
+func (m *FakeMetadata) GetMetadata(key string) (string, error) {
+	networkInterfacesPrefix := "network/interfaces/macs/"
+	i := m.aws.selfInstance
+	if key == "placement/availability-zone" {
+		az := ""
+		if i.Placement != nil {
+			az = aws.StringValue(i.Placement.AvailabilityZone)
+		}
+		return az, nil
+	} else if key == "instance-id" {
+		return aws.StringValue(i.InstanceId), nil
+	} else if key == "local-hostname" {
+		return aws.StringValue(i.PrivateDnsName), nil
+	} else if key == "public-hostname" {
+		return aws.StringValue(i.PublicDnsName), nil
+	} else if key == "local-ipv4" {
+		return aws.StringValue(i.PrivateIpAddress), nil
+	} else if key == "public-ipv4" {
+		return aws.StringValue(i.PublicIpAddress), nil
+	} else if strings.HasPrefix(key, networkInterfacesPrefix) {
+		if key == networkInterfacesPrefix {
+			return strings.Join(m.aws.networkInterfacesMacs, "/\n") + "/\n", nil
+		}
+
+		keySplit := strings.Split(key, "/")
+		macParam := keySplit[3]
+		if len(keySplit) == 5 && keySplit[4] == "vpc-id" {
+			for i, macElem := range m.aws.networkInterfacesMacs {
+				if macParam == macElem {
+					return m.aws.networkInterfacesVpcIDs[i], nil
+				}
+			}
+		}
+		if len(keySplit) == 5 && keySplit[4] == "local-ipv4s" {
+			for i, macElem := range m.aws.networkInterfacesMacs {
+				if macParam == macElem {
+					return strings.Join(m.aws.networkInterfacesPrivateIPs[i], "/\n"), nil
+				}
+			}
+		}
+
+		return "", nil
+	} else {
+		return "", nil
+	}
+}
+
+// FakeELB is a fake ELB client used for testing
+type FakeELB struct {
+	aws *FakeAWSServices
+}
+
+// CreateLoadBalancer is not implemented but is required for interface
+// conformance
+func (elb *FakeELB) CreateLoadBalancer(*elb.CreateLoadBalancerInput) (*elb.CreateLoadBalancerOutput, error) {
+	panic("Not implemented")
+}
+
+// DeleteLoadBalancer is not implemented but is required for interface
+// conformance
+func (elb *FakeELB) DeleteLoadBalancer(input *elb.DeleteLoadBalancerInput) (*elb.DeleteLoadBalancerOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeLoadBalancers is not implemented but is required for interface
+// conformance
+func (elb *FakeELB) DescribeLoadBalancers(input *elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error) {
+	panic("Not implemented")
+}
+
+// AddTags is not implemented but is required for interface conformance
+func (elb *FakeELB) AddTags(input *elb.AddTagsInput) (*elb.AddTagsOutput, error) {
+	panic("Not implemented")
+}
+
+// RegisterInstancesWithLoadBalancer is not implemented but is required for
+// interface conformance
+func (elb *FakeELB) RegisterInstancesWithLoadBalancer(*elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error) {
+	panic("Not implemented")
+}
+
+// DeregisterInstancesFromLoadBalancer is not implemented but is required for
+// interface conformance
+func (elb *FakeELB) DeregisterInstancesFromLoadBalancer(*elb.DeregisterInstancesFromLoadBalancerInput) (*elb.DeregisterInstancesFromLoadBalancerOutput, error) {
+	panic("Not implemented")
+}
+
+// DetachLoadBalancerFromSubnets is not implemented but is required for
+// interface conformance
+func (elb *FakeELB) DetachLoadBalancerFromSubnets(*elb.DetachLoadBalancerFromSubnetsInput) (*elb.DetachLoadBalancerFromSubnetsOutput, error) {
+	panic("Not implemented")
+}
+
+// AttachLoadBalancerToSubnets is not implemented but is required for interface
+// conformance
+func (elb *FakeELB) AttachLoadBalancerToSubnets(*elb.AttachLoadBalancerToSubnetsInput) (*elb.AttachLoadBalancerToSubnetsOutput, error) {
+	panic("Not implemented")
+}
+
+// CreateLoadBalancerListeners is not implemented but is required for interface
+// conformance
+func (elb *FakeELB) CreateLoadBalancerListeners(*elb.CreateLoadBalancerListenersInput) (*elb.CreateLoadBalancerListenersOutput, error) {
+	panic("Not implemented")
+}
+
+// DeleteLoadBalancerListeners is not implemented but is required for interface
+// conformance
+func (elb *FakeELB) DeleteLoadBalancerListeners(*elb.DeleteLoadBalancerListenersInput) (*elb.DeleteLoadBalancerListenersOutput, error) {
+	panic("Not implemented")
+}
+
+// ApplySecurityGroupsToLoadBalancer is not implemented but is required for
+// interface conformance
+func (elb *FakeELB) ApplySecurityGroupsToLoadBalancer(*elb.ApplySecurityGroupsToLoadBalancerInput) (*elb.ApplySecurityGroupsToLoadBalancerOutput, error) {
+	panic("Not implemented")
+}
+
+// ConfigureHealthCheck is not implemented but is required for interface
+// conformance
+func (elb *FakeELB) ConfigureHealthCheck(*elb.ConfigureHealthCheckInput) (*elb.ConfigureHealthCheckOutput, error) {
+	panic("Not implemented")
+}
+
+// CreateLoadBalancerPolicy is not implemented but is required for interface
+// conformance
+func (elb *FakeELB) CreateLoadBalancerPolicy(*elb.CreateLoadBalancerPolicyInput) (*elb.CreateLoadBalancerPolicyOutput, error) {
+	panic("Not implemented")
+}
+
+// SetLoadBalancerPoliciesForBackendServer is not implemented but is required
+// for interface conformance
+func (elb *FakeELB) SetLoadBalancerPoliciesForBackendServer(*elb.SetLoadBalancerPoliciesForBackendServerInput) (*elb.SetLoadBalancerPoliciesForBackendServerOutput, error) {
+	panic("Not implemented")
+}
+
+// SetLoadBalancerPoliciesOfListener is not implemented but is required for
+// interface conformance
+func (elb *FakeELB) SetLoadBalancerPoliciesOfListener(input *elb.SetLoadBalancerPoliciesOfListenerInput) (*elb.SetLoadBalancerPoliciesOfListenerOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeLoadBalancerPolicies is not implemented but is required for
+// interface conformance
+func (elb *FakeELB) DescribeLoadBalancerPolicies(input *elb.DescribeLoadBalancerPoliciesInput) (*elb.DescribeLoadBalancerPoliciesOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeLoadBalancerAttributes is not implemented but is required for
+// interface conformance
+func (elb *FakeELB) DescribeLoadBalancerAttributes(*elb.DescribeLoadBalancerAttributesInput) (*elb.DescribeLoadBalancerAttributesOutput, error) {
+	panic("Not implemented")
+}
+
+// ModifyLoadBalancerAttributes is not implemented but is required for
+// interface conformance
+func (elb *FakeELB) ModifyLoadBalancerAttributes(*elb.ModifyLoadBalancerAttributesInput) (*elb.ModifyLoadBalancerAttributesOutput, error) {
+	panic("Not implemented")
+}
+
+// expectDescribeLoadBalancers is not implemented but is required for interface
+// conformance
+func (elb *FakeELB) expectDescribeLoadBalancers(loadBalancerName string) {
+	panic("Not implemented")
+}
+
+// FakeELBV2 is a fake ELBV2 client used for testing
+type FakeELBV2 struct {
+	aws *FakeAWSServices
+}
+
+// AddTags is not implemented but is required for interface conformance
+func (elb *FakeELBV2) AddTags(input *elbv2.AddTagsInput) (*elbv2.AddTagsOutput, error) {
+	panic("Not implemented")
+}
+
+// CreateLoadBalancer is not implemented but is required for interface
+// conformance
+func (elb *FakeELBV2) CreateLoadBalancer(*elbv2.CreateLoadBalancerInput) (*elbv2.CreateLoadBalancerOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeLoadBalancers is not implemented but is required for interface
+// conformance
+func (elb *FakeELBV2) DescribeLoadBalancers(*elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error) {
+	panic("Not implemented")
+}
+
+// DeleteLoadBalancer is not implemented but is required for interface
+// conformance
+func (elb *FakeELBV2) DeleteLoadBalancer(*elbv2.DeleteLoadBalancerInput) (*elbv2.DeleteLoadBalancerOutput, error) {
+	panic("Not implemented")
+}
+
+// ModifyLoadBalancerAttributes is not implemented but is required for
+// interface conformance
+func (elb *FakeELBV2) ModifyLoadBalancerAttributes(*elbv2.ModifyLoadBalancerAttributesInput) (*elbv2.ModifyLoadBalancerAttributesOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeLoadBalancerAttributes is not implemented but is required for
+// interface conformance
+func (elb *FakeELBV2) DescribeLoadBalancerAttributes(*elbv2.DescribeLoadBalancerAttributesInput) (*elbv2.DescribeLoadBalancerAttributesOutput, error) {
+	panic("Not implemented")
+}
+
+// CreateTargetGroup is not implemented but is required for interface
+// conformance
+func (elb *FakeELBV2) CreateTargetGroup(*elbv2.CreateTargetGroupInput) (*elbv2.CreateTargetGroupOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeTargetGroups is not implemented but is required for interface
+// conformance
+func (elb *FakeELBV2) DescribeTargetGroups(*elbv2.DescribeTargetGroupsInput) (*elbv2.DescribeTargetGroupsOutput, error) {
+	panic("Not implemented")
+}
+
+// ModifyTargetGroup is not implemented but is required for interface
+// conformance
+func (elb *FakeELBV2) ModifyTargetGroup(*elbv2.ModifyTargetGroupInput) (*elbv2.ModifyTargetGroupOutput, error) {
+	panic("Not implemented")
+}
+
+// DeleteTargetGroup is not implemented but is required for interface
+// conformance
+func (elb *FakeELBV2) DeleteTargetGroup(*elbv2.DeleteTargetGroupInput) (*elbv2.DeleteTargetGroupOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeTargetHealth is not implemented but is required for interface
+// conformance
+func (elb *FakeELBV2) DescribeTargetHealth(input *elbv2.DescribeTargetHealthInput) (*elbv2.DescribeTargetHealthOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeTargetGroupAttributes is not implemented but is required for
+// interface conformance
+func (elb *FakeELBV2) DescribeTargetGroupAttributes(*elbv2.DescribeTargetGroupAttributesInput) (*elbv2.DescribeTargetGroupAttributesOutput, error) {
+	panic("Not implemented")
+}
+
+// ModifyTargetGroupAttributes is not implemented but is required for interface
+// conformance
+func (elb *FakeELBV2) ModifyTargetGroupAttributes(*elbv2.ModifyTargetGroupAttributesInput) (*elbv2.ModifyTargetGroupAttributesOutput, error) {
+	panic("Not implemented")
+}
+
+// RegisterTargets is not implemented but is required for interface conformance
+func (elb *FakeELBV2) RegisterTargets(*elbv2.RegisterTargetsInput) (*elbv2.RegisterTargetsOutput, error) {
+	panic("Not implemented")
+}
+
+// DeregisterTargets is not implemented but is required for interface
+// conformance
+func (elb *FakeELBV2) DeregisterTargets(*elbv2.DeregisterTargetsInput) (*elbv2.DeregisterTargetsOutput, error) {
+	panic("Not implemented")
+}
+
+// CreateListener is not implemented but is required for interface conformance
+func (elb *FakeELBV2) CreateListener(*elbv2.CreateListenerInput) (*elbv2.CreateListenerOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeListeners is not implemented but is required for interface
+// conformance
+func (elb *FakeELBV2) DescribeListeners(*elbv2.DescribeListenersInput) (*elbv2.DescribeListenersOutput, error) {
+	panic("Not implemented")
+}
+
+// DeleteListener is not implemented but is required for interface conformance
+func (elb *FakeELBV2) DeleteListener(*elbv2.DeleteListenerInput) (*elbv2.DeleteListenerOutput, error) {
+	panic("Not implemented")
+}
+
+// ModifyListener is not implemented but is required for interface conformance
+func (elb *FakeELBV2) ModifyListener(*elbv2.ModifyListenerInput) (*elbv2.ModifyListenerOutput, error) {
+	panic("Not implemented")
+}
+
+// WaitUntilLoadBalancersDeleted is not implemented but is required for
+// interface conformance
+func (elb *FakeELBV2) WaitUntilLoadBalancersDeleted(*elbv2.DescribeLoadBalancersInput) error {
+	panic("Not implemented")
+}
+
+// FakeASG is a fake Autoscaling client used for testing
+type FakeASG struct {
+	aws *FakeAWSServices
+}
+
+// UpdateAutoScalingGroup is not implemented but is required for interface
+// conformance
+func (a *FakeASG) UpdateAutoScalingGroup(*autoscaling.UpdateAutoScalingGroupInput) (*autoscaling.UpdateAutoScalingGroupOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeAutoScalingGroups is not implemented but is required for interface
+// conformance
+func (a *FakeASG) DescribeAutoScalingGroups(*autoscaling.DescribeAutoScalingGroupsInput) (*autoscaling.DescribeAutoScalingGroupsOutput, error) {
+	panic("Not implemented")
+}
+
+// FakeKMS is a fake KMS client used for testing
+type FakeKMS struct {
+	aws *FakeAWSServices
+}
+
+// DescribeKey is not implemented but is required for interface conformance
+func (kms *FakeKMS) DescribeKey(*kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error) {
+	panic("Not implemented")
+}
+
+func instanceMatchesFilter(instance *ec2.Instance, filter *ec2.Filter) bool {
+	name := *filter.Name
+	if name == "private-dns-name" {
+		if instance.PrivateDnsName == nil {
+			return false
+		}
+		return contains(filter.Values, *instance.PrivateDnsName)
+	}
+
+	if name == "instance-state-name" {
+		return contains(filter.Values, *instance.State.Name)
+	}
+
+	if name == "tag-key" {
+		for _, instanceTag := range instance.Tags {
+			if contains(filter.Values, aws.StringValue(instanceTag.Key)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if strings.HasPrefix(name, "tag:") {
+		tagName := name[4:]
+		for _, instanceTag := range instance.Tags {
+			if aws.StringValue(instanceTag.Key) == tagName && contains(filter.Values, aws.StringValue(instanceTag.Value)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	panic("Unknown filter name: " + name)
+}
+
+func contains(haystack []*string, needle string) bool {
+	for _, s := range haystack {
+		// (deliberately panic if s == nil)
+		if needle == *s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cloudprovider/providers/aws/aws_instancegroups.go
+++ b/pkg/cloudprovider/providers/aws/aws_instancegroups.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"k8s.io/klog"
+)
+
+// AWSCloud implements InstanceGroups
+var _ InstanceGroups = &Cloud{}
+
+// ResizeInstanceGroup sets the size of the specificed instancegroup Exported
+// so it can be used by the e2e tests, which don't want to instantiate a full
+// cloudprovider.
+func ResizeInstanceGroup(asg ASG, instanceGroupName string, size int) error {
+	request := &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String(instanceGroupName),
+		MinSize:              aws.Int64(int64(size)),
+		MaxSize:              aws.Int64(int64(size)),
+	}
+	if _, err := asg.UpdateAutoScalingGroup(request); err != nil {
+		return fmt.Errorf("error resizing AWS autoscaling group: %q", err)
+	}
+	return nil
+}
+
+// ResizeInstanceGroup implements InstanceGroups.ResizeInstanceGroup
+// Set the size to the fixed size
+func (c *Cloud) ResizeInstanceGroup(instanceGroupName string, size int) error {
+	return ResizeInstanceGroup(c.asg, instanceGroupName, size)
+}
+
+// DescribeInstanceGroup gets info about the specified instancegroup
+// Exported so it can be used by the e2e tests,
+// which don't want to instantiate a full cloudprovider.
+func DescribeInstanceGroup(asg ASG, instanceGroupName string) (InstanceGroupInfo, error) {
+	request := &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String(instanceGroupName)},
+	}
+	response, err := asg.DescribeAutoScalingGroups(request)
+	if err != nil {
+		return nil, fmt.Errorf("error listing AWS autoscaling group (%s): %q", instanceGroupName, err)
+	}
+
+	if len(response.AutoScalingGroups) == 0 {
+		return nil, nil
+	}
+	if len(response.AutoScalingGroups) > 1 {
+		klog.Warning("AWS returned multiple autoscaling groups with name ", instanceGroupName)
+	}
+	group := response.AutoScalingGroups[0]
+	return &awsInstanceGroup{group: group}, nil
+}
+
+// DescribeInstanceGroup implements InstanceGroups.DescribeInstanceGroup
+// Queries the cloud provider for information about the specified instance group
+func (c *Cloud) DescribeInstanceGroup(instanceGroupName string) (InstanceGroupInfo, error) {
+	return DescribeInstanceGroup(c.asg, instanceGroupName)
+}
+
+// awsInstanceGroup implements InstanceGroupInfo
+var _ InstanceGroupInfo = &awsInstanceGroup{}
+
+type awsInstanceGroup struct {
+	group *autoscaling.Group
+}
+
+// Implement InstanceGroupInfo.CurrentSize
+// The number of instances currently running under control of this group
+func (g *awsInstanceGroup) CurrentSize() (int, error) {
+	return len(g.group.Instances), nil
+}

--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -1,0 +1,1513 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"k8s.io/klog"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	// ProxyProtocolPolicyName is the tag named used for the proxy protocol
+	// policy
+	ProxyProtocolPolicyName = "k8s-proxyprotocol-enabled"
+
+	// SSLNegotiationPolicyNameFormat is a format string used for the SSL
+	// negotiation policy tag name
+	SSLNegotiationPolicyNameFormat = "k8s-SSLNegotiationPolicy-%s"
+)
+
+var (
+	// Defaults for ELB Healthcheck
+	defaultHCHealthyThreshold   = int64(2)
+	defaultHCUnhealthyThreshold = int64(6)
+	defaultHCTimeout            = int64(5)
+	defaultHCInterval           = int64(10)
+)
+
+func isNLB(annotations map[string]string) bool {
+	if annotations[ServiceAnnotationLoadBalancerType] == "nlb" {
+		return true
+	}
+	return false
+}
+
+type nlbPortMapping struct {
+	FrontendPort int64
+	TrafficPort  int64
+	ClientCIDR   string
+
+	HealthCheckPort     int64
+	HealthCheckPath     string
+	HealthCheckProtocol string
+}
+
+// getLoadBalancerAdditionalTags converts the comma separated list of key-value
+// pairs in the ServiceAnnotationLoadBalancerAdditionalTags annotation and returns
+// it as a map.
+func getLoadBalancerAdditionalTags(annotations map[string]string) map[string]string {
+	additionalTags := make(map[string]string)
+	if additionalTagsList, ok := annotations[ServiceAnnotationLoadBalancerAdditionalTags]; ok {
+		additionalTagsList = strings.TrimSpace(additionalTagsList)
+
+		// Break up list of "Key1=Val,Key2=Val2"
+		tagList := strings.Split(additionalTagsList, ",")
+
+		// Break up "Key=Val"
+		for _, tagSet := range tagList {
+			tag := strings.Split(strings.TrimSpace(tagSet), "=")
+
+			// Accept "Key=val" or "Key=" or just "Key"
+			if len(tag) >= 2 && len(tag[0]) != 0 {
+				// There is a key and a value, so save it
+				additionalTags[tag[0]] = tag[1]
+			} else if len(tag) == 1 && len(tag[0]) != 0 {
+				// Just "Key"
+				additionalTags[tag[0]] = ""
+			}
+		}
+	}
+
+	return additionalTags
+}
+
+// ensureLoadBalancerv2 ensures a v2 load balancer is created
+func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBalancerName string, mappings []nlbPortMapping, instanceIDs, subnetIDs []string, internalELB bool, annotations map[string]string) (*elbv2.LoadBalancer, error) {
+	loadBalancer, err := c.describeLoadBalancerv2(loadBalancerName)
+	if err != nil {
+		return nil, err
+	}
+
+	dirty := false
+
+	// Get additional tags set by the user
+	tags := getLoadBalancerAdditionalTags(annotations)
+	// Add default tags
+	tags[TagNameKubernetesService] = namespacedName.String()
+	tags = c.tagging.buildTags(ResourceLifecycleOwned, tags)
+
+	if loadBalancer == nil {
+		// Create the LB
+		createRequest := &elbv2.CreateLoadBalancerInput{
+			Type: aws.String(elbv2.LoadBalancerTypeEnumNetwork),
+			Name: aws.String(loadBalancerName),
+		}
+		if internalELB {
+			createRequest.Scheme = aws.String("internal")
+		}
+
+		// We are supposed to specify one subnet per AZ.
+		// TODO: What happens if we have more than one subnet per AZ?
+		createRequest.SubnetMappings = createSubnetMappings(subnetIDs)
+
+		for k, v := range tags {
+			createRequest.Tags = append(createRequest.Tags, &elbv2.Tag{
+				Key: aws.String(k), Value: aws.String(v),
+			})
+		}
+
+		klog.Infof("Creating load balancer for %v with name: %s", namespacedName, loadBalancerName)
+		createResponse, err := c.elbv2.CreateLoadBalancer(createRequest)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating load balancer: %q", err)
+		}
+
+		loadBalancer = createResponse.LoadBalancers[0]
+
+		// Create Target Groups
+		addTagsInput := &elbv2.AddTagsInput{
+			ResourceArns: []*string{},
+			Tags:         []*elbv2.Tag{},
+		}
+
+		for i := range mappings {
+			// It is easier to keep track of updates by having possibly
+			// duplicate target groups where the backend port is the same
+			_, targetGroupArn, err := c.createListenerV2(createResponse.LoadBalancers[0].LoadBalancerArn, mappings[i], namespacedName, instanceIDs, *createResponse.LoadBalancers[0].VpcId)
+			if err != nil {
+				return nil, fmt.Errorf("Error creating listener: %q", err)
+			}
+			addTagsInput.ResourceArns = append(addTagsInput.ResourceArns, targetGroupArn)
+
+		}
+
+		// Add tags to targets
+		for k, v := range tags {
+			addTagsInput.Tags = append(addTagsInput.Tags, &elbv2.Tag{
+				Key: aws.String(k), Value: aws.String(v),
+			})
+		}
+		if len(addTagsInput.ResourceArns) > 0 && len(addTagsInput.Tags) > 0 {
+			_, err = c.elbv2.AddTags(addTagsInput)
+			if err != nil {
+				return nil, fmt.Errorf("Error adding tags after creating Load Balancer: %q", err)
+			}
+		}
+	} else {
+		// TODO: Sync internal vs non-internal
+
+		// sync mappings
+		{
+			listenerDescriptions, err := c.elbv2.DescribeListeners(
+				&elbv2.DescribeListenersInput{
+					LoadBalancerArn: loadBalancer.LoadBalancerArn,
+				},
+			)
+			if err != nil {
+				return nil, fmt.Errorf("Error describing listeners: %q", err)
+			}
+
+			// actual maps FrontendPort to an elbv2.Listener
+			actual := map[int64]*elbv2.Listener{}
+			for _, listener := range listenerDescriptions.Listeners {
+				actual[*listener.Port] = listener
+			}
+
+			actualTargetGroups, err := c.elbv2.DescribeTargetGroups(
+				&elbv2.DescribeTargetGroupsInput{
+					LoadBalancerArn: loadBalancer.LoadBalancerArn,
+				},
+			)
+			if err != nil {
+				return nil, fmt.Errorf("Error listing target groups: %q", err)
+			}
+
+			nodePortTargetGroup := map[int64]*elbv2.TargetGroup{}
+			for _, targetGroup := range actualTargetGroups.TargetGroups {
+				nodePortTargetGroup[*targetGroup.Port] = targetGroup
+			}
+
+			// Create Target Groups
+			addTagsInput := &elbv2.AddTagsInput{
+				ResourceArns: []*string{},
+				Tags:         []*elbv2.Tag{},
+			}
+
+			// Handle additions/modifications
+			for _, mapping := range mappings {
+				frontendPort := mapping.FrontendPort
+				nodePort := mapping.TrafficPort
+
+				// modifications
+				if listener, ok := actual[frontendPort]; ok {
+					// nodePort must have changed, we'll need to delete old TG
+					// and recreate
+					if targetGroup, ok := nodePortTargetGroup[nodePort]; !ok {
+						// Create new Target group
+						targetName := createTargetName(namespacedName, frontendPort, nodePort)
+						targetGroup, err = c.ensureTargetGroup(
+							nil,
+							mapping,
+							instanceIDs,
+							targetName,
+							*loadBalancer.VpcId,
+						)
+						if err != nil {
+							return nil, err
+						}
+
+						// Associate new target group to LB
+						_, err := c.elbv2.ModifyListener(&elbv2.ModifyListenerInput{
+							ListenerArn: listener.ListenerArn,
+							Port:        aws.Int64(frontendPort),
+							Protocol:    aws.String("TCP"),
+							DefaultActions: []*elbv2.Action{{
+								TargetGroupArn: targetGroup.TargetGroupArn,
+								Type:           aws.String("forward"),
+							}},
+						})
+						if err != nil {
+							return nil, fmt.Errorf("Error updating load balancer listener: %q", err)
+						}
+
+						// Delete old target group
+						_, err = c.elbv2.DeleteTargetGroup(&elbv2.DeleteTargetGroupInput{
+							TargetGroupArn: listener.DefaultActions[0].TargetGroupArn,
+						})
+						if err != nil {
+							return nil, fmt.Errorf("Error deleting old target group: %q", err)
+						}
+
+					} else {
+						// Run ensureTargetGroup to make sure instances in service are up-to-date
+						targetName := createTargetName(namespacedName, frontendPort, nodePort)
+						_, err = c.ensureTargetGroup(
+							targetGroup,
+							mapping,
+							instanceIDs,
+							targetName,
+							*loadBalancer.VpcId,
+						)
+						if err != nil {
+							return nil, err
+						}
+					}
+					dirty = true
+					continue
+				}
+
+				// Additions
+				_, targetGroupArn, err := c.createListenerV2(loadBalancer.LoadBalancerArn, mapping, namespacedName, instanceIDs, *loadBalancer.VpcId)
+				if err != nil {
+					return nil, err
+				}
+				addTagsInput.ResourceArns = append(addTagsInput.ResourceArns, targetGroupArn)
+				dirty = true
+			}
+
+			frontEndPorts := map[int64]bool{}
+			for i := range mappings {
+				frontEndPorts[mappings[i].FrontendPort] = true
+			}
+
+			// handle deletions
+			for port, listener := range actual {
+				if _, ok := frontEndPorts[port]; !ok {
+					err := c.deleteListenerV2(listener)
+					if err != nil {
+						return nil, err
+					}
+					dirty = true
+				}
+			}
+
+			// Add tags to new targets
+			for k, v := range tags {
+				addTagsInput.Tags = append(addTagsInput.Tags, &elbv2.Tag{
+					Key: aws.String(k), Value: aws.String(v),
+				})
+			}
+			if len(addTagsInput.ResourceArns) > 0 && len(addTagsInput.Tags) > 0 {
+				_, err = c.elbv2.AddTags(addTagsInput)
+				if err != nil {
+					return nil, fmt.Errorf("Error adding tags after modifying load balancer targets: %q", err)
+				}
+			}
+		}
+
+		// Subnets cannot be modified on NLBs
+		if dirty {
+			loadBalancers, err := c.elbv2.DescribeLoadBalancers(
+				&elbv2.DescribeLoadBalancersInput{
+					LoadBalancerArns: []*string{
+						loadBalancer.LoadBalancerArn,
+					},
+				},
+			)
+			if err != nil {
+				return nil, fmt.Errorf("Error retrieving load balancer after update: %q", err)
+			}
+			loadBalancer = loadBalancers.LoadBalancers[0]
+		}
+	}
+	return loadBalancer, nil
+}
+
+// create a valid target group name - ensure name is not over 32 characters
+func createTargetName(namespacedName types.NamespacedName, frontendPort, nodePort int64) string {
+	sha := fmt.Sprintf("%x", sha1.Sum([]byte(namespacedName.String())))[:13]
+	return fmt.Sprintf("k8s-tg-%s-%d-%d", sha, frontendPort, nodePort)
+}
+
+func (c *Cloud) createListenerV2(loadBalancerArn *string, mapping nlbPortMapping, namespacedName types.NamespacedName, instanceIDs []string, vpcID string) (listener *elbv2.Listener, targetGroupArn *string, err error) {
+	targetName := createTargetName(namespacedName, mapping.FrontendPort, mapping.TrafficPort)
+
+	klog.Infof("Creating load balancer target group for %v with name: %s", namespacedName, targetName)
+	target, err := c.ensureTargetGroup(
+		nil,
+		mapping,
+		instanceIDs,
+		targetName,
+		vpcID,
+	)
+	if err != nil {
+		return nil, aws.String(""), err
+	}
+
+	createListernerInput := &elbv2.CreateListenerInput{
+		LoadBalancerArn: loadBalancerArn,
+		Port:            aws.Int64(mapping.FrontendPort),
+		Protocol:        aws.String("TCP"),
+		DefaultActions: []*elbv2.Action{{
+			TargetGroupArn: target.TargetGroupArn,
+			Type:           aws.String(elbv2.ActionTypeEnumForward),
+		}},
+	}
+	klog.Infof("Creating load balancer listener for %v", namespacedName)
+	createListenerOutput, err := c.elbv2.CreateListener(createListernerInput)
+	if err != nil {
+		return nil, aws.String(""), fmt.Errorf("Error creating load balancer listener: %q", err)
+	}
+	return createListenerOutput.Listeners[0], target.TargetGroupArn, nil
+}
+
+// cleans up listener and corresponding target group
+func (c *Cloud) deleteListenerV2(listener *elbv2.Listener) error {
+	_, err := c.elbv2.DeleteListener(&elbv2.DeleteListenerInput{ListenerArn: listener.ListenerArn})
+	if err != nil {
+		return fmt.Errorf("Error deleting load balancer listener: %q", err)
+	}
+	_, err = c.elbv2.DeleteTargetGroup(&elbv2.DeleteTargetGroupInput{TargetGroupArn: listener.DefaultActions[0].TargetGroupArn})
+	if err != nil {
+		return fmt.Errorf("Error deleting load balancer target group: %q", err)
+	}
+	return nil
+}
+
+// ensureTargetGroup creates a target group with a set of instances
+func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, mapping nlbPortMapping, instances []string, name string, vpcID string) (*elbv2.TargetGroup, error) {
+	dirty := false
+	if targetGroup == nil {
+
+		input := &elbv2.CreateTargetGroupInput{
+			VpcId:                      aws.String(vpcID),
+			Name:                       aws.String(name),
+			Port:                       aws.Int64(mapping.TrafficPort),
+			Protocol:                   aws.String("TCP"),
+			TargetType:                 aws.String("instance"),
+			HealthCheckIntervalSeconds: aws.Int64(30),
+			HealthCheckPort:            aws.String("traffic-port"),
+			HealthCheckProtocol:        aws.String("TCP"),
+			HealthyThresholdCount:      aws.Int64(3),
+			UnhealthyThresholdCount:    aws.Int64(3),
+		}
+
+		input.HealthCheckProtocol = aws.String(mapping.HealthCheckProtocol)
+		if mapping.HealthCheckProtocol != elbv2.ProtocolEnumTcp {
+			input.HealthCheckPath = aws.String(mapping.HealthCheckPath)
+		}
+
+		// Account for externalTrafficPolicy = "Local"
+		if mapping.HealthCheckPort != mapping.TrafficPort {
+			input.HealthCheckPort = aws.String(strconv.Itoa(int(mapping.HealthCheckPort)))
+		}
+
+		result, err := c.elbv2.CreateTargetGroup(input)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating load balancer target group: %q", err)
+		}
+		if len(result.TargetGroups) != 1 {
+			return nil, fmt.Errorf("Expected only one target group on CreateTargetGroup, got %d groups", len(result.TargetGroups))
+		}
+
+		registerInput := &elbv2.RegisterTargetsInput{
+			TargetGroupArn: result.TargetGroups[0].TargetGroupArn,
+			Targets:        []*elbv2.TargetDescription{},
+		}
+		for _, instanceID := range instances {
+			registerInput.Targets = append(registerInput.Targets, &elbv2.TargetDescription{
+				Id:   aws.String(string(instanceID)),
+				Port: aws.Int64(mapping.TrafficPort),
+			})
+		}
+
+		_, err = c.elbv2.RegisterTargets(registerInput)
+		if err != nil {
+			return nil, fmt.Errorf("Error registering targets for load balancer: %q", err)
+		}
+
+		return result.TargetGroups[0], nil
+	}
+
+	// handle instances in service
+	{
+		healthResponse, err := c.elbv2.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{TargetGroupArn: targetGroup.TargetGroupArn})
+		if err != nil {
+			return nil, fmt.Errorf("Error describing target group health: %q", err)
+		}
+		actualIDs := []string{}
+		for _, healthDescription := range healthResponse.TargetHealthDescriptions {
+			if healthDescription.TargetHealth.Reason != nil {
+				switch aws.StringValue(healthDescription.TargetHealth.Reason) {
+				case elbv2.TargetHealthReasonEnumTargetDeregistrationInProgress:
+					// We don't need to count this instance in service if it is
+					// on its way out
+				default:
+					actualIDs = append(actualIDs, *healthDescription.Target.Id)
+				}
+			}
+		}
+
+		actual := sets.NewString(actualIDs...)
+		expected := sets.NewString(instances...)
+
+		additions := expected.Difference(actual)
+		removals := actual.Difference(expected)
+
+		if len(additions) > 0 {
+			registerInput := &elbv2.RegisterTargetsInput{
+				TargetGroupArn: targetGroup.TargetGroupArn,
+				Targets:        []*elbv2.TargetDescription{},
+			}
+			for instanceID := range additions {
+				registerInput.Targets = append(registerInput.Targets, &elbv2.TargetDescription{
+					Id:   aws.String(instanceID),
+					Port: aws.Int64(mapping.TrafficPort),
+				})
+			}
+			_, err := c.elbv2.RegisterTargets(registerInput)
+			if err != nil {
+				return nil, fmt.Errorf("Error registering new targets in target group: %q", err)
+			}
+			dirty = true
+		}
+
+		if len(removals) > 0 {
+			deregisterInput := &elbv2.DeregisterTargetsInput{
+				TargetGroupArn: targetGroup.TargetGroupArn,
+				Targets:        []*elbv2.TargetDescription{},
+			}
+			for instanceID := range removals {
+				deregisterInput.Targets = append(deregisterInput.Targets, &elbv2.TargetDescription{
+					Id:   aws.String(instanceID),
+					Port: aws.Int64(mapping.TrafficPort),
+				})
+			}
+			_, err := c.elbv2.DeregisterTargets(deregisterInput)
+			if err != nil {
+				return nil, fmt.Errorf("Error trying to deregister targets in target group: %q", err)
+			}
+			dirty = true
+		}
+	}
+
+	// ensure the health check is correct
+	{
+		dirtyHealthCheck := false
+
+		input := &elbv2.ModifyTargetGroupInput{
+			TargetGroupArn: targetGroup.TargetGroupArn,
+		}
+
+		if aws.StringValue(targetGroup.HealthCheckProtocol) != mapping.HealthCheckProtocol {
+			input.HealthCheckProtocol = aws.String(mapping.HealthCheckProtocol)
+			dirtyHealthCheck = true
+		}
+		if aws.StringValue(targetGroup.HealthCheckPort) != strconv.Itoa(int(mapping.HealthCheckPort)) {
+			input.HealthCheckPort = aws.String(strconv.Itoa(int(mapping.HealthCheckPort)))
+			dirtyHealthCheck = true
+		}
+		if mapping.HealthCheckPath != "" && mapping.HealthCheckProtocol != elbv2.ProtocolEnumTcp {
+			input.HealthCheckPath = aws.String(mapping.HealthCheckPath)
+			dirtyHealthCheck = true
+		}
+
+		if dirtyHealthCheck {
+			_, err := c.elbv2.ModifyTargetGroup(input)
+			if err != nil {
+				return nil, fmt.Errorf("Error modifying target group health check: %q", err)
+			}
+
+			dirty = true
+		}
+	}
+
+	if dirty {
+		result, err := c.elbv2.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{
+			Names: []*string{aws.String(name)},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving target group after creation/update: %q", err)
+		}
+		targetGroup = result.TargetGroups[0]
+	}
+
+	return targetGroup, nil
+}
+
+func portsForNLB(lbName string, sg *ec2.SecurityGroup, clientTraffic bool) sets.Int64 {
+	response := sets.NewInt64()
+	var annotation string
+	if clientTraffic {
+		annotation = fmt.Sprintf("%s=%s", NLBClientRuleDescription, lbName)
+	} else {
+		annotation = fmt.Sprintf("%s=%s", NLBHealthCheckRuleDescription, lbName)
+	}
+
+	for i := range sg.IpPermissions {
+		for j := range sg.IpPermissions[i].IpRanges {
+			description := aws.StringValue(sg.IpPermissions[i].IpRanges[j].Description)
+			if description == annotation {
+				// TODO  should probably check FromPort == ToPort
+				response.Insert(aws.Int64Value(sg.IpPermissions[i].FromPort))
+			}
+		}
+	}
+	return response
+}
+
+// filterForIPRangeDescription filters in security groups that have IpRange Descriptions that match a loadBalancerName
+func filterForIPRangeDescription(securityGroups []*ec2.SecurityGroup, lbName string) []*ec2.SecurityGroup {
+	response := []*ec2.SecurityGroup{}
+	clientRule := fmt.Sprintf("%s=%s", NLBClientRuleDescription, lbName)
+	healthRule := fmt.Sprintf("%s=%s", NLBHealthCheckRuleDescription, lbName)
+	for i := range securityGroups {
+		for j := range securityGroups[i].IpPermissions {
+			for k := range securityGroups[i].IpPermissions[j].IpRanges {
+				description := aws.StringValue(securityGroups[i].IpPermissions[j].IpRanges[k].Description)
+				if description == clientRule || description == healthRule {
+					response = append(response, securityGroups[i])
+				}
+			}
+		}
+	}
+	return response
+}
+
+func (c *Cloud) getVpcCidrBlock() (*string, error) {
+	vpcs, err := c.ec2.DescribeVpcs(&ec2.DescribeVpcsInput{
+		VpcIds: []*string{aws.String(c.vpcID)},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Error querying VPC for ELB: %q", err)
+	}
+	if len(vpcs.Vpcs) != 1 {
+		return nil, fmt.Errorf("Error querying VPC for ELB, got %d vpcs for %s", len(vpcs.Vpcs), c.vpcID)
+	}
+	return vpcs.Vpcs[0].CidrBlock, nil
+}
+
+// abstraction for updating SG rules
+// if clientTraffic is false, then only update HealthCheck rules
+func (c *Cloud) updateInstanceSecurityGroupsForNLBTraffic(actualGroups []*ec2.SecurityGroup, desiredSgIds []string, ports []int64, lbName string, clientCidrs []string, clientTraffic bool) error {
+
+	// Map containing the groups we want to make changes on; the ports to make
+	// changes on; and whether to add or remove it. true to add, false to remove
+	portChanges := map[string]map[int64]bool{}
+
+	for _, id := range desiredSgIds {
+		// consider everything an addition for now
+		if _, ok := portChanges[id]; !ok {
+			portChanges[id] = make(map[int64]bool)
+		}
+		for _, port := range ports {
+			portChanges[id][port] = true
+		}
+	}
+
+	// Compare to actual groups
+	for _, actualGroup := range actualGroups {
+		actualGroupID := aws.StringValue(actualGroup.GroupId)
+		if actualGroupID == "" {
+			klog.Warning("Ignoring group without ID: ", actualGroup)
+			continue
+		}
+
+		addingMap, ok := portChanges[actualGroupID]
+		if ok {
+			desiredSet := sets.NewInt64()
+			for port := range addingMap {
+				desiredSet.Insert(port)
+			}
+			existingSet := portsForNLB(lbName, actualGroup, clientTraffic)
+
+			// remove from portChanges ports that are already allowed
+			if intersection := desiredSet.Intersection(existingSet); intersection.Len() > 0 {
+				for p := range intersection {
+					delete(portChanges[actualGroupID], p)
+				}
+			}
+
+			// allowed ports that need to be removed
+			if difference := existingSet.Difference(desiredSet); difference.Len() > 0 {
+				for p := range difference {
+					portChanges[actualGroupID][p] = false
+				}
+			}
+		}
+	}
+
+	// Make changes we've planned on
+	for instanceSecurityGroupID, portMap := range portChanges {
+		adds := []*ec2.IpPermission{}
+		removes := []*ec2.IpPermission{}
+		for port, add := range portMap {
+			if add {
+				if clientTraffic {
+					klog.V(2).Infof("Adding rule for client MTU discovery from the network load balancer (%s) to instances (%s)", clientCidrs, instanceSecurityGroupID)
+					klog.V(2).Infof("Adding rule for client traffic from the network load balancer (%s) to instances (%s)", clientCidrs, instanceSecurityGroupID)
+				} else {
+					klog.V(2).Infof("Adding rule for health check traffic from the network load balancer (%s) to instances (%s)", clientCidrs, instanceSecurityGroupID)
+				}
+			} else {
+				if clientTraffic {
+					klog.V(2).Infof("Removing rule for client MTU discovery from the network load balancer (%s) to instances (%s)", clientCidrs, instanceSecurityGroupID)
+					klog.V(2).Infof("Removing rule for client traffic from the network load balancer (%s) to instance (%s)", clientCidrs, instanceSecurityGroupID)
+				}
+				klog.V(2).Infof("Removing rule for health check traffic from the network load balancer (%s) to instance (%s)", clientCidrs, instanceSecurityGroupID)
+			}
+
+			if clientTraffic {
+				clientRuleAnnotation := fmt.Sprintf("%s=%s", NLBClientRuleDescription, lbName)
+				// Client Traffic
+				permission := &ec2.IpPermission{
+					FromPort:   aws.Int64(port),
+					ToPort:     aws.Int64(port),
+					IpProtocol: aws.String("tcp"),
+				}
+				ranges := []*ec2.IpRange{}
+				for _, cidr := range clientCidrs {
+					ranges = append(ranges, &ec2.IpRange{
+						CidrIp:      aws.String(cidr),
+						Description: aws.String(clientRuleAnnotation),
+					})
+				}
+				permission.IpRanges = ranges
+				if add {
+					adds = append(adds, permission)
+				} else {
+					removes = append(removes, permission)
+				}
+			} else {
+				healthRuleAnnotation := fmt.Sprintf("%s=%s", NLBHealthCheckRuleDescription, lbName)
+
+				// NLB HealthCheck
+				permission := &ec2.IpPermission{
+					FromPort:   aws.Int64(port),
+					ToPort:     aws.Int64(port),
+					IpProtocol: aws.String("tcp"),
+				}
+				ranges := []*ec2.IpRange{}
+				for _, cidr := range clientCidrs {
+					ranges = append(ranges, &ec2.IpRange{
+						CidrIp:      aws.String(cidr),
+						Description: aws.String(healthRuleAnnotation),
+					})
+				}
+				permission.IpRanges = ranges
+				if add {
+					adds = append(adds, permission)
+				} else {
+					removes = append(removes, permission)
+				}
+			}
+		}
+
+		if len(adds) > 0 {
+			changed, err := c.addSecurityGroupIngress(instanceSecurityGroupID, adds)
+			if err != nil {
+				return err
+			}
+			if !changed {
+				klog.Warning("Allowing ingress was not needed; concurrent change? groupId=", instanceSecurityGroupID)
+			}
+		}
+
+		if len(removes) > 0 {
+			changed, err := c.removeSecurityGroupIngress(instanceSecurityGroupID, removes)
+			if err != nil {
+				return err
+			}
+			if !changed {
+				klog.Warning("Revoking ingress was not needed; concurrent change? groupId=", instanceSecurityGroupID)
+			}
+		}
+
+		if clientTraffic {
+			// MTU discovery
+			mtuRuleAnnotation := fmt.Sprintf("%s=%s", NLBMtuDiscoveryRuleDescription, lbName)
+			mtuPermission := &ec2.IpPermission{
+				IpProtocol: aws.String("icmp"),
+				FromPort:   aws.Int64(3),
+				ToPort:     aws.Int64(4),
+			}
+			ranges := []*ec2.IpRange{}
+			for _, cidr := range clientCidrs {
+				ranges = append(ranges, &ec2.IpRange{
+					CidrIp:      aws.String(cidr),
+					Description: aws.String(mtuRuleAnnotation),
+				})
+			}
+			mtuPermission.IpRanges = ranges
+
+			group, err := c.findSecurityGroup(instanceSecurityGroupID)
+			if err != nil {
+				klog.Warningf("Error retrieving security group: %q", err)
+				return err
+			}
+
+			if group == nil {
+				klog.Warning("Security group not found: ", instanceSecurityGroupID)
+				return nil
+			}
+
+			icmpExists := false
+			permCount := 0
+			for _, perm := range group.IpPermissions {
+				if *perm.IpProtocol == "icmp" {
+					icmpExists = true
+					continue
+				}
+
+				if perm.FromPort != nil {
+					permCount++
+				}
+			}
+
+			if !icmpExists && permCount > 0 {
+				// the icmp permission is missing
+				changed, err := c.addSecurityGroupIngress(instanceSecurityGroupID, []*ec2.IpPermission{mtuPermission})
+				if err != nil {
+					klog.Warningf("Error adding MTU permission to security group: %q", err)
+					return err
+				}
+				if !changed {
+					klog.Warning("Allowing ingress was not needed; concurrent change? groupId=", instanceSecurityGroupID)
+				}
+			} else if icmpExists && permCount == 0 {
+				// there is no additional permissions, remove icmp
+				changed, err := c.removeSecurityGroupIngress(instanceSecurityGroupID, []*ec2.IpPermission{mtuPermission})
+				if err != nil {
+					klog.Warningf("Error removing MTU permission to security group: %q", err)
+					return err
+				}
+				if !changed {
+					klog.Warning("Revoking ingress was not needed; concurrent change? groupId=", instanceSecurityGroupID)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Add SG rules for a given NLB
+func (c *Cloud) updateInstanceSecurityGroupsForNLB(mappings []nlbPortMapping, instances map[awsInstanceID]*ec2.Instance, lbName string, clientCidrs []string) error {
+	if c.cfg.Global.DisableSecurityGroupIngress {
+		return nil
+	}
+
+	vpcCidr, err := c.getVpcCidrBlock()
+	if err != nil {
+		return err
+	}
+
+	// Unlike the classic ELB, NLB does not have a security group that we can
+	// filter against all existing groups to see if they allow access. Instead
+	// we use the IpRange.Description field to annotate NLB health check and
+	// client traffic rules
+
+	// Get the actual list of groups that allow ingress for the load-balancer
+	var actualGroups []*ec2.SecurityGroup
+	{
+		// Server side filter
+		describeRequest := &ec2.DescribeSecurityGroupsInput{}
+		filters := []*ec2.Filter{
+			newEc2Filter("ip-permission.protocol", "tcp"),
+		}
+		describeRequest.Filters = c.tagging.addFilters(filters)
+		response, err := c.ec2.DescribeSecurityGroups(describeRequest)
+		if err != nil {
+			return fmt.Errorf("Error querying security groups for NLB: %q", err)
+		}
+		for _, sg := range response {
+			if !c.tagging.hasClusterTag(sg.Tags) {
+				continue
+			}
+			actualGroups = append(actualGroups, sg)
+		}
+
+		// client-side filter
+		// Filter out groups that don't have IP Rules we've annotated for this service
+		actualGroups = filterForIPRangeDescription(actualGroups, lbName)
+	}
+
+	taggedSecurityGroups, err := c.getTaggedSecurityGroups()
+	if err != nil {
+		return fmt.Errorf("Error querying for tagged security groups: %q", err)
+	}
+
+	externalTrafficPolicyIsLocal := false
+	trafficPorts := []int64{}
+	for i := range mappings {
+		trafficPorts = append(trafficPorts, mappings[i].TrafficPort)
+		if mappings[i].TrafficPort != mappings[i].HealthCheckPort {
+			externalTrafficPolicyIsLocal = true
+		}
+	}
+
+	healthCheckPorts := trafficPorts
+	// if externalTrafficPolicy is Local, all listeners use the same health
+	// check port
+	if externalTrafficPolicyIsLocal && len(mappings) > 0 {
+		healthCheckPorts = []int64{mappings[0].HealthCheckPort}
+	}
+
+	desiredGroupIds := []string{}
+	// Scan instances for groups we want open
+	for _, instance := range instances {
+		securityGroup, err := findSecurityGroupForInstance(instance, taggedSecurityGroups)
+		if err != nil {
+			return err
+		}
+
+		if securityGroup == nil {
+			klog.Warningf("Ignoring instance without security group: %s", aws.StringValue(instance.InstanceId))
+			continue
+		}
+
+		id := aws.StringValue(securityGroup.GroupId)
+		if id == "" {
+			klog.Warningf("found security group without id: %v", securityGroup)
+			continue
+		}
+
+		desiredGroupIds = append(desiredGroupIds, id)
+	}
+
+	// Run once for Client traffic
+	err = c.updateInstanceSecurityGroupsForNLBTraffic(actualGroups, desiredGroupIds, trafficPorts, lbName, clientCidrs, true)
+	if err != nil {
+		return err
+	}
+
+	// Run once for health check traffic
+	err = c.updateInstanceSecurityGroupsForNLBTraffic(actualGroups, desiredGroupIds, healthCheckPorts, lbName, []string{aws.StringValue(vpcCidr)}, false)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBalancerName string, listeners []*elb.Listener, subnetIDs []string, securityGroupIDs []string, internalELB, proxyProtocol bool, loadBalancerAttributes *elb.LoadBalancerAttributes, annotations map[string]string) (*elb.LoadBalancerDescription, error) {
+	loadBalancer, err := c.describeLoadBalancer(loadBalancerName)
+	if err != nil {
+		return nil, err
+	}
+
+	dirty := false
+
+	if loadBalancer == nil {
+		createRequest := &elb.CreateLoadBalancerInput{}
+		createRequest.LoadBalancerName = aws.String(loadBalancerName)
+
+		createRequest.Listeners = listeners
+
+		if internalELB {
+			createRequest.Scheme = aws.String("internal")
+		}
+
+		// We are supposed to specify one subnet per AZ.
+		// TODO: What happens if we have more than one subnet per AZ?
+		if subnetIDs == nil {
+			createRequest.Subnets = nil
+		} else {
+			createRequest.Subnets = aws.StringSlice(subnetIDs)
+		}
+
+		if securityGroupIDs == nil {
+			createRequest.SecurityGroups = nil
+		} else {
+			createRequest.SecurityGroups = aws.StringSlice(securityGroupIDs)
+		}
+
+		// Get additional tags set by the user
+		tags := getLoadBalancerAdditionalTags(annotations)
+
+		// Add default tags
+		tags[TagNameKubernetesService] = namespacedName.String()
+		tags = c.tagging.buildTags(ResourceLifecycleOwned, tags)
+
+		for k, v := range tags {
+			createRequest.Tags = append(createRequest.Tags, &elb.Tag{
+				Key: aws.String(k), Value: aws.String(v),
+			})
+		}
+
+		klog.Infof("Creating load balancer for %v with name: %s", namespacedName, loadBalancerName)
+		_, err := c.elb.CreateLoadBalancer(createRequest)
+		if err != nil {
+			return nil, err
+		}
+
+		if proxyProtocol {
+			err = c.createProxyProtocolPolicy(loadBalancerName)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, listener := range listeners {
+				klog.V(2).Infof("Adjusting AWS loadbalancer proxy protocol on node port %d. Setting to true", *listener.InstancePort)
+				err := c.setBackendPolicies(loadBalancerName, *listener.InstancePort, []*string{aws.String(ProxyProtocolPolicyName)})
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		dirty = true
+	} else {
+		// TODO: Sync internal vs non-internal
+
+		{
+			// Sync subnets
+			expected := sets.NewString(subnetIDs...)
+			actual := stringSetFromPointers(loadBalancer.Subnets)
+
+			additions := expected.Difference(actual)
+			removals := actual.Difference(expected)
+
+			if removals.Len() != 0 {
+				request := &elb.DetachLoadBalancerFromSubnetsInput{}
+				request.LoadBalancerName = aws.String(loadBalancerName)
+				request.Subnets = stringSetToPointers(removals)
+				klog.V(2).Info("Detaching load balancer from removed subnets")
+				_, err := c.elb.DetachLoadBalancerFromSubnets(request)
+				if err != nil {
+					return nil, fmt.Errorf("error detaching AWS loadbalancer from subnets: %q", err)
+				}
+				dirty = true
+			}
+
+			if additions.Len() != 0 {
+				request := &elb.AttachLoadBalancerToSubnetsInput{}
+				request.LoadBalancerName = aws.String(loadBalancerName)
+				request.Subnets = stringSetToPointers(additions)
+				klog.V(2).Info("Attaching load balancer to added subnets")
+				_, err := c.elb.AttachLoadBalancerToSubnets(request)
+				if err != nil {
+					return nil, fmt.Errorf("error attaching AWS loadbalancer to subnets: %q", err)
+				}
+				dirty = true
+			}
+		}
+
+		{
+			// Sync security groups
+			expected := sets.NewString(securityGroupIDs...)
+			actual := stringSetFromPointers(loadBalancer.SecurityGroups)
+
+			if !expected.Equal(actual) {
+				// This call just replaces the security groups, unlike e.g. subnets (!)
+				request := &elb.ApplySecurityGroupsToLoadBalancerInput{}
+				request.LoadBalancerName = aws.String(loadBalancerName)
+				if securityGroupIDs == nil {
+					request.SecurityGroups = nil
+				} else {
+					request.SecurityGroups = aws.StringSlice(securityGroupIDs)
+				}
+				klog.V(2).Info("Applying updated security groups to load balancer")
+				_, err := c.elb.ApplySecurityGroupsToLoadBalancer(request)
+				if err != nil {
+					return nil, fmt.Errorf("error applying AWS loadbalancer security groups: %q", err)
+				}
+				dirty = true
+			}
+		}
+
+		{
+			// Sync listeners
+			listenerDescriptions := loadBalancer.ListenerDescriptions
+
+			foundSet := make(map[int]bool)
+			removals := []*int64{}
+			for _, listenerDescription := range listenerDescriptions {
+				actual := listenerDescription.Listener
+				if actual == nil {
+					klog.Warning("Ignoring empty listener in AWS loadbalancer: ", loadBalancerName)
+					continue
+				}
+
+				found := -1
+				for i, expected := range listeners {
+					if elbProtocolsAreEqual(actual.Protocol, expected.Protocol) {
+						continue
+					}
+					if elbProtocolsAreEqual(actual.InstanceProtocol, expected.InstanceProtocol) {
+						continue
+					}
+					if aws.Int64Value(actual.InstancePort) != aws.Int64Value(expected.InstancePort) {
+						continue
+					}
+					if aws.Int64Value(actual.LoadBalancerPort) != aws.Int64Value(expected.LoadBalancerPort) {
+						continue
+					}
+					if awsArnEquals(actual.SSLCertificateId, expected.SSLCertificateId) {
+						continue
+					}
+					found = i
+				}
+				if found != -1 {
+					foundSet[found] = true
+				} else {
+					removals = append(removals, actual.LoadBalancerPort)
+				}
+			}
+
+			additions := []*elb.Listener{}
+			for i := range listeners {
+				if foundSet[i] {
+					continue
+				}
+				additions = append(additions, listeners[i])
+			}
+
+			if len(removals) != 0 {
+				request := &elb.DeleteLoadBalancerListenersInput{}
+				request.LoadBalancerName = aws.String(loadBalancerName)
+				request.LoadBalancerPorts = removals
+				klog.V(2).Info("Deleting removed load balancer listeners")
+				_, err := c.elb.DeleteLoadBalancerListeners(request)
+				if err != nil {
+					return nil, fmt.Errorf("error deleting AWS loadbalancer listeners: %q", err)
+				}
+				dirty = true
+			}
+
+			if len(additions) != 0 {
+				request := &elb.CreateLoadBalancerListenersInput{}
+				request.LoadBalancerName = aws.String(loadBalancerName)
+				request.Listeners = additions
+				klog.V(2).Info("Creating added load balancer listeners")
+				_, err := c.elb.CreateLoadBalancerListeners(request)
+				if err != nil {
+					return nil, fmt.Errorf("error creating AWS loadbalancer listeners: %q", err)
+				}
+				dirty = true
+			}
+		}
+
+		{
+			// Sync proxy protocol state for new and existing listeners
+
+			proxyPolicies := make([]*string, 0)
+			if proxyProtocol {
+				// Ensure the backend policy exists
+
+				// NOTE The documentation for the AWS API indicates we could get an HTTP 400
+				// back if a policy of the same name already exists. However, the aws-sdk does not
+				// seem to return an error to us in these cases. Therefore, this will issue an API
+				// request every time.
+				err := c.createProxyProtocolPolicy(loadBalancerName)
+				if err != nil {
+					return nil, err
+				}
+
+				proxyPolicies = append(proxyPolicies, aws.String(ProxyProtocolPolicyName))
+			}
+
+			foundBackends := make(map[int64]bool)
+			proxyProtocolBackends := make(map[int64]bool)
+			for _, backendListener := range loadBalancer.BackendServerDescriptions {
+				foundBackends[*backendListener.InstancePort] = false
+				proxyProtocolBackends[*backendListener.InstancePort] = proxyProtocolEnabled(backendListener)
+			}
+
+			for _, listener := range listeners {
+				setPolicy := false
+				instancePort := *listener.InstancePort
+
+				if currentState, ok := proxyProtocolBackends[instancePort]; !ok {
+					// This is a new ELB backend so we only need to worry about
+					// potentially adding a policy and not removing an
+					// existing one
+					setPolicy = proxyProtocol
+				} else {
+					foundBackends[instancePort] = true
+					// This is an existing ELB backend so we need to determine
+					// if the state changed
+					setPolicy = (currentState != proxyProtocol)
+				}
+
+				if setPolicy {
+					klog.V(2).Infof("Adjusting AWS loadbalancer proxy protocol on node port %d. Setting to %t", instancePort, proxyProtocol)
+					err := c.setBackendPolicies(loadBalancerName, instancePort, proxyPolicies)
+					if err != nil {
+						return nil, err
+					}
+					dirty = true
+				}
+			}
+
+			// We now need to figure out if any backend policies need removed
+			// because these old policies will stick around even if there is no
+			// corresponding listener anymore
+			for instancePort, found := range foundBackends {
+				if !found {
+					klog.V(2).Infof("Adjusting AWS loadbalancer proxy protocol on node port %d. Setting to false", instancePort)
+					err := c.setBackendPolicies(loadBalancerName, instancePort, []*string{})
+					if err != nil {
+						return nil, err
+					}
+					dirty = true
+				}
+			}
+		}
+
+		{
+			// Add additional tags
+			klog.V(2).Infof("Creating additional load balancer tags for %s", loadBalancerName)
+			tags := getLoadBalancerAdditionalTags(annotations)
+			if len(tags) > 0 {
+				err := c.addLoadBalancerTags(loadBalancerName, tags)
+				if err != nil {
+					return nil, fmt.Errorf("unable to create additional load balancer tags: %v", err)
+				}
+			}
+		}
+	}
+
+	// Whether the ELB was new or existing, sync attributes regardless. This accounts for things
+	// that cannot be specified at the time of creation and can only be modified after the fact,
+	// e.g. idle connection timeout.
+	{
+		describeAttributesRequest := &elb.DescribeLoadBalancerAttributesInput{}
+		describeAttributesRequest.LoadBalancerName = aws.String(loadBalancerName)
+		describeAttributesOutput, err := c.elb.DescribeLoadBalancerAttributes(describeAttributesRequest)
+		if err != nil {
+			klog.Warning("Unable to retrieve load balancer attributes during attribute sync")
+			return nil, err
+		}
+
+		foundAttributes := &describeAttributesOutput.LoadBalancerAttributes
+
+		// Update attributes if they're dirty
+		if !reflect.DeepEqual(loadBalancerAttributes, foundAttributes) {
+			klog.V(2).Infof("Updating load-balancer attributes for %q", loadBalancerName)
+
+			modifyAttributesRequest := &elb.ModifyLoadBalancerAttributesInput{}
+			modifyAttributesRequest.LoadBalancerName = aws.String(loadBalancerName)
+			modifyAttributesRequest.LoadBalancerAttributes = loadBalancerAttributes
+			_, err = c.elb.ModifyLoadBalancerAttributes(modifyAttributesRequest)
+			if err != nil {
+				return nil, fmt.Errorf("Unable to update load balancer attributes during attribute sync: %q", err)
+			}
+			dirty = true
+		}
+	}
+
+	if dirty {
+		loadBalancer, err = c.describeLoadBalancer(loadBalancerName)
+		if err != nil {
+			klog.Warning("Unable to retrieve load balancer after creation/update")
+			return nil, err
+		}
+	}
+
+	return loadBalancer, nil
+}
+
+func createSubnetMappings(subnetIDs []string) []*elbv2.SubnetMapping {
+	response := []*elbv2.SubnetMapping{}
+
+	for _, id := range subnetIDs {
+		// Ignore AllocationId for now
+		response = append(response, &elbv2.SubnetMapping{SubnetId: aws.String(id)})
+	}
+
+	return response
+}
+
+// elbProtocolsAreEqual checks if two ELB protocol strings are considered the same
+// Comparison is case insensitive
+func elbProtocolsAreEqual(l, r *string) bool {
+	if l == nil || r == nil {
+		return l == r
+	}
+	return strings.EqualFold(aws.StringValue(l), aws.StringValue(r))
+}
+
+// awsArnEquals checks if two ARN strings are considered the same
+// Comparison is case insensitive
+func awsArnEquals(l, r *string) bool {
+	if l == nil || r == nil {
+		return l == r
+	}
+	return strings.EqualFold(aws.StringValue(l), aws.StringValue(r))
+}
+
+// getExpectedHealthCheck returns an elb.Healthcheck for the provided target
+// and using either sensible defaults or overrides via Service annotations
+func (c *Cloud) getExpectedHealthCheck(target string, annotations map[string]string) (*elb.HealthCheck, error) {
+	healthcheck := &elb.HealthCheck{Target: &target}
+	getOrDefault := func(annotation string, defaultValue int64) (*int64, error) {
+		i64 := defaultValue
+		var err error
+		if s, ok := annotations[annotation]; ok {
+			i64, err = strconv.ParseInt(s, 10, 0)
+			if err != nil {
+				return nil, fmt.Errorf("failed parsing health check annotation value: %v", err)
+			}
+		}
+		return &i64, nil
+	}
+	var err error
+	healthcheck.HealthyThreshold, err = getOrDefault(ServiceAnnotationLoadBalancerHCHealthyThreshold, defaultHCHealthyThreshold)
+	if err != nil {
+		return nil, err
+	}
+	healthcheck.UnhealthyThreshold, err = getOrDefault(ServiceAnnotationLoadBalancerHCUnhealthyThreshold, defaultHCUnhealthyThreshold)
+	if err != nil {
+		return nil, err
+	}
+	healthcheck.Timeout, err = getOrDefault(ServiceAnnotationLoadBalancerHCTimeout, defaultHCTimeout)
+	if err != nil {
+		return nil, err
+	}
+	healthcheck.Interval, err = getOrDefault(ServiceAnnotationLoadBalancerHCInterval, defaultHCInterval)
+	if err != nil {
+		return nil, err
+	}
+	if err = healthcheck.Validate(); err != nil {
+		return nil, fmt.Errorf("some of the load balancer health check parameters are invalid: %v", err)
+	}
+	return healthcheck, nil
+}
+
+// Makes sure that the health check for an ELB matches the configured health check node port
+func (c *Cloud) ensureLoadBalancerHealthCheck(loadBalancer *elb.LoadBalancerDescription, protocol string, port int32, path string, annotations map[string]string) error {
+	name := aws.StringValue(loadBalancer.LoadBalancerName)
+
+	actual := loadBalancer.HealthCheck
+	expectedTarget := protocol + ":" + strconv.FormatInt(int64(port), 10) + path
+	expected, err := c.getExpectedHealthCheck(expectedTarget, annotations)
+	if err != nil {
+		return fmt.Errorf("cannot update health check for load balancer %q: %q", name, err)
+	}
+
+	// comparing attributes 1 by 1 to avoid breakage in case a new field is
+	// added to the HC which breaks the equality
+	if aws.StringValue(expected.Target) == aws.StringValue(actual.Target) &&
+		aws.Int64Value(expected.HealthyThreshold) == aws.Int64Value(actual.HealthyThreshold) &&
+		aws.Int64Value(expected.UnhealthyThreshold) == aws.Int64Value(actual.UnhealthyThreshold) &&
+		aws.Int64Value(expected.Interval) == aws.Int64Value(actual.Interval) &&
+		aws.Int64Value(expected.Timeout) == aws.Int64Value(actual.Timeout) {
+		return nil
+	}
+
+	request := &elb.ConfigureHealthCheckInput{}
+	request.HealthCheck = expected
+	request.LoadBalancerName = loadBalancer.LoadBalancerName
+
+	_, err = c.elb.ConfigureHealthCheck(request)
+	if err != nil {
+		return fmt.Errorf("error configuring load balancer health check for %q: %q", name, err)
+	}
+
+	return nil
+}
+
+// Makes sure that exactly the specified hosts are registered as instances with the load balancer
+func (c *Cloud) ensureLoadBalancerInstances(loadBalancerName string, lbInstances []*elb.Instance, instanceIDs map[awsInstanceID]*ec2.Instance) error {
+	expected := sets.NewString()
+	for id := range instanceIDs {
+		expected.Insert(string(id))
+	}
+
+	actual := sets.NewString()
+	for _, lbInstance := range lbInstances {
+		actual.Insert(aws.StringValue(lbInstance.InstanceId))
+	}
+
+	additions := expected.Difference(actual)
+	removals := actual.Difference(expected)
+
+	addInstances := []*elb.Instance{}
+	for _, instanceID := range additions.List() {
+		addInstance := &elb.Instance{}
+		addInstance.InstanceId = aws.String(instanceID)
+		addInstances = append(addInstances, addInstance)
+	}
+
+	removeInstances := []*elb.Instance{}
+	for _, instanceID := range removals.List() {
+		removeInstance := &elb.Instance{}
+		removeInstance.InstanceId = aws.String(instanceID)
+		removeInstances = append(removeInstances, removeInstance)
+	}
+
+	if len(addInstances) > 0 {
+		registerRequest := &elb.RegisterInstancesWithLoadBalancerInput{}
+		registerRequest.Instances = addInstances
+		registerRequest.LoadBalancerName = aws.String(loadBalancerName)
+		_, err := c.elb.RegisterInstancesWithLoadBalancer(registerRequest)
+		if err != nil {
+			return err
+		}
+		klog.V(1).Infof("Instances added to load-balancer %s", loadBalancerName)
+	}
+
+	if len(removeInstances) > 0 {
+		deregisterRequest := &elb.DeregisterInstancesFromLoadBalancerInput{}
+		deregisterRequest.Instances = removeInstances
+		deregisterRequest.LoadBalancerName = aws.String(loadBalancerName)
+		_, err := c.elb.DeregisterInstancesFromLoadBalancer(deregisterRequest)
+		if err != nil {
+			return err
+		}
+		klog.V(1).Infof("Instances removed from load-balancer %s", loadBalancerName)
+	}
+
+	return nil
+}
+
+func (c *Cloud) getLoadBalancerTLSPorts(loadBalancer *elb.LoadBalancerDescription) []int64 {
+	ports := []int64{}
+
+	for _, listenerDescription := range loadBalancer.ListenerDescriptions {
+		protocol := aws.StringValue(listenerDescription.Listener.Protocol)
+		if protocol == "SSL" || protocol == "HTTPS" {
+			ports = append(ports, aws.Int64Value(listenerDescription.Listener.LoadBalancerPort))
+		}
+	}
+	return ports
+}
+
+func (c *Cloud) ensureSSLNegotiationPolicy(loadBalancer *elb.LoadBalancerDescription, policyName string) error {
+	klog.V(2).Info("Describing load balancer policies on load balancer")
+	result, err := c.elb.DescribeLoadBalancerPolicies(&elb.DescribeLoadBalancerPoliciesInput{
+		LoadBalancerName: loadBalancer.LoadBalancerName,
+		PolicyNames: []*string{
+			aws.String(fmt.Sprintf(SSLNegotiationPolicyNameFormat, policyName)),
+		},
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case elb.ErrCodePolicyNotFoundException:
+			default:
+				return fmt.Errorf("error describing security policies on load balancer: %q", err)
+			}
+		}
+	}
+
+	if len(result.PolicyDescriptions) > 0 {
+		return nil
+	}
+
+	klog.V(2).Infof("Creating SSL negotiation policy '%s' on load balancer", fmt.Sprintf(SSLNegotiationPolicyNameFormat, policyName))
+	// there is an upper limit of 98 policies on an ELB, we're pretty safe from
+	// running into it
+	_, err = c.elb.CreateLoadBalancerPolicy(&elb.CreateLoadBalancerPolicyInput{
+		LoadBalancerName: loadBalancer.LoadBalancerName,
+		PolicyName:       aws.String(fmt.Sprintf(SSLNegotiationPolicyNameFormat, policyName)),
+		PolicyTypeName:   aws.String("SSLNegotiationPolicyType"),
+		PolicyAttributes: []*elb.PolicyAttribute{
+			{
+				AttributeName:  aws.String("Reference-Security-Policy"),
+				AttributeValue: aws.String(policyName),
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error creating security policy on load balancer: %q", err)
+	}
+	return nil
+}
+
+func (c *Cloud) setSSLNegotiationPolicy(loadBalancerName, sslPolicyName string, port int64) error {
+	policyName := fmt.Sprintf(SSLNegotiationPolicyNameFormat, sslPolicyName)
+	request := &elb.SetLoadBalancerPoliciesOfListenerInput{
+		LoadBalancerName: aws.String(loadBalancerName),
+		LoadBalancerPort: aws.Int64(port),
+		PolicyNames: []*string{
+			aws.String(policyName),
+		},
+	}
+	klog.V(2).Infof("Setting SSL negotiation policy '%s' on load balancer", policyName)
+	_, err := c.elb.SetLoadBalancerPoliciesOfListener(request)
+	if err != nil {
+		return fmt.Errorf("error setting SSL negotiation policy '%s' on load balancer: %q", policyName, err)
+	}
+	return nil
+}
+
+func (c *Cloud) createProxyProtocolPolicy(loadBalancerName string) error {
+	request := &elb.CreateLoadBalancerPolicyInput{
+		LoadBalancerName: aws.String(loadBalancerName),
+		PolicyName:       aws.String(ProxyProtocolPolicyName),
+		PolicyTypeName:   aws.String("ProxyProtocolPolicyType"),
+		PolicyAttributes: []*elb.PolicyAttribute{
+			{
+				AttributeName:  aws.String("ProxyProtocol"),
+				AttributeValue: aws.String("true"),
+			},
+		},
+	}
+	klog.V(2).Info("Creating proxy protocol policy on load balancer")
+	_, err := c.elb.CreateLoadBalancerPolicy(request)
+	if err != nil {
+		return fmt.Errorf("error creating proxy protocol policy on load balancer: %q", err)
+	}
+
+	return nil
+}
+
+func (c *Cloud) setBackendPolicies(loadBalancerName string, instancePort int64, policies []*string) error {
+	request := &elb.SetLoadBalancerPoliciesForBackendServerInput{
+		InstancePort:     aws.Int64(instancePort),
+		LoadBalancerName: aws.String(loadBalancerName),
+		PolicyNames:      policies,
+	}
+	if len(policies) > 0 {
+		klog.V(2).Infof("Adding AWS loadbalancer backend policies on node port %d", instancePort)
+	} else {
+		klog.V(2).Infof("Removing AWS loadbalancer backend policies on node port %d", instancePort)
+	}
+	_, err := c.elb.SetLoadBalancerPoliciesForBackendServer(request)
+	if err != nil {
+		return fmt.Errorf("error adjusting AWS loadbalancer backend policies: %q", err)
+	}
+
+	return nil
+}
+
+func proxyProtocolEnabled(backend *elb.BackendServerDescription) bool {
+	for _, policy := range backend.PolicyNames {
+		if aws.StringValue(policy) == ProxyProtocolPolicyName {
+			return true
+		}
+	}
+
+	return false
+}
+
+// findInstancesForELB gets the EC2 instances corresponding to the Nodes, for setting up an ELB
+// We ignore Nodes (with a log message) where the instanceid cannot be determined from the provider,
+// and we ignore instances which are not found
+func (c *Cloud) findInstancesForELB(nodes []*v1.Node) (map[awsInstanceID]*ec2.Instance, error) {
+	// Map to instance ids ignoring Nodes where we cannot find the id (but logging)
+	instanceIDs := mapToAWSInstanceIDsTolerant(nodes)
+
+	cacheCriteria := cacheCriteria{
+		// MaxAge not required, because we only care about security groups, which should not change
+		HasInstances: instanceIDs, // Refresh if any of the instance ids are missing
+	}
+	snapshot, err := c.instanceCache.describeAllInstancesCached(cacheCriteria)
+	if err != nil {
+		return nil, err
+	}
+
+	instances := snapshot.FindInstances(instanceIDs)
+	// We ignore instances that cannot be found
+
+	return instances, nil
+}

--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func TestElbProtocolsAreEqual(t *testing.T) {
+	grid := []struct {
+		L        *string
+		R        *string
+		Expected bool
+	}{
+		{
+			L:        aws.String("http"),
+			R:        aws.String("http"),
+			Expected: true,
+		},
+		{
+			L:        aws.String("HTTP"),
+			R:        aws.String("http"),
+			Expected: true,
+		},
+		{
+			L:        aws.String("HTTP"),
+			R:        aws.String("TCP"),
+			Expected: false,
+		},
+		{
+			L:        aws.String(""),
+			R:        aws.String("TCP"),
+			Expected: false,
+		},
+		{
+			L:        aws.String(""),
+			R:        aws.String(""),
+			Expected: true,
+		},
+		{
+			L:        nil,
+			R:        aws.String(""),
+			Expected: false,
+		},
+		{
+			L:        aws.String(""),
+			R:        nil,
+			Expected: false,
+		},
+		{
+			L:        nil,
+			R:        nil,
+			Expected: true,
+		},
+	}
+	for _, g := range grid {
+		actual := elbProtocolsAreEqual(g.L, g.R)
+		if actual != g.Expected {
+			t.Errorf("unexpected result from protocolsEquals(%v, %v)", g.L, g.R)
+		}
+	}
+}
+
+func TestAWSARNEquals(t *testing.T) {
+	grid := []struct {
+		L        *string
+		R        *string
+		Expected bool
+	}{
+		{
+			L:        aws.String("arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"),
+			R:        aws.String("arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"),
+			Expected: true,
+		},
+		{
+			L:        aws.String("ARN:AWS:ACM:US-EAST-1:123456789012:CERTIFICATE/12345678-1234-1234-1234-123456789012"),
+			R:        aws.String("arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"),
+			Expected: true,
+		},
+		{
+			L:        aws.String("arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"),
+			R:        aws.String(""),
+			Expected: false,
+		},
+		{
+			L:        aws.String(""),
+			R:        aws.String(""),
+			Expected: true,
+		},
+		{
+			L:        nil,
+			R:        aws.String(""),
+			Expected: false,
+		},
+		{
+			L:        aws.String(""),
+			R:        nil,
+			Expected: false,
+		},
+		{
+			L:        nil,
+			R:        nil,
+			Expected: true,
+		},
+	}
+	for _, g := range grid {
+		actual := awsArnEquals(g.L, g.R)
+		if actual != g.Expected {
+			t.Errorf("unexpected result from awsArnEquals(%v, %v)", g.L, g.R)
+		}
+	}
+}
+
+func TestIsNLB(t *testing.T) {
+	tests := []struct {
+		name string
+
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			"NLB annotation provided",
+			map[string]string{"service.beta.kubernetes.io/aws-load-balancer-type": "nlb"},
+			true,
+		},
+		{
+			"NLB annotation has invalid value",
+			map[string]string{"service.beta.kubernetes.io/aws-load-balancer-type": "elb"},
+			false,
+		},
+		{
+			"NLB annotation absent",
+			map[string]string{},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Running test case %s", test.name)
+		got := isNLB(test.annotations)
+
+		if got != test.want {
+			t.Errorf("Incorrect value for isNLB() case %s. Got %t, expected %t.", test.name, got, test.want)
+		}
+	}
+}

--- a/pkg/cloudprovider/providers/aws/aws_metrics.go
+++ b/pkg/cloudprovider/providers/aws/aws_metrics.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	awsAPIMetric = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "cloudprovider_aws_api_request_duration_seconds",
+			Help: "Latency of AWS API calls",
+		},
+		[]string{"request"})
+
+	awsAPIErrorMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cloudprovider_aws_api_request_errors",
+			Help: "AWS API errors",
+		},
+		[]string{"request"})
+
+	awsAPIThrottlesMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cloudprovider_aws_api_throttled_requests_total",
+			Help: "AWS API throttled requests",
+		},
+		[]string{"operation_name"})
+)
+
+func recordAWSMetric(actionName string, timeTaken float64, err error) {
+	if err != nil {
+		awsAPIErrorMetric.With(prometheus.Labels{"request": actionName}).Inc()
+	} else {
+		awsAPIMetric.With(prometheus.Labels{"request": actionName}).Observe(timeTaken)
+	}
+}
+
+func recordAWSThrottlesMetric(operation string) {
+	awsAPIThrottlesMetric.With(prometheus.Labels{"operation_name": operation}).Inc()
+}
+
+func registerMetrics() {
+	prometheus.MustRegister(awsAPIMetric)
+	prometheus.MustRegister(awsAPIErrorMetric)
+	prometheus.MustRegister(awsAPIThrottlesMetric)
+}

--- a/pkg/cloudprovider/providers/aws/aws_routes.go
+++ b/pkg/cloudprovider/providers/aws/aws_routes.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/klog"
+
+	cloudprovider "k8s.io/cloud-provider"
+)
+
+func (c *Cloud) findRouteTable(clusterName string) (*ec2.RouteTable, error) {
+	// This should be unnecessary (we already filter on TagNameKubernetesCluster,
+	// and something is broken if cluster name doesn't match, but anyway...
+	// TODO: All clouds should be cluster-aware by default
+	var tables []*ec2.RouteTable
+
+	if c.cfg.Global.RouteTableID != "" {
+		request := &ec2.DescribeRouteTablesInput{Filters: []*ec2.Filter{newEc2Filter("route-table-id", c.cfg.Global.RouteTableID)}}
+		response, err := c.ec2.DescribeRouteTables(request)
+		if err != nil {
+			return nil, err
+		}
+
+		tables = response
+	} else {
+		request := &ec2.DescribeRouteTablesInput{Filters: c.tagging.addFilters(nil)}
+		response, err := c.ec2.DescribeRouteTables(request)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, table := range response {
+			if c.tagging.hasClusterTag(table.Tags) {
+				tables = append(tables, table)
+			}
+		}
+	}
+
+	if len(tables) == 0 {
+		return nil, fmt.Errorf("unable to find route table for AWS cluster: %s", clusterName)
+	}
+
+	if len(tables) != 1 {
+		return nil, fmt.Errorf("found multiple matching AWS route tables for AWS cluster: %s", clusterName)
+	}
+	return tables[0], nil
+}
+
+// ListRoutes implements Routes.ListRoutes
+// List all routes that match the filter
+func (c *Cloud) ListRoutes(ctx context.Context, clusterName string) ([]*cloudprovider.Route, error) {
+	table, err := c.findRouteTable(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	var routes []*cloudprovider.Route
+	var instanceIDs []*string
+
+	for _, r := range table.Routes {
+		instanceID := aws.StringValue(r.InstanceId)
+
+		if instanceID == "" {
+			continue
+		}
+
+		instanceIDs = append(instanceIDs, &instanceID)
+	}
+
+	instances, err := c.getInstancesByIDs(instanceIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range table.Routes {
+		destinationCIDR := aws.StringValue(r.DestinationCidrBlock)
+		if destinationCIDR == "" {
+			continue
+		}
+
+		route := &cloudprovider.Route{
+			Name:            clusterName + "-" + destinationCIDR,
+			DestinationCIDR: destinationCIDR,
+		}
+
+		// Capture blackhole routes
+		if aws.StringValue(r.State) == ec2.RouteStateBlackhole {
+			route.Blackhole = true
+			routes = append(routes, route)
+			continue
+		}
+
+		// Capture instance routes
+		instanceID := aws.StringValue(r.InstanceId)
+		if instanceID != "" {
+			instance, found := instances[instanceID]
+			if found {
+				route.TargetNode = mapInstanceToNodeName(instance)
+				routes = append(routes, route)
+			} else {
+				klog.Warningf("unable to find instance ID %s in the list of instances being routed to", instanceID)
+			}
+		}
+	}
+
+	return routes, nil
+}
+
+// Sets the instance attribute "source-dest-check" to the specified value
+func (c *Cloud) configureInstanceSourceDestCheck(instanceID string, sourceDestCheck bool) error {
+	request := &ec2.ModifyInstanceAttributeInput{}
+	request.InstanceId = aws.String(instanceID)
+	request.SourceDestCheck = &ec2.AttributeBooleanValue{Value: aws.Bool(sourceDestCheck)}
+
+	_, err := c.ec2.ModifyInstanceAttribute(request)
+	if err != nil {
+		return fmt.Errorf("error configuring source-dest-check on instance %s: %q", instanceID, err)
+	}
+	return nil
+}
+
+// CreateRoute implements Routes.CreateRoute
+// Create the described route
+func (c *Cloud) CreateRoute(ctx context.Context, clusterName string, nameHint string, route *cloudprovider.Route) error {
+	instance, err := c.getInstanceByNodeName(route.TargetNode)
+	if err != nil {
+		return err
+	}
+
+	// In addition to configuring the route itself, we also need to configure the instance to accept that traffic
+	// On AWS, this requires turning source-dest checks off
+	err = c.configureInstanceSourceDestCheck(aws.StringValue(instance.InstanceId), false)
+	if err != nil {
+		return err
+	}
+
+	table, err := c.findRouteTable(clusterName)
+	if err != nil {
+		return err
+	}
+
+	var deleteRoute *ec2.Route
+	for _, r := range table.Routes {
+		destinationCIDR := aws.StringValue(r.DestinationCidrBlock)
+
+		if destinationCIDR != route.DestinationCIDR {
+			continue
+		}
+
+		if aws.StringValue(r.State) == ec2.RouteStateBlackhole {
+			deleteRoute = r
+		}
+	}
+
+	if deleteRoute != nil {
+		klog.Infof("deleting blackholed route: %s", aws.StringValue(deleteRoute.DestinationCidrBlock))
+
+		request := &ec2.DeleteRouteInput{}
+		request.DestinationCidrBlock = deleteRoute.DestinationCidrBlock
+		request.RouteTableId = table.RouteTableId
+
+		_, err = c.ec2.DeleteRoute(request)
+		if err != nil {
+			return fmt.Errorf("error deleting blackholed AWS route (%s): %q", aws.StringValue(deleteRoute.DestinationCidrBlock), err)
+		}
+	}
+
+	request := &ec2.CreateRouteInput{}
+	// TODO: use ClientToken for idempotency?
+	request.DestinationCidrBlock = aws.String(route.DestinationCIDR)
+	request.InstanceId = instance.InstanceId
+	request.RouteTableId = table.RouteTableId
+
+	_, err = c.ec2.CreateRoute(request)
+	if err != nil {
+		return fmt.Errorf("error creating AWS route (%s): %q", route.DestinationCIDR, err)
+	}
+
+	return nil
+}
+
+// DeleteRoute implements Routes.DeleteRoute
+// Delete the specified route
+func (c *Cloud) DeleteRoute(ctx context.Context, clusterName string, route *cloudprovider.Route) error {
+	table, err := c.findRouteTable(clusterName)
+	if err != nil {
+		return err
+	}
+
+	request := &ec2.DeleteRouteInput{}
+	request.DestinationCidrBlock = aws.String(route.DestinationCIDR)
+	request.RouteTableId = table.RouteTableId
+
+	_, err = c.ec2.DeleteRoute(request)
+	if err != nil {
+		return fmt.Errorf("error deleting AWS route (%s): %q", route.DestinationCIDR, err)
+	}
+
+	return nil
+}

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -1,0 +1,1438 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
+)
+
+const TestClusterID = "clusterid.test"
+const TestClusterName = "testCluster"
+
+type MockedFakeEC2 struct {
+	*FakeEC2Impl
+	mock.Mock
+}
+
+func (m *MockedFakeEC2) expectDescribeSecurityGroups(clusterID, groupName string) {
+	tags := []*ec2.Tag{
+		{Key: aws.String(TagNameKubernetesClusterLegacy), Value: aws.String(clusterID)},
+		{Key: aws.String(fmt.Sprintf("%s%s", TagNameKubernetesClusterPrefix, clusterID)), Value: aws.String(ResourceLifecycleOwned)},
+	}
+
+	m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{Filters: []*ec2.Filter{
+		newEc2Filter("group-name", groupName),
+		newEc2Filter("vpc-id", ""),
+	}}).Return([]*ec2.SecurityGroup{{Tags: tags}})
+}
+
+func (m *MockedFakeEC2) DescribeVolumes(request *ec2.DescribeVolumesInput) ([]*ec2.Volume, error) {
+	args := m.Called(request)
+	return args.Get(0).([]*ec2.Volume), nil
+}
+
+func (m *MockedFakeEC2) DescribeSecurityGroups(request *ec2.DescribeSecurityGroupsInput) ([]*ec2.SecurityGroup, error) {
+	args := m.Called(request)
+	return args.Get(0).([]*ec2.SecurityGroup), nil
+}
+
+func (m *MockedFakeEC2) CreateVolume(request *ec2.CreateVolumeInput) (*ec2.Volume, error) {
+	args := m.Called(request)
+	return args.Get(0).(*ec2.Volume), nil
+}
+
+type MockedFakeELB struct {
+	*FakeELB
+	mock.Mock
+}
+
+func (m *MockedFakeELB) DescribeLoadBalancers(input *elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*elb.DescribeLoadBalancersOutput), nil
+}
+
+func (m *MockedFakeELB) expectDescribeLoadBalancers(loadBalancerName string) {
+	m.On("DescribeLoadBalancers", &elb.DescribeLoadBalancersInput{LoadBalancerNames: []*string{aws.String(loadBalancerName)}}).Return(&elb.DescribeLoadBalancersOutput{
+		LoadBalancerDescriptions: []*elb.LoadBalancerDescription{{}},
+	})
+}
+
+func (m *MockedFakeELB) AddTags(input *elb.AddTagsInput) (*elb.AddTagsOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*elb.AddTagsOutput), nil
+}
+
+func (m *MockedFakeELB) ConfigureHealthCheck(input *elb.ConfigureHealthCheckInput) (*elb.ConfigureHealthCheckOutput, error) {
+	args := m.Called(input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*elb.ConfigureHealthCheckOutput), args.Error(1)
+}
+
+func (m *MockedFakeELB) expectConfigureHealthCheck(loadBalancerName *string, expectedHC *elb.HealthCheck, returnErr error) {
+	expected := &elb.ConfigureHealthCheckInput{HealthCheck: expectedHC, LoadBalancerName: loadBalancerName}
+	call := m.On("ConfigureHealthCheck", expected)
+	if returnErr != nil {
+		call.Return(nil, returnErr)
+	} else {
+		call.Return(&elb.ConfigureHealthCheckOutput{}, nil)
+	}
+}
+
+func TestReadAWSCloudConfig(t *testing.T) {
+	tests := []struct {
+		name string
+
+		reader io.Reader
+		aws    Services
+
+		expectError bool
+		zone        string
+	}{
+		{
+			"No config reader",
+			nil, nil,
+			true, "",
+		},
+		{
+			"Empty config, no metadata",
+			strings.NewReader(""), nil,
+			true, "",
+		},
+		{
+			"No zone in config, no metadata",
+			strings.NewReader("[global]\n"), nil,
+			true, "",
+		},
+		{
+			"Zone in config, no metadata",
+			strings.NewReader("[global]\nzone = eu-west-1a"), nil,
+			false, "eu-west-1a",
+		},
+		{
+			"No zone in config, metadata does not have zone",
+			strings.NewReader("[global]\n"), newMockedFakeAWSServices(TestClusterID).WithAz(""),
+			true, "",
+		},
+		{
+			"No zone in config, metadata has zone",
+			strings.NewReader("[global]\n"), newMockedFakeAWSServices(TestClusterID),
+			false, "us-east-1a",
+		},
+		{
+			"Zone in config should take precedence over metadata",
+			strings.NewReader("[global]\nzone = eu-west-1a"), newMockedFakeAWSServices(TestClusterID),
+			false, "eu-west-1a",
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Running test case %s", test.name)
+		var metadata EC2Metadata
+		if test.aws != nil {
+			metadata, _ = test.aws.Metadata()
+		}
+		cfg, err := readAWSCloudConfig(test.reader)
+		if err == nil {
+			err = updateConfigZone(cfg, metadata)
+		}
+		if test.expectError {
+			if err == nil {
+				t.Errorf("Should error for case %s (cfg=%v)", test.name, cfg)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Should succeed for case: %s", test.name)
+			}
+			if cfg.Global.Zone != test.zone {
+				t.Errorf("Incorrect zone value (%s vs %s) for case: %s",
+					cfg.Global.Zone, test.zone, test.name)
+			}
+		}
+	}
+}
+
+func TestNewAWSCloud(t *testing.T) {
+	tests := []struct {
+		name string
+
+		reader      io.Reader
+		awsServices Services
+
+		expectError bool
+		region      string
+	}{
+		{
+			"No config reader",
+			nil, newMockedFakeAWSServices(TestClusterID).WithAz(""),
+			true, "",
+		},
+		{
+			"Config specifies valid zone",
+			strings.NewReader("[global]\nzone = eu-west-1a"), newMockedFakeAWSServices(TestClusterID),
+			false, "eu-west-1",
+		},
+		{
+			"Gets zone from metadata when not in config",
+			strings.NewReader("[global]\n"),
+			newMockedFakeAWSServices(TestClusterID),
+			false, "us-east-1",
+		},
+		{
+			"No zone in config or metadata",
+			strings.NewReader("[global]\n"),
+			newMockedFakeAWSServices(TestClusterID).WithAz(""),
+			true, "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Running test case %s", test.name)
+		cfg, err := readAWSCloudConfig(test.reader)
+		var c *Cloud
+		if err == nil {
+			c, err = newAWSCloud(*cfg, test.awsServices)
+		}
+		if test.expectError {
+			if err == nil {
+				t.Errorf("Should error for case %s", test.name)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Should succeed for case: %s, got %v", test.name, err)
+			} else if c.region != test.region {
+				t.Errorf("Incorrect region value (%s vs %s) for case: %s",
+					c.region, test.region, test.name)
+			}
+		}
+	}
+}
+
+func mockInstancesResp(selfInstance *ec2.Instance, instances []*ec2.Instance) (*Cloud, *FakeAWSServices) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	awsServices.instances = instances
+	awsServices.selfInstance = selfInstance
+	awsCloud, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		panic(err)
+	}
+	return awsCloud, awsServices
+}
+
+func mockAvailabilityZone(availabilityZone string) *Cloud {
+	awsServices := newMockedFakeAWSServices(TestClusterID).WithAz(availabilityZone)
+	awsCloud, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		panic(err)
+	}
+	return awsCloud
+}
+
+func testHasNodeAddress(t *testing.T, addrs []v1.NodeAddress, addressType v1.NodeAddressType, address string) {
+	for _, addr := range addrs {
+		if addr.Type == addressType && addr.Address == address {
+			return
+		}
+	}
+	t.Errorf("Did not find expected address: %s:%s in %v", addressType, address, addrs)
+}
+
+func TestNodeAddresses(t *testing.T) {
+	// Note these instances have the same name
+	// (we test that this produces an error)
+	var instance0 ec2.Instance
+	var instance1 ec2.Instance
+	var instance2 ec2.Instance
+
+	// ClusterID needs to be set
+	var tag ec2.Tag
+	tag.Key = aws.String(TagNameKubernetesClusterLegacy)
+	tag.Value = aws.String(TestClusterID)
+	tags := []*ec2.Tag{&tag}
+
+	//0
+	instance0.InstanceId = aws.String("i-0")
+	instance0.PrivateDnsName = aws.String("instance-same.ec2.internal")
+	instance0.PrivateIpAddress = aws.String("192.168.0.1")
+	instance0.PublicDnsName = aws.String("instance-same.ec2.external")
+	instance0.PublicIpAddress = aws.String("1.2.3.4")
+	instance0.NetworkInterfaces = []*ec2.InstanceNetworkInterface{
+		{
+			Status: aws.String(ec2.NetworkInterfaceStatusInUse),
+			PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
+				{
+					PrivateIpAddress: aws.String("192.168.0.1"),
+				},
+			},
+		},
+	}
+	instance0.InstanceType = aws.String("c3.large")
+	instance0.Placement = &ec2.Placement{AvailabilityZone: aws.String("us-east-1a")}
+	instance0.Tags = tags
+	state0 := ec2.InstanceState{
+		Name: aws.String("running"),
+	}
+	instance0.State = &state0
+
+	//1
+	instance1.InstanceId = aws.String("i-1")
+	instance1.PrivateDnsName = aws.String("instance-same.ec2.internal")
+	instance1.PrivateIpAddress = aws.String("192.168.0.2")
+	instance1.InstanceType = aws.String("c3.large")
+	instance1.Placement = &ec2.Placement{AvailabilityZone: aws.String("us-east-1a")}
+	instance1.Tags = tags
+	state1 := ec2.InstanceState{
+		Name: aws.String("running"),
+	}
+	instance1.State = &state1
+
+	//2
+	instance2.InstanceId = aws.String("i-2")
+	instance2.PrivateDnsName = aws.String("instance-other.ec2.internal")
+	instance2.PrivateIpAddress = aws.String("192.168.0.1")
+	instance2.PublicIpAddress = aws.String("1.2.3.4")
+	instance2.InstanceType = aws.String("c3.large")
+	instance2.Placement = &ec2.Placement{AvailabilityZone: aws.String("us-east-1a")}
+	instance2.Tags = tags
+	state2 := ec2.InstanceState{
+		Name: aws.String("running"),
+	}
+	instance2.State = &state2
+
+	instances := []*ec2.Instance{&instance0, &instance1, &instance2}
+
+	aws1, _ := mockInstancesResp(&instance0, []*ec2.Instance{&instance0})
+	_, err1 := aws1.NodeAddresses(context.TODO(), "instance-mismatch.ec2.internal")
+	if err1 == nil {
+		t.Errorf("Should error when no instance found")
+	}
+
+	aws2, _ := mockInstancesResp(&instance2, instances)
+	_, err2 := aws2.NodeAddresses(context.TODO(), "instance-same.ec2.internal")
+	if err2 == nil {
+		t.Errorf("Should error when multiple instances found")
+	}
+
+	aws3, _ := mockInstancesResp(&instance0, instances[0:1])
+	// change node name so it uses the instance instead of metadata
+	aws3.selfAWSInstance.nodeName = "foo"
+	addrs3, err3 := aws3.NodeAddresses(context.TODO(), "instance-same.ec2.internal")
+	if err3 != nil {
+		t.Errorf("Should not error when instance found")
+	}
+	if len(addrs3) != 5 {
+		t.Errorf("Should return exactly 5 NodeAddresses")
+	}
+	testHasNodeAddress(t, addrs3, v1.NodeInternalIP, "192.168.0.1")
+	testHasNodeAddress(t, addrs3, v1.NodeExternalIP, "1.2.3.4")
+	testHasNodeAddress(t, addrs3, v1.NodeExternalDNS, "instance-same.ec2.external")
+	testHasNodeAddress(t, addrs3, v1.NodeInternalDNS, "instance-same.ec2.internal")
+	testHasNodeAddress(t, addrs3, v1.NodeHostName, "instance-same.ec2.internal")
+}
+
+func TestNodeAddressesWithMetadata(t *testing.T) {
+	var instance ec2.Instance
+
+	// ClusterID needs to be set
+	var tag ec2.Tag
+	tag.Key = aws.String(TagNameKubernetesClusterLegacy)
+	tag.Value = aws.String(TestClusterID)
+	tags := []*ec2.Tag{&tag}
+
+	instanceName := "instance.ec2.internal"
+	instance.InstanceId = aws.String("i-0")
+	instance.PrivateDnsName = &instanceName
+	instance.PublicIpAddress = aws.String("2.3.4.5")
+	instance.InstanceType = aws.String("c3.large")
+	instance.Placement = &ec2.Placement{AvailabilityZone: aws.String("us-east-1a")}
+	instance.Tags = tags
+	state := ec2.InstanceState{
+		Name: aws.String("running"),
+	}
+	instance.State = &state
+
+	instances := []*ec2.Instance{&instance}
+	awsCloud, awsServices := mockInstancesResp(&instance, instances)
+
+	awsServices.networkInterfacesMacs = []string{"0a:26:89:f3:9c:f6", "0a:77:64:c4:6a:48"}
+	awsServices.networkInterfacesPrivateIPs = [][]string{{"192.168.0.1"}, {"192.168.0.2"}}
+	addrs, err := awsCloud.NodeAddresses(context.TODO(), "")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "192.168.0.1")
+	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "192.168.0.2")
+	testHasNodeAddress(t, addrs, v1.NodeExternalIP, "2.3.4.5")
+}
+
+func TestGetRegion(t *testing.T) {
+	aws := mockAvailabilityZone("us-west-2e")
+	zones, ok := aws.Zones()
+	if !ok {
+		t.Fatalf("Unexpected missing zones impl")
+	}
+	zone, err := zones.GetZone(context.TODO())
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if zone.Region != "us-west-2" {
+		t.Errorf("Unexpected region: %s", zone.Region)
+	}
+	if zone.FailureDomain != "us-west-2e" {
+		t.Errorf("Unexpected FailureDomain: %s", zone.FailureDomain)
+	}
+}
+
+func TestFindVPCID(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+	vpcID, err := c.findVPCID()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if vpcID != "vpc-mac0" {
+		t.Errorf("Unexpected vpcID: %s", vpcID)
+	}
+}
+
+func constructSubnets(subnetsIn map[int]map[string]string) (subnetsOut []*ec2.Subnet) {
+	for i := range subnetsIn {
+		subnetsOut = append(
+			subnetsOut,
+			constructSubnet(
+				subnetsIn[i]["id"],
+				subnetsIn[i]["az"],
+			),
+		)
+	}
+	return
+}
+
+func constructSubnet(id string, az string) *ec2.Subnet {
+	return &ec2.Subnet{
+		SubnetId:         &id,
+		AvailabilityZone: &az,
+	}
+}
+
+func constructRouteTables(routeTablesIn map[string]bool) (routeTablesOut []*ec2.RouteTable) {
+	routeTablesOut = append(routeTablesOut,
+		&ec2.RouteTable{
+			Associations: []*ec2.RouteTableAssociation{{Main: aws.Bool(true)}},
+			Routes: []*ec2.Route{{
+				DestinationCidrBlock: aws.String("0.0.0.0/0"),
+				GatewayId:            aws.String("igw-main"),
+			}},
+		})
+
+	for subnetID := range routeTablesIn {
+		routeTablesOut = append(
+			routeTablesOut,
+			constructRouteTable(
+				subnetID,
+				routeTablesIn[subnetID],
+			),
+		)
+	}
+	return
+}
+
+func constructRouteTable(subnetID string, public bool) *ec2.RouteTable {
+	var gatewayID string
+	if public {
+		gatewayID = "igw-" + subnetID[len(subnetID)-8:8]
+	} else {
+		gatewayID = "vgw-" + subnetID[len(subnetID)-8:8]
+	}
+	return &ec2.RouteTable{
+		Associations: []*ec2.RouteTableAssociation{{SubnetId: aws.String(subnetID)}},
+		Routes: []*ec2.Route{{
+			DestinationCidrBlock: aws.String("0.0.0.0/0"),
+			GatewayId:            aws.String(gatewayID),
+		}},
+	}
+}
+
+func TestSubnetIDsinVPC(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+
+	// test with 3 subnets from 3 different AZs
+	subnets := make(map[int]map[string]string)
+	subnets[0] = make(map[string]string)
+	subnets[0]["id"] = "subnet-a0000001"
+	subnets[0]["az"] = "af-south-1a"
+	subnets[1] = make(map[string]string)
+	subnets[1]["id"] = "subnet-b0000001"
+	subnets[1]["az"] = "af-south-1b"
+	subnets[2] = make(map[string]string)
+	subnets[2]["id"] = "subnet-c0000001"
+	subnets[2]["az"] = "af-south-1c"
+	constructedSubnets := constructSubnets(subnets)
+	awsServices.ec2.RemoveSubnets()
+	for _, subnet := range constructedSubnets {
+		awsServices.ec2.CreateSubnet(subnet)
+	}
+
+	routeTables := map[string]bool{
+		"subnet-a0000001": true,
+		"subnet-b0000001": true,
+		"subnet-c0000001": true,
+	}
+	constructedRouteTables := constructRouteTables(routeTables)
+	awsServices.ec2.RemoveRouteTables()
+	for _, rt := range constructedRouteTables {
+		awsServices.ec2.CreateRouteTable(rt)
+	}
+
+	result, err := c.findELBSubnets(false)
+	if err != nil {
+		t.Errorf("Error listing subnets: %v", err)
+		return
+	}
+
+	if len(result) != 3 {
+		t.Errorf("Expected 3 subnets but got %d", len(result))
+		return
+	}
+
+	resultSet := make(map[string]bool)
+	for _, v := range result {
+		resultSet[v] = true
+	}
+
+	for i := range subnets {
+		if !resultSet[subnets[i]["id"]] {
+			t.Errorf("Expected subnet%d '%s' in result: %v", i, subnets[i]["id"], result)
+			return
+		}
+	}
+
+	// test implicit routing table - when subnets are not explicitly linked to a table they should use main
+	constructedRouteTables = constructRouteTables(map[string]bool{})
+	awsServices.ec2.RemoveRouteTables()
+	for _, rt := range constructedRouteTables {
+		awsServices.ec2.CreateRouteTable(rt)
+	}
+
+	result, err = c.findELBSubnets(false)
+	if err != nil {
+		t.Errorf("Error listing subnets: %v", err)
+		return
+	}
+
+	if len(result) != 3 {
+		t.Errorf("Expected 3 subnets but got %d", len(result))
+		return
+	}
+
+	resultSet = make(map[string]bool)
+	for _, v := range result {
+		resultSet[v] = true
+	}
+
+	for i := range subnets {
+		if !resultSet[subnets[i]["id"]] {
+			t.Errorf("Expected subnet%d '%s' in result: %v", i, subnets[i]["id"], result)
+			return
+		}
+	}
+
+	// Test with 5 subnets from 3 different AZs.
+	// Add 2 duplicate AZ subnets lexicographically chosen one is the middle element in array to
+	// check that we both choose the correct entry when it comes after and before another element
+	// in the same AZ.
+	subnets[3] = make(map[string]string)
+	subnets[3]["id"] = "subnet-c0000000"
+	subnets[3]["az"] = "af-south-1c"
+	subnets[4] = make(map[string]string)
+	subnets[4]["id"] = "subnet-c0000002"
+	subnets[4]["az"] = "af-south-1c"
+	constructedSubnets = constructSubnets(subnets)
+	awsServices.ec2.RemoveSubnets()
+	for _, subnet := range constructedSubnets {
+		awsServices.ec2.CreateSubnet(subnet)
+	}
+	routeTables["subnet-c0000000"] = true
+	routeTables["subnet-c0000002"] = true
+	constructedRouteTables = constructRouteTables(routeTables)
+	awsServices.ec2.RemoveRouteTables()
+	for _, rt := range constructedRouteTables {
+		awsServices.ec2.CreateRouteTable(rt)
+	}
+
+	result, err = c.findELBSubnets(false)
+	if err != nil {
+		t.Errorf("Error listing subnets: %v", err)
+		return
+	}
+
+	if len(result) != 3 {
+		t.Errorf("Expected 3 subnets but got %d", len(result))
+		return
+	}
+
+	expected := []*string{aws.String("subnet-a0000001"), aws.String("subnet-b0000001"), aws.String("subnet-c0000000")}
+	for _, s := range result {
+		if !contains(expected, s) {
+			t.Errorf("Unexpected subnet '%s' found", s)
+			return
+		}
+	}
+
+	delete(routeTables, "subnet-c0000002")
+
+	// test with 6 subnets from 3 different AZs
+	// with 3 private subnets
+	subnets[4] = make(map[string]string)
+	subnets[4]["id"] = "subnet-d0000001"
+	subnets[4]["az"] = "af-south-1a"
+	subnets[5] = make(map[string]string)
+	subnets[5]["id"] = "subnet-d0000002"
+	subnets[5]["az"] = "af-south-1b"
+
+	constructedSubnets = constructSubnets(subnets)
+	awsServices.ec2.RemoveSubnets()
+	for _, subnet := range constructedSubnets {
+		awsServices.ec2.CreateSubnet(subnet)
+	}
+
+	routeTables["subnet-a0000001"] = false
+	routeTables["subnet-b0000001"] = false
+	routeTables["subnet-c0000001"] = false
+	routeTables["subnet-c0000000"] = true
+	routeTables["subnet-d0000001"] = true
+	routeTables["subnet-d0000002"] = true
+	constructedRouteTables = constructRouteTables(routeTables)
+	awsServices.ec2.RemoveRouteTables()
+	for _, rt := range constructedRouteTables {
+		awsServices.ec2.CreateRouteTable(rt)
+	}
+	result, err = c.findELBSubnets(false)
+	if err != nil {
+		t.Errorf("Error listing subnets: %v", err)
+		return
+	}
+
+	if len(result) != 3 {
+		t.Errorf("Expected 3 subnets but got %d", len(result))
+		return
+	}
+
+	expected = []*string{aws.String("subnet-c0000000"), aws.String("subnet-d0000001"), aws.String("subnet-d0000002")}
+	for _, s := range result {
+		if !contains(expected, s) {
+			t.Errorf("Unexpected subnet '%s' found", s)
+			return
+		}
+	}
+}
+
+func TestIpPermissionExistsHandlesMultipleGroupIds(t *testing.T) {
+	oldIPPermission := ec2.IpPermission{
+		UserIdGroupPairs: []*ec2.UserIdGroupPair{
+			{GroupId: aws.String("firstGroupId")},
+			{GroupId: aws.String("secondGroupId")},
+			{GroupId: aws.String("thirdGroupId")},
+		},
+	}
+
+	existingIPPermission := ec2.IpPermission{
+		UserIdGroupPairs: []*ec2.UserIdGroupPair{
+			{GroupId: aws.String("secondGroupId")},
+		},
+	}
+
+	newIPPermission := ec2.IpPermission{
+		UserIdGroupPairs: []*ec2.UserIdGroupPair{
+			{GroupId: aws.String("fourthGroupId")},
+		},
+	}
+
+	equals := ipPermissionExists(&existingIPPermission, &oldIPPermission, false)
+	if !equals {
+		t.Errorf("Should have been considered equal since first is in the second array of groups")
+	}
+
+	equals = ipPermissionExists(&newIPPermission, &oldIPPermission, false)
+	if equals {
+		t.Errorf("Should have not been considered equal since first is not in the second array of groups")
+	}
+
+	// The first pair matches, but the second does not
+	newIPPermission2 := ec2.IpPermission{
+		UserIdGroupPairs: []*ec2.UserIdGroupPair{
+			{GroupId: aws.String("firstGroupId")},
+			{GroupId: aws.String("fourthGroupId")},
+		},
+	}
+	equals = ipPermissionExists(&newIPPermission2, &oldIPPermission, false)
+	if equals {
+		t.Errorf("Should have not been considered equal since first is not in the second array of groups")
+	}
+}
+
+func TestIpPermissionExistsHandlesRangeSubsets(t *testing.T) {
+	// Two existing scenarios we'll test against
+	emptyIPPermission := ec2.IpPermission{}
+
+	oldIPPermission := ec2.IpPermission{
+		IpRanges: []*ec2.IpRange{
+			{CidrIp: aws.String("10.0.0.0/8")},
+			{CidrIp: aws.String("192.168.1.0/24")},
+		},
+	}
+
+	// Two already existing ranges and a new one
+	existingIPPermission := ec2.IpPermission{
+		IpRanges: []*ec2.IpRange{
+			{CidrIp: aws.String("10.0.0.0/8")},
+		},
+	}
+	existingIPPermission2 := ec2.IpPermission{
+		IpRanges: []*ec2.IpRange{
+			{CidrIp: aws.String("192.168.1.0/24")},
+		},
+	}
+
+	newIPPermission := ec2.IpPermission{
+		IpRanges: []*ec2.IpRange{
+			{CidrIp: aws.String("172.16.0.0/16")},
+		},
+	}
+
+	exists := ipPermissionExists(&emptyIPPermission, &emptyIPPermission, false)
+	if !exists {
+		t.Errorf("Should have been considered existing since we're comparing a range array against itself")
+	}
+	exists = ipPermissionExists(&oldIPPermission, &oldIPPermission, false)
+	if !exists {
+		t.Errorf("Should have been considered existing since we're comparing a range array against itself")
+	}
+
+	exists = ipPermissionExists(&existingIPPermission, &oldIPPermission, false)
+	if !exists {
+		t.Errorf("Should have been considered existing since 10.* is in oldIPPermission's array of ranges")
+	}
+	exists = ipPermissionExists(&existingIPPermission2, &oldIPPermission, false)
+	if !exists {
+		t.Errorf("Should have been considered existing since 192.* is in oldIpPermission2's array of ranges")
+	}
+
+	exists = ipPermissionExists(&newIPPermission, &emptyIPPermission, false)
+	if exists {
+		t.Errorf("Should have not been considered existing since we compared against a missing array of ranges")
+	}
+	exists = ipPermissionExists(&newIPPermission, &oldIPPermission, false)
+	if exists {
+		t.Errorf("Should have not been considered existing since 172.* is not in oldIPPermission's array of ranges")
+	}
+}
+
+func TestIpPermissionExistsHandlesMultipleGroupIdsWithUserIds(t *testing.T) {
+	oldIPPermission := ec2.IpPermission{
+		UserIdGroupPairs: []*ec2.UserIdGroupPair{
+			{GroupId: aws.String("firstGroupId"), UserId: aws.String("firstUserId")},
+			{GroupId: aws.String("secondGroupId"), UserId: aws.String("secondUserId")},
+			{GroupId: aws.String("thirdGroupId"), UserId: aws.String("thirdUserId")},
+		},
+	}
+
+	existingIPPermission := ec2.IpPermission{
+		UserIdGroupPairs: []*ec2.UserIdGroupPair{
+			{GroupId: aws.String("secondGroupId"), UserId: aws.String("secondUserId")},
+		},
+	}
+
+	newIPPermission := ec2.IpPermission{
+		UserIdGroupPairs: []*ec2.UserIdGroupPair{
+			{GroupId: aws.String("secondGroupId"), UserId: aws.String("anotherUserId")},
+		},
+	}
+
+	equals := ipPermissionExists(&existingIPPermission, &oldIPPermission, true)
+	if !equals {
+		t.Errorf("Should have been considered equal since first is in the second array of groups")
+	}
+
+	equals = ipPermissionExists(&newIPPermission, &oldIPPermission, true)
+	if equals {
+		t.Errorf("Should have not been considered equal since first is not in the second array of groups")
+	}
+}
+
+func TestFindInstanceByNodeNameExcludesTerminatedInstances(t *testing.T) {
+	awsStates := []struct {
+		id       int64
+		state    string
+		expected bool
+	}{
+		{0, ec2.InstanceStateNamePending, true},
+		{16, ec2.InstanceStateNameRunning, true},
+		{32, ec2.InstanceStateNameShuttingDown, true},
+		{48, ec2.InstanceStateNameTerminated, false},
+		{64, ec2.InstanceStateNameStopping, true},
+		{80, ec2.InstanceStateNameStopped, true},
+	}
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+
+	nodeName := types.NodeName("my-dns.internal")
+
+	var tag ec2.Tag
+	tag.Key = aws.String(TagNameKubernetesClusterLegacy)
+	tag.Value = aws.String(TestClusterID)
+	tags := []*ec2.Tag{&tag}
+
+	var testInstance ec2.Instance
+	testInstance.PrivateDnsName = aws.String(string(nodeName))
+	testInstance.Tags = tags
+
+	awsDefaultInstances := awsServices.instances
+	for _, awsState := range awsStates {
+		id := "i-" + awsState.state
+		testInstance.InstanceId = aws.String(id)
+		testInstance.State = &ec2.InstanceState{Code: aws.Int64(awsState.id), Name: aws.String(awsState.state)}
+
+		awsServices.instances = append(awsDefaultInstances, &testInstance)
+
+		c, err := newAWSCloud(CloudConfig{}, awsServices)
+		if err != nil {
+			t.Errorf("Error building aws cloud: %v", err)
+			return
+		}
+
+		resultInstance, err := c.findInstanceByNodeName(nodeName)
+
+		if awsState.expected {
+			if err != nil || resultInstance == nil {
+				t.Errorf("Expected to find instance %v", *testInstance.InstanceId)
+				return
+			}
+			if *resultInstance.InstanceId != *testInstance.InstanceId {
+				t.Errorf("Wrong instance returned by findInstanceByNodeName() expected: %v, actual: %v", *testInstance.InstanceId, *resultInstance.InstanceId)
+				return
+			}
+		} else {
+			if err == nil && resultInstance != nil {
+				t.Errorf("Did not expect to find instance %v", *resultInstance.InstanceId)
+				return
+			}
+		}
+	}
+}
+
+func TestGetInstanceByNodeNameBatching(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	assert.Nil(t, err, "Error building aws cloud: %v", err)
+	var tag ec2.Tag
+	tag.Key = aws.String(TagNameKubernetesClusterPrefix + TestClusterID)
+	tag.Value = aws.String("")
+	tags := []*ec2.Tag{&tag}
+	nodeNames := []string{}
+	for i := 0; i < 200; i++ {
+		nodeName := fmt.Sprintf("ip-171-20-42-%d.ec2.internal", i)
+		nodeNames = append(nodeNames, nodeName)
+		ec2Instance := &ec2.Instance{}
+		instanceID := fmt.Sprintf("i-abcedf%d", i)
+		ec2Instance.InstanceId = aws.String(instanceID)
+		ec2Instance.PrivateDnsName = aws.String(nodeName)
+		ec2Instance.State = &ec2.InstanceState{Code: aws.Int64(48), Name: aws.String("running")}
+		ec2Instance.Tags = tags
+		awsServices.instances = append(awsServices.instances, ec2Instance)
+
+	}
+
+	instances, err := c.getInstancesByNodeNames(nodeNames)
+	assert.Nil(t, err, "Error getting instances by nodeNames %v: %v", nodeNames, err)
+	assert.NotEmpty(t, instances)
+	assert.Equal(t, 200, len(instances), "Expected 200 but got less")
+}
+
+func TestGetVolumeLabels(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	assert.Nil(t, err, "Error building aws cloud: %v", err)
+	volumeID := EBSVolumeID("vol-VolumeId")
+	expectedVolumeRequest := &ec2.DescribeVolumesInput{VolumeIds: []*string{volumeID.awsString()}}
+	awsServices.ec2.(*MockedFakeEC2).On("DescribeVolumes", expectedVolumeRequest).Return([]*ec2.Volume{
+		{
+			VolumeId:         volumeID.awsString(),
+			AvailabilityZone: aws.String("us-east-1a"),
+		},
+	})
+
+	labels, err := c.GetVolumeLabels(KubernetesVolumeID("aws:///" + string(volumeID)))
+
+	assert.Nil(t, err, "Error creating Volume %v", err)
+	assert.Equal(t, map[string]string{
+		kubeletapis.LabelZoneFailureDomain: "us-east-1a",
+		kubeletapis.LabelZoneRegion:        "us-east-1"}, labels)
+	awsServices.ec2.(*MockedFakeEC2).AssertExpectations(t)
+}
+
+func TestDescribeLoadBalancerOnDelete(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
+	awsServices.elb.(*MockedFakeELB).expectDescribeLoadBalancers("aid")
+
+	c.EnsureLoadBalancerDeleted(context.TODO(), TestClusterName, &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "myservice", UID: "id"}})
+}
+
+func TestDescribeLoadBalancerOnUpdate(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
+	awsServices.elb.(*MockedFakeELB).expectDescribeLoadBalancers("aid")
+
+	c.UpdateLoadBalancer(context.TODO(), TestClusterName, &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "myservice", UID: "id"}}, []*v1.Node{})
+}
+
+func TestDescribeLoadBalancerOnGet(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
+	awsServices.elb.(*MockedFakeELB).expectDescribeLoadBalancers("aid")
+
+	c.GetLoadBalancer(context.TODO(), TestClusterName, &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "myservice", UID: "id"}})
+}
+
+func TestDescribeLoadBalancerOnEnsure(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
+	awsServices.elb.(*MockedFakeELB).expectDescribeLoadBalancers("aid")
+
+	c.EnsureLoadBalancer(context.TODO(), TestClusterName, &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "myservice", UID: "id"}}, []*v1.Node{})
+}
+
+func TestBuildListener(t *testing.T) {
+	tests := []struct {
+		name string
+
+		lbPort                    int64
+		portName                  string
+		instancePort              int64
+		backendProtocolAnnotation string
+		certAnnotation            string
+		sslPortAnnotation         string
+
+		expectError      bool
+		lbProtocol       string
+		instanceProtocol string
+		certID           string
+	}{
+		{
+			"No cert or BE protocol annotation, passthrough",
+			80, "", 7999, "", "", "",
+			false, "tcp", "tcp", "",
+		},
+		{
+			"Cert annotation without BE protocol specified, SSL->TCP",
+			80, "", 8000, "", "cert", "",
+			false, "ssl", "tcp", "cert",
+		},
+		{
+			"BE protocol without cert annotation, passthrough",
+			443, "", 8001, "https", "", "",
+			false, "tcp", "tcp", "",
+		},
+		{
+			"Invalid cert annotation, bogus backend protocol",
+			443, "", 8002, "bacon", "foo", "",
+			true, "tcp", "tcp", "",
+		},
+		{
+			"Invalid cert annotation, protocol followed by equal sign",
+			443, "", 8003, "http=", "=", "",
+			true, "tcp", "tcp", "",
+		},
+		{
+			"HTTPS->HTTPS",
+			443, "", 8004, "https", "cert", "",
+			false, "https", "https", "cert",
+		},
+		{
+			"HTTPS->HTTP",
+			443, "", 8005, "http", "cert", "",
+			false, "https", "http", "cert",
+		},
+		{
+			"SSL->SSL",
+			443, "", 8006, "ssl", "cert", "",
+			false, "ssl", "ssl", "cert",
+		},
+		{
+			"SSL->TCP",
+			443, "", 8007, "tcp", "cert", "",
+			false, "ssl", "tcp", "cert",
+		},
+		{
+			"Port in whitelist",
+			1234, "", 8008, "tcp", "cert", "1234,5678",
+			false, "ssl", "tcp", "cert",
+		},
+		{
+			"Port not in whitelist, passthrough",
+			443, "", 8009, "tcp", "cert", "1234,5678",
+			false, "tcp", "tcp", "",
+		},
+		{
+			"Named port in whitelist",
+			1234, "bar", 8010, "tcp", "cert", "foo,bar",
+			false, "ssl", "tcp", "cert",
+		},
+		{
+			"Named port not in whitelist, passthrough",
+			443, "", 8011, "tcp", "cert", "foo,bar",
+			false, "tcp", "tcp", "",
+		},
+		{
+			"HTTP->HTTP",
+			80, "", 8012, "http", "", "",
+			false, "http", "http", "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Running test case %s", test.name)
+		annotations := make(map[string]string)
+		if test.backendProtocolAnnotation != "" {
+			annotations[ServiceAnnotationLoadBalancerBEProtocol] = test.backendProtocolAnnotation
+		}
+		if test.certAnnotation != "" {
+			annotations[ServiceAnnotationLoadBalancerCertificate] = test.certAnnotation
+		}
+		ports := getPortSets(test.sslPortAnnotation)
+		l, err := buildListener(v1.ServicePort{
+			NodePort: int32(test.instancePort),
+			Port:     int32(test.lbPort),
+			Name:     test.portName,
+			Protocol: v1.Protocol("tcp"),
+		}, annotations, ports)
+		if test.expectError {
+			if err == nil {
+				t.Errorf("Should error for case %s", test.name)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Should succeed for case: %s, got %v", test.name, err)
+			} else {
+				var cert *string
+				if test.certID != "" {
+					cert = &test.certID
+				}
+				expected := &elb.Listener{
+					InstancePort:     &test.instancePort,
+					InstanceProtocol: &test.instanceProtocol,
+					LoadBalancerPort: &test.lbPort,
+					Protocol:         &test.lbProtocol,
+					SSLCertificateId: cert,
+				}
+				if !reflect.DeepEqual(l, expected) {
+					t.Errorf("Incorrect listener (%v vs expected %v) for case: %s",
+						l, expected, test.name)
+				}
+			}
+		}
+	}
+}
+
+func TestProxyProtocolEnabled(t *testing.T) {
+	policies := sets.NewString(ProxyProtocolPolicyName, "FooBarFoo")
+	fakeBackend := &elb.BackendServerDescription{
+		InstancePort: aws.Int64(80),
+		PolicyNames:  stringSetToPointers(policies),
+	}
+	result := proxyProtocolEnabled(fakeBackend)
+	assert.True(t, result, "expected to find %s in %s", ProxyProtocolPolicyName, policies)
+
+	policies = sets.NewString("FooBarFoo")
+	fakeBackend = &elb.BackendServerDescription{
+		InstancePort: aws.Int64(80),
+		PolicyNames: []*string{
+			aws.String("FooBarFoo"),
+		},
+	}
+	result = proxyProtocolEnabled(fakeBackend)
+	assert.False(t, result, "did not expect to find %s in %s", ProxyProtocolPolicyName, policies)
+
+	policies = sets.NewString()
+	fakeBackend = &elb.BackendServerDescription{
+		InstancePort: aws.Int64(80),
+	}
+	result = proxyProtocolEnabled(fakeBackend)
+	assert.False(t, result, "did not expect to find %s in %s", ProxyProtocolPolicyName, policies)
+}
+
+func TestGetLoadBalancerAdditionalTags(t *testing.T) {
+	tagTests := []struct {
+		Annotations map[string]string
+		Tags        map[string]string
+	}{
+		{
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "Key=Val",
+			},
+			Tags: map[string]string{
+				"Key": "Val",
+			},
+		},
+		{
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "Key1=Val1, Key2=Val2",
+			},
+			Tags: map[string]string{
+				"Key1": "Val1",
+				"Key2": "Val2",
+			},
+		},
+		{
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "Key1=, Key2=Val2",
+				"anotherKey": "anotherValue",
+			},
+			Tags: map[string]string{
+				"Key1": "",
+				"Key2": "Val2",
+			},
+		},
+		{
+			Annotations: map[string]string{
+				"Nothing": "Key1=, Key2=Val2, Key3",
+			},
+			Tags: map[string]string{},
+		},
+		{
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "K=V K1=V2,Key1========, =====, ======Val, =Val, , 234,",
+			},
+			Tags: map[string]string{
+				"K":    "V K1",
+				"Key1": "",
+				"234":  "",
+			},
+		},
+	}
+
+	for _, tagTest := range tagTests {
+		result := getLoadBalancerAdditionalTags(tagTest.Annotations)
+		for k, v := range result {
+			if len(result) != len(tagTest.Tags) {
+				t.Errorf("incorrect expected length: %v != %v", result, tagTest.Tags)
+				continue
+			}
+			if tagTest.Tags[k] != v {
+				t.Errorf("%s != %s", tagTest.Tags[k], v)
+				continue
+			}
+		}
+	}
+}
+
+func TestLBExtraSecurityGroupsAnnotation(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
+
+	sg1 := map[string]string{ServiceAnnotationLoadBalancerExtraSecurityGroups: "sg-000001"}
+	sg2 := map[string]string{ServiceAnnotationLoadBalancerExtraSecurityGroups: "sg-000002"}
+	sg3 := map[string]string{ServiceAnnotationLoadBalancerExtraSecurityGroups: "sg-000001, sg-000002"}
+
+	tests := []struct {
+		name string
+
+		annotations map[string]string
+		expectedSGs []string
+	}{
+		{"No extra SG annotation", map[string]string{}, []string{}},
+		{"Empty extra SGs specified", map[string]string{ServiceAnnotationLoadBalancerExtraSecurityGroups: ", ,,"}, []string{}},
+		{"SG specified", sg1, []string{sg1[ServiceAnnotationLoadBalancerExtraSecurityGroups]}},
+		{"Multiple SGs specified", sg3, []string{sg1[ServiceAnnotationLoadBalancerExtraSecurityGroups], sg2[ServiceAnnotationLoadBalancerExtraSecurityGroups]}},
+	}
+
+	awsServices.ec2.(*MockedFakeEC2).expectDescribeSecurityGroups(TestClusterID, "k8s-elb-aid")
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			serviceName := types.NamespacedName{Namespace: "default", Name: "myservice"}
+
+			sgList, err := c.buildELBSecurityGroupList(serviceName, "aid", test.annotations)
+			assert.NoError(t, err, "buildELBSecurityGroupList failed")
+			extraSGs := sgList[1:]
+			assert.True(t, sets.NewString(test.expectedSGs...).Equal(sets.NewString(extraSGs...)),
+				"Security Groups expected=%q , returned=%q", test.expectedSGs, extraSGs)
+		})
+	}
+}
+
+func TestLBSecurityGroupsAnnotation(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
+
+	sg1 := map[string]string{ServiceAnnotationLoadBalancerSecurityGroups: "sg-000001"}
+	sg2 := map[string]string{ServiceAnnotationLoadBalancerSecurityGroups: "sg-000002"}
+	sg3 := map[string]string{ServiceAnnotationLoadBalancerSecurityGroups: "sg-000001, sg-000002"}
+
+	tests := []struct {
+		name string
+
+		annotations map[string]string
+		expectedSGs []string
+	}{
+		{"SG specified", sg1, []string{sg1[ServiceAnnotationLoadBalancerSecurityGroups]}},
+		{"Multiple SGs specified", sg3, []string{sg1[ServiceAnnotationLoadBalancerSecurityGroups], sg2[ServiceAnnotationLoadBalancerSecurityGroups]}},
+	}
+
+	awsServices.ec2.(*MockedFakeEC2).expectDescribeSecurityGroups(TestClusterID, "k8s-elb-aid")
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			serviceName := types.NamespacedName{Namespace: "default", Name: "myservice"}
+
+			sgList, err := c.buildELBSecurityGroupList(serviceName, "aid", test.annotations)
+			assert.NoError(t, err, "buildELBSecurityGroupList failed")
+			assert.True(t, sets.NewString(test.expectedSGs...).Equal(sets.NewString(sgList...)),
+				"Security Groups expected=%q , returned=%q", test.expectedSGs, sgList)
+		})
+	}
+}
+
+// Test that we can add a load balancer tag
+func TestAddLoadBalancerTags(t *testing.T) {
+	loadBalancerName := "test-elb"
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
+
+	want := make(map[string]string)
+	want["tag1"] = "val1"
+
+	expectedAddTagsRequest := &elb.AddTagsInput{
+		LoadBalancerNames: []*string{&loadBalancerName},
+		Tags: []*elb.Tag{
+			{
+				Key:   aws.String("tag1"),
+				Value: aws.String("val1"),
+			},
+		},
+	}
+	awsServices.elb.(*MockedFakeELB).On("AddTags", expectedAddTagsRequest).Return(&elb.AddTagsOutput{})
+
+	err := c.addLoadBalancerTags(loadBalancerName, want)
+	assert.Nil(t, err, "Error adding load balancer tags: %v", err)
+	awsServices.elb.(*MockedFakeELB).AssertExpectations(t)
+}
+
+func TestEnsureLoadBalancerHealthCheck(t *testing.T) {
+
+	tests := []struct {
+		name                string
+		annotations         map[string]string
+		overriddenFieldName string
+		overriddenValue     int64
+	}{
+		{"falls back to HC defaults", map[string]string{}, "", int64(0)},
+		{"healthy threshold override", map[string]string{ServiceAnnotationLoadBalancerHCHealthyThreshold: "7"}, "HealthyThreshold", int64(7)},
+		{"unhealthy threshold override", map[string]string{ServiceAnnotationLoadBalancerHCUnhealthyThreshold: "7"}, "UnhealthyThreshold", int64(7)},
+		{"timeout override", map[string]string{ServiceAnnotationLoadBalancerHCTimeout: "7"}, "Timeout", int64(7)},
+		{"interval override", map[string]string{ServiceAnnotationLoadBalancerHCInterval: "7"}, "Interval", int64(7)},
+	}
+	lbName := "myLB"
+	// this HC will always differ from the expected HC and thus it is expected an
+	// API call will be made to update it
+	currentHC := &elb.HealthCheck{}
+	elbDesc := &elb.LoadBalancerDescription{LoadBalancerName: &lbName, HealthCheck: currentHC}
+	defaultHealthyThreshold := int64(2)
+	defaultUnhealthyThreshold := int64(6)
+	defaultTimeout := int64(5)
+	defaultInterval := int64(10)
+	protocol, path, port := "tcp", "", int32(8080)
+	target := "tcp:8080"
+	defaultHC := &elb.HealthCheck{
+		HealthyThreshold:   &defaultHealthyThreshold,
+		UnhealthyThreshold: &defaultUnhealthyThreshold,
+		Timeout:            &defaultTimeout,
+		Interval:           &defaultInterval,
+		Target:             &target,
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			awsServices := newMockedFakeAWSServices(TestClusterID)
+			c, err := newAWSCloud(CloudConfig{}, awsServices)
+			assert.Nil(t, err, "Error building aws cloud: %v", err)
+			expectedHC := *defaultHC
+			if test.overriddenFieldName != "" { // cater for test case with no overrides
+				value := reflect.ValueOf(&test.overriddenValue)
+				reflect.ValueOf(&expectedHC).Elem().FieldByName(test.overriddenFieldName).Set(value)
+			}
+			awsServices.elb.(*MockedFakeELB).expectConfigureHealthCheck(&lbName, &expectedHC, nil)
+
+			err = c.ensureLoadBalancerHealthCheck(elbDesc, protocol, port, path, test.annotations)
+
+			require.Nil(t, err)
+			awsServices.elb.(*MockedFakeELB).AssertExpectations(t)
+		})
+	}
+
+	t.Run("does not make an API call if the current health check is the same", func(t *testing.T) {
+		awsServices := newMockedFakeAWSServices(TestClusterID)
+		c, err := newAWSCloud(CloudConfig{}, awsServices)
+		assert.Nil(t, err, "Error building aws cloud: %v", err)
+		expectedHC := *defaultHC
+		timeout := int64(3)
+		expectedHC.Timeout = &timeout
+		annotations := map[string]string{ServiceAnnotationLoadBalancerHCTimeout: "3"}
+		var currentHC elb.HealthCheck
+		currentHC = expectedHC
+
+		// NOTE no call expectations are set on the ELB mock
+		// test default HC
+		elbDesc := &elb.LoadBalancerDescription{LoadBalancerName: &lbName, HealthCheck: defaultHC}
+		err = c.ensureLoadBalancerHealthCheck(elbDesc, protocol, port, path, map[string]string{})
+		assert.Nil(t, err)
+		// test HC with override
+		elbDesc = &elb.LoadBalancerDescription{LoadBalancerName: &lbName, HealthCheck: &currentHC}
+		err = c.ensureLoadBalancerHealthCheck(elbDesc, protocol, port, path, annotations)
+		assert.Nil(t, err)
+	})
+
+	t.Run("validates resulting expected health check before making an API call", func(t *testing.T) {
+		awsServices := newMockedFakeAWSServices(TestClusterID)
+		c, err := newAWSCloud(CloudConfig{}, awsServices)
+		assert.Nil(t, err, "Error building aws cloud: %v", err)
+		expectedHC := *defaultHC
+		invalidThreshold := int64(1)
+		expectedHC.HealthyThreshold = &invalidThreshold
+		require.Error(t, expectedHC.Validate()) // confirm test precondition
+		annotations := map[string]string{ServiceAnnotationLoadBalancerHCTimeout: "1"}
+
+		// NOTE no call expectations are set on the ELB mock
+		err = c.ensureLoadBalancerHealthCheck(elbDesc, protocol, port, path, annotations)
+
+		require.Error(t, err)
+	})
+
+	t.Run("handles invalid override values", func(t *testing.T) {
+		awsServices := newMockedFakeAWSServices(TestClusterID)
+		c, err := newAWSCloud(CloudConfig{}, awsServices)
+		assert.Nil(t, err, "Error building aws cloud: %v", err)
+		annotations := map[string]string{ServiceAnnotationLoadBalancerHCTimeout: "3.3"}
+
+		// NOTE no call expectations are set on the ELB mock
+		err = c.ensureLoadBalancerHealthCheck(elbDesc, protocol, port, path, annotations)
+
+		require.Error(t, err)
+	})
+
+	t.Run("returns error when updating the health check fails", func(t *testing.T) {
+		awsServices := newMockedFakeAWSServices(TestClusterID)
+		c, err := newAWSCloud(CloudConfig{}, awsServices)
+		assert.Nil(t, err, "Error building aws cloud: %v", err)
+		returnErr := fmt.Errorf("throttling error")
+		awsServices.elb.(*MockedFakeELB).expectConfigureHealthCheck(&lbName, defaultHC, returnErr)
+
+		err = c.ensureLoadBalancerHealthCheck(elbDesc, protocol, port, path, map[string]string{})
+
+		require.Error(t, err)
+		awsServices.elb.(*MockedFakeELB).AssertExpectations(t)
+	})
+}
+
+func TestFindSecurityGroupForInstance(t *testing.T) {
+	groups := map[string]*ec2.SecurityGroup{"sg123": {GroupId: aws.String("sg123")}}
+	id, err := findSecurityGroupForInstance(&ec2.Instance{SecurityGroups: []*ec2.GroupIdentifier{{GroupId: aws.String("sg123"), GroupName: aws.String("my_group")}}}, groups)
+	if err != nil {
+		t.Error()
+	}
+	assert.Equal(t, *id.GroupId, "sg123")
+	assert.Equal(t, *id.GroupName, "my_group")
+}
+
+func TestFindSecurityGroupForInstanceMultipleTagged(t *testing.T) {
+	groups := map[string]*ec2.SecurityGroup{"sg123": {GroupId: aws.String("sg123")}}
+	_, err := findSecurityGroupForInstance(&ec2.Instance{
+		SecurityGroups: []*ec2.GroupIdentifier{
+			{GroupId: aws.String("sg123"), GroupName: aws.String("my_group")},
+			{GroupId: aws.String("sg123"), GroupName: aws.String("another_group")},
+		},
+	}, groups)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sg123(my_group)")
+	assert.Contains(t, err.Error(), "sg123(another_group)")
+}
+
+func TestCreateDisk(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
+
+	volumeOptions := &VolumeOptions{
+		AvailabilityZone: "us-east-1a",
+		CapacityGB:       10,
+	}
+	request := &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Encrypted:        aws.Bool(false),
+		VolumeType:       aws.String(DefaultVolumeType),
+		Size:             aws.Int64(10),
+		TagSpecifications: []*ec2.TagSpecification{
+			{ResourceType: aws.String(ec2.ResourceTypeVolume), Tags: []*ec2.Tag{
+				{Key: aws.String(TagNameKubernetesClusterLegacy), Value: aws.String(TestClusterID)},
+				{Key: aws.String(fmt.Sprintf("%s%s", TagNameKubernetesClusterPrefix, TestClusterID)), Value: aws.String(ResourceLifecycleOwned)},
+			}},
+		},
+	}
+	volume := &ec2.Volume{
+		AvailabilityZone: aws.String("us-east-1a"),
+		VolumeId:         aws.String("vol-volumeId0"),
+	}
+	awsServices.ec2.(*MockedFakeEC2).On("CreateVolume", request).Return(volume, nil)
+
+	volumeID, err := c.CreateDisk(volumeOptions)
+	assert.Nil(t, err, "Error creating disk: %v", err)
+	assert.Equal(t, volumeID, KubernetesVolumeID("aws://us-east-1a/vol-volumeId0"))
+	awsServices.ec2.(*MockedFakeEC2).AssertExpectations(t)
+}
+
+func newMockedFakeAWSServices(id string) *FakeAWSServices {
+	s := NewFakeAWSServices(id)
+	s.ec2 = &MockedFakeEC2{FakeEC2Impl: s.ec2.(*FakeEC2Impl)}
+	s.elb = &MockedFakeELB{FakeELB: s.elb.(*FakeELB)}
+	return s
+}

--- a/pkg/cloudprovider/providers/aws/aws_utils.go
+++ b/pkg/cloudprovider/providers/aws/aws_utils.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func stringSetToPointers(in sets.String) []*string {
+	if in == nil {
+		return nil
+	}
+	out := make([]*string, 0, len(in))
+	for k := range in {
+		out = append(out, aws.String(k))
+	}
+	return out
+}
+
+func stringSetFromPointers(in []*string) sets.String {
+	if in == nil {
+		return nil
+	}
+	out := sets.NewString()
+	for i := range in {
+		out.Insert(aws.StringValue(in[i]))
+	}
+	return out
+}

--- a/pkg/cloudprovider/providers/aws/device_allocator.go
+++ b/pkg/cloudprovider/providers/aws/device_allocator.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// ExistingDevices is a map of assigned devices. Presence of a key with a device
+// name in the map means that the device is allocated. Value is irrelevant and
+// can be used for anything that DeviceAllocator user wants.
+// Only the relevant part of device name should be in the map, e.g. "ba" for
+// "/dev/xvdba".
+type ExistingDevices map[mountDevice]EBSVolumeID
+
+// DeviceAllocator finds available device name, taking into account already
+// assigned device names from ExistingDevices map. It tries to find the next
+// device name to the previously assigned one (from previous DeviceAllocator
+// call), so all available device names are used eventually and it minimizes
+// device name reuse.
+//
+// All these allocations are in-memory, nothing is written to / read from
+// /dev directory.
+//
+// On AWS, we should assign new (not yet used) device names to attached volumes.
+// If we reuse a previously used name, we may get the volume "attaching" forever,
+// see https://aws.amazon.com/premiumsupport/knowledge-center/ebs-stuck-attaching/.
+type DeviceAllocator interface {
+	// GetNext returns a free device name or error when there is no free device
+	// name. Only the device suffix is returned, e.g. "ba" for "/dev/xvdba".
+	// It's up to the called to add appropriate "/dev/sd" or "/dev/xvd" prefix.
+	GetNext(existingDevices ExistingDevices) (mountDevice, error)
+
+	// Deprioritize the device so as it can't be used immediately again
+	Deprioritize(mountDevice)
+
+	// Lock the deviceAllocator
+	Lock()
+
+	// Unlock the deviceAllocator
+	Unlock()
+}
+
+type deviceAllocator struct {
+	possibleDevices map[mountDevice]int
+	counter         int
+	deviceLock      sync.Mutex
+}
+
+var _ DeviceAllocator = &deviceAllocator{}
+
+type devicePair struct {
+	deviceName  mountDevice
+	deviceIndex int
+}
+
+type devicePairList []devicePair
+
+func (p devicePairList) Len() int           { return len(p) }
+func (p devicePairList) Less(i, j int) bool { return p[i].deviceIndex < p[j].deviceIndex }
+func (p devicePairList) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// NewDeviceAllocator allocates device names according to scheme ba..bz, ca..cz
+// it moves along the ring and always picks next device until device list is
+// exhausted.
+func NewDeviceAllocator() DeviceAllocator {
+	possibleDevices := make(map[mountDevice]int)
+	for _, firstChar := range []rune{'b', 'c'} {
+		for i := 'a'; i <= 'z'; i++ {
+			dev := mountDevice([]rune{firstChar, i})
+			possibleDevices[dev] = 0
+		}
+	}
+	return &deviceAllocator{
+		possibleDevices: possibleDevices,
+		counter:         0,
+	}
+}
+
+// GetNext gets next available device from the pool, this function assumes that caller
+// holds the necessary lock on deviceAllocator
+func (d *deviceAllocator) GetNext(existingDevices ExistingDevices) (mountDevice, error) {
+	for _, devicePair := range d.sortByCount() {
+		if _, found := existingDevices[devicePair.deviceName]; !found {
+			return devicePair.deviceName, nil
+		}
+	}
+	return "", fmt.Errorf("no devices are available")
+}
+
+func (d *deviceAllocator) sortByCount() devicePairList {
+	dpl := make(devicePairList, 0)
+	for deviceName, deviceIndex := range d.possibleDevices {
+		dpl = append(dpl, devicePair{deviceName, deviceIndex})
+	}
+	sort.Sort(dpl)
+	return dpl
+}
+
+func (d *deviceAllocator) Lock() {
+	d.deviceLock.Lock()
+}
+
+func (d *deviceAllocator) Unlock() {
+	d.deviceLock.Unlock()
+}
+
+// Deprioritize the device so as it can't be used immediately again
+func (d *deviceAllocator) Deprioritize(chosen mountDevice) {
+	d.deviceLock.Lock()
+	defer d.deviceLock.Unlock()
+	if _, ok := d.possibleDevices[chosen]; ok {
+		d.counter++
+		d.possibleDevices[chosen] = d.counter
+	}
+}

--- a/pkg/cloudprovider/providers/aws/device_allocator_test.go
+++ b/pkg/cloudprovider/providers/aws/device_allocator_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import "testing"
+
+func TestDeviceAllocator(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingDevices ExistingDevices
+		deviceMap       map[mountDevice]int
+		expectedOutput  mountDevice
+	}{
+		{
+			"empty device list with wrap",
+			ExistingDevices{},
+			generateUnsortedDeviceList(),
+			"bd", // next to 'zz' is the first one, 'ba'
+		},
+	}
+
+	for _, test := range tests {
+		allocator := NewDeviceAllocator().(*deviceAllocator)
+		for k, v := range test.deviceMap {
+			allocator.possibleDevices[k] = v
+		}
+
+		got, err := allocator.GetNext(test.existingDevices)
+		if err != nil {
+			t.Errorf("text %q: unexpected error: %v", test.name, err)
+		}
+		if got != test.expectedOutput {
+			t.Errorf("text %q: expected %q, got %q", test.name, test.expectedOutput, got)
+		}
+	}
+}
+
+func generateUnsortedDeviceList() map[mountDevice]int {
+	possibleDevices := make(map[mountDevice]int)
+	for _, firstChar := range []rune{'b', 'c'} {
+		for i := 'a'; i <= 'z'; i++ {
+			dev := mountDevice([]rune{firstChar, i})
+			possibleDevices[dev] = 3
+		}
+	}
+	possibleDevices["bd"] = 0
+	return possibleDevices
+}
+
+func TestDeviceAllocatorError(t *testing.T) {
+	allocator := NewDeviceAllocator().(*deviceAllocator)
+	existingDevices := ExistingDevices{}
+
+	// make all devices used
+	var first, second byte
+	for first = 'b'; first <= 'c'; first++ {
+		for second = 'a'; second <= 'z'; second++ {
+			device := [2]byte{first, second}
+			existingDevices[mountDevice(device[:])] = "used"
+		}
+	}
+
+	device, err := allocator.GetNext(existingDevices)
+	if err == nil {
+		t.Errorf("expected error, got device  %q", device)
+	}
+}

--- a/pkg/cloudprovider/providers/aws/instances.go
+++ b/pkg/cloudprovider/providers/aws/instances.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/klog"
+
+	"k8s.io/api/core/v1"
+)
+
+// awsInstanceRegMatch represents Regex Match for AWS instance.
+var awsInstanceRegMatch = regexp.MustCompile("^i-[^/]*$")
+
+// awsInstanceID represents the ID of the instance in the AWS API, e.g. i-12345678
+// The "traditional" format is "i-12345678"
+// A new longer format is also being introduced: "i-12345678abcdef01"
+// We should not assume anything about the length or format, though it seems
+// reasonable to assume that instances will continue to start with "i-".
+type awsInstanceID string
+
+func (i awsInstanceID) awsString() *string {
+	return aws.String(string(i))
+}
+
+// kubernetesInstanceID represents the id for an instance in the kubernetes API;
+// the following form
+//  * aws:///<zone>/<awsInstanceId>
+//  * aws:////<awsInstanceId>
+//  * <awsInstanceId>
+type kubernetesInstanceID string
+
+// mapToAWSInstanceID extracts the awsInstanceID from the kubernetesInstanceID
+func (name kubernetesInstanceID) mapToAWSInstanceID() (awsInstanceID, error) {
+	s := string(name)
+
+	if !strings.HasPrefix(s, "aws://") {
+		// Assume a bare aws volume id (vol-1234...)
+		// Build a URL with an empty host (AZ)
+		s = "aws://" + "/" + "/" + s
+	}
+	url, err := url.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("Invalid instance name (%s): %v", name, err)
+	}
+	if url.Scheme != "aws" {
+		return "", fmt.Errorf("Invalid scheme for AWS instance (%s)", name)
+	}
+
+	awsID := ""
+	tokens := strings.Split(strings.Trim(url.Path, "/"), "/")
+	if len(tokens) == 1 {
+		// instanceId
+		awsID = tokens[0]
+	} else if len(tokens) == 2 {
+		// az/instanceId
+		awsID = tokens[1]
+	}
+
+	// We sanity check the resulting volume; the two known formats are
+	// i-12345678 and i-12345678abcdef01
+	if awsID == "" || !awsInstanceRegMatch.MatchString(awsID) {
+		return "", fmt.Errorf("Invalid format for AWS instance (%s)", name)
+	}
+
+	return awsInstanceID(awsID), nil
+}
+
+// mapToAWSInstanceID extracts the awsInstanceIDs from the Nodes, returning an error if a Node cannot be mapped
+func mapToAWSInstanceIDs(nodes []*v1.Node) ([]awsInstanceID, error) {
+	var instanceIDs []awsInstanceID
+	for _, node := range nodes {
+		if node.Spec.ProviderID == "" {
+			return nil, fmt.Errorf("node %q did not have ProviderID set", node.Name)
+		}
+		instanceID, err := kubernetesInstanceID(node.Spec.ProviderID).mapToAWSInstanceID()
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse ProviderID %q for node %q", node.Spec.ProviderID, node.Name)
+		}
+		instanceIDs = append(instanceIDs, instanceID)
+	}
+
+	return instanceIDs, nil
+}
+
+// mapToAWSInstanceIDsTolerant extracts the awsInstanceIDs from the Nodes, skipping Nodes that cannot be mapped
+func mapToAWSInstanceIDsTolerant(nodes []*v1.Node) []awsInstanceID {
+	var instanceIDs []awsInstanceID
+	for _, node := range nodes {
+		if node.Spec.ProviderID == "" {
+			klog.Warningf("node %q did not have ProviderID set", node.Name)
+			continue
+		}
+		instanceID, err := kubernetesInstanceID(node.Spec.ProviderID).mapToAWSInstanceID()
+		if err != nil {
+			klog.Warningf("unable to parse ProviderID %q for node %q", node.Spec.ProviderID, node.Name)
+			continue
+		}
+		instanceIDs = append(instanceIDs, instanceID)
+	}
+
+	return instanceIDs
+}
+
+// Gets the full information about this instance from the EC2 API
+func describeInstance(ec2Client EC2, instanceID awsInstanceID) (*ec2.Instance, error) {
+	request := &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{instanceID.awsString()},
+	}
+
+	instances, err := ec2Client.DescribeInstances(request)
+	if err != nil {
+		return nil, err
+	}
+	if len(instances) == 0 {
+		return nil, fmt.Errorf("no instances found for instance: %s", instanceID)
+	}
+	if len(instances) > 1 {
+		return nil, fmt.Errorf("multiple instances found for instance: %s", instanceID)
+	}
+	return instances[0], nil
+}
+
+// instanceCache manages the cache of DescribeInstances
+type instanceCache struct {
+	// TODO: Get rid of this field, send all calls through the instanceCache
+	cloud *Cloud
+
+	mutex    sync.Mutex
+	snapshot *allInstancesSnapshot
+}
+
+// Gets the full information about these instance from the EC2 API
+func (c *instanceCache) describeAllInstancesUncached() (*allInstancesSnapshot, error) {
+	now := time.Now()
+
+	klog.V(4).Infof("EC2 DescribeInstances - fetching all instances")
+
+	filters := []*ec2.Filter{}
+	instances, err := c.cloud.describeInstances(filters)
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[awsInstanceID]*ec2.Instance)
+	for _, i := range instances {
+		id := awsInstanceID(aws.StringValue(i.InstanceId))
+		m[id] = i
+	}
+
+	snapshot := &allInstancesSnapshot{now, m}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.snapshot != nil && snapshot.olderThan(c.snapshot) {
+		// If this happens a lot, we could run this function in a mutex and only return one result
+		klog.Infof("Not caching concurrent AWS DescribeInstances results")
+	} else {
+		c.snapshot = snapshot
+	}
+
+	return snapshot, nil
+}
+
+// cacheCriteria holds criteria that must hold to use a cached snapshot
+type cacheCriteria struct {
+	// MaxAge indicates the maximum age of a cached snapshot we can accept.
+	// If set to 0 (i.e. unset), cached values will not time out because of age.
+	MaxAge time.Duration
+
+	// HasInstances is a list of awsInstanceIDs that must be in a cached snapshot for it to be considered valid.
+	// If an instance is not found in the cached snapshot, the snapshot be ignored and we will re-fetch.
+	HasInstances []awsInstanceID
+}
+
+// describeAllInstancesCached returns all instances, using cached results if applicable
+func (c *instanceCache) describeAllInstancesCached(criteria cacheCriteria) (*allInstancesSnapshot, error) {
+	var err error
+	snapshot := c.getSnapshot()
+	if snapshot != nil && !snapshot.MeetsCriteria(criteria) {
+		snapshot = nil
+	}
+
+	if snapshot == nil {
+		snapshot, err = c.describeAllInstancesUncached()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		klog.V(6).Infof("EC2 DescribeInstances - using cached results")
+	}
+
+	return snapshot, nil
+}
+
+// getSnapshot returns a snapshot if one exists
+func (c *instanceCache) getSnapshot() *allInstancesSnapshot {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return c.snapshot
+}
+
+// olderThan is a simple helper to encapsulate timestamp comparison
+func (s *allInstancesSnapshot) olderThan(other *allInstancesSnapshot) bool {
+	// After() is technically broken by time changes until we have monotonic time
+	return other.timestamp.After(s.timestamp)
+}
+
+// MeetsCriteria returns true if the snapshot meets the criteria in cacheCriteria
+func (s *allInstancesSnapshot) MeetsCriteria(criteria cacheCriteria) bool {
+	if criteria.MaxAge > 0 {
+		// Sub() is technically broken by time changes until we have monotonic time
+		now := time.Now()
+		if now.Sub(s.timestamp) > criteria.MaxAge {
+			klog.V(6).Infof("instanceCache snapshot cannot be used as is older than MaxAge=%s", criteria.MaxAge)
+			return false
+		}
+	}
+
+	if len(criteria.HasInstances) != 0 {
+		for _, id := range criteria.HasInstances {
+			if nil == s.instances[id] {
+				klog.V(6).Infof("instanceCache snapshot cannot be used as does not contain instance %s", id)
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// allInstancesSnapshot holds the results from querying for all instances,
+// along with the timestamp for cache-invalidation purposes
+type allInstancesSnapshot struct {
+	timestamp time.Time
+	instances map[awsInstanceID]*ec2.Instance
+}
+
+// FindInstances returns the instances corresponding to the specified ids.  If an id is not found, it is ignored.
+func (s *allInstancesSnapshot) FindInstances(ids []awsInstanceID) map[awsInstanceID]*ec2.Instance {
+	m := make(map[awsInstanceID]*ec2.Instance)
+	for _, id := range ids {
+		instance := s.instances[id]
+		if instance != nil {
+			m[id] = instance
+		}
+	}
+	return m
+}

--- a/pkg/cloudprovider/providers/aws/instances_test.go
+++ b/pkg/cloudprovider/providers/aws/instances_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/api/core/v1"
+)
+
+func TestMapToAWSInstanceIDs(t *testing.T) {
+	tests := []struct {
+		Kubernetes  kubernetesInstanceID
+		Aws         awsInstanceID
+		ExpectError bool
+	}{
+		{
+			Kubernetes: "aws:///us-east-1a/i-12345678",
+			Aws:        "i-12345678",
+		},
+		{
+			Kubernetes: "aws:////i-12345678",
+			Aws:        "i-12345678",
+		},
+		{
+			Kubernetes: "i-12345678",
+			Aws:        "i-12345678",
+		},
+		{
+			Kubernetes: "aws:///us-east-1a/i-12345678abcdef01",
+			Aws:        "i-12345678abcdef01",
+		},
+		{
+			Kubernetes: "aws:////i-12345678abcdef01",
+			Aws:        "i-12345678abcdef01",
+		},
+		{
+			Kubernetes: "i-12345678abcdef01",
+			Aws:        "i-12345678abcdef01",
+		},
+		{
+			Kubernetes:  "vol-123456789",
+			ExpectError: true,
+		},
+		{
+			Kubernetes:  "aws:///us-east-1a/vol-12345678abcdef01",
+			ExpectError: true,
+		},
+		{
+			Kubernetes:  "aws://accountid/us-east-1a/vol-12345678abcdef01",
+			ExpectError: true,
+		},
+		{
+			Kubernetes:  "aws:///us-east-1a/vol-12345678abcdef01/suffix",
+			ExpectError: true,
+		},
+		{
+			Kubernetes:  "",
+			ExpectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		awsID, err := test.Kubernetes.mapToAWSInstanceID()
+		if err != nil {
+			if !test.ExpectError {
+				t.Errorf("unexpected error parsing %s: %v", test.Kubernetes, err)
+			}
+		} else {
+			if test.ExpectError {
+				t.Errorf("expected error parsing %s", test.Kubernetes)
+			} else if test.Aws != awsID {
+				t.Errorf("unexpected value parsing %s, got %s", test.Kubernetes, awsID)
+			}
+		}
+	}
+
+	for _, test := range tests {
+		node := &v1.Node{}
+		node.Spec.ProviderID = string(test.Kubernetes)
+
+		awsInstanceIds, err := mapToAWSInstanceIDs([]*v1.Node{node})
+		if err != nil {
+			if !test.ExpectError {
+				t.Errorf("unexpected error parsing %s: %v", test.Kubernetes, err)
+			}
+		} else {
+			if test.ExpectError {
+				t.Errorf("expected error parsing %s", test.Kubernetes)
+			} else if len(awsInstanceIds) != 1 {
+				t.Errorf("unexpected value parsing %s, got %s", test.Kubernetes, awsInstanceIds)
+			} else if awsInstanceIds[0] != test.Aws {
+				t.Errorf("unexpected value parsing %s, got %s", test.Kubernetes, awsInstanceIds)
+			}
+		}
+
+		awsInstanceIds = mapToAWSInstanceIDsTolerant([]*v1.Node{node})
+		if test.ExpectError {
+			if len(awsInstanceIds) != 0 {
+				t.Errorf("unexpected results parsing %s: %s", test.Kubernetes, awsInstanceIds)
+			}
+		} else {
+			if len(awsInstanceIds) != 1 {
+				t.Errorf("unexpected value parsing %s, got %s", test.Kubernetes, awsInstanceIds)
+			} else if awsInstanceIds[0] != test.Aws {
+				t.Errorf("unexpected value parsing %s, got %s", test.Kubernetes, awsInstanceIds)
+			}
+		}
+	}
+}
+
+func TestSnapshotMeetsCriteria(t *testing.T) {
+	snapshot := &allInstancesSnapshot{timestamp: time.Now().Add(-3601 * time.Second)}
+
+	if !snapshot.MeetsCriteria(cacheCriteria{}) {
+		t.Errorf("Snapshot should always meet empty criteria")
+	}
+
+	if snapshot.MeetsCriteria(cacheCriteria{MaxAge: time.Hour}) {
+		t.Errorf("Snapshot did not honor MaxAge")
+	}
+
+	if snapshot.MeetsCriteria(cacheCriteria{HasInstances: []awsInstanceID{awsInstanceID("i-12345678")}}) {
+		t.Errorf("Snapshot did not honor HasInstances with missing instances")
+	}
+
+	snapshot.instances = make(map[awsInstanceID]*ec2.Instance)
+	snapshot.instances[awsInstanceID("i-12345678")] = &ec2.Instance{}
+
+	if !snapshot.MeetsCriteria(cacheCriteria{HasInstances: []awsInstanceID{awsInstanceID("i-12345678")}}) {
+		t.Errorf("Snapshot did not honor HasInstances with matching instances")
+	}
+
+	if snapshot.MeetsCriteria(cacheCriteria{HasInstances: []awsInstanceID{awsInstanceID("i-12345678"), awsInstanceID("i-00000000")}}) {
+		t.Errorf("Snapshot did not honor HasInstances with partially matching instances")
+	}
+}
+
+func TestOlderThan(t *testing.T) {
+	t1 := time.Now()
+	t2 := t1.Add(time.Second)
+
+	s1 := &allInstancesSnapshot{timestamp: t1}
+	s2 := &allInstancesSnapshot{timestamp: t2}
+
+	assert.True(t, s1.olderThan(s2), "s1 should be olderThan s2")
+	assert.False(t, s2.olderThan(s1), "s2 not should be olderThan s1")
+	assert.False(t, s1.olderThan(s1), "s1 not should be olderThan itself")
+}
+
+func TestSnapshotFindInstances(t *testing.T) {
+	snapshot := &allInstancesSnapshot{}
+
+	snapshot.instances = make(map[awsInstanceID]*ec2.Instance)
+	{
+		id := awsInstanceID("i-12345678")
+		snapshot.instances[id] = &ec2.Instance{InstanceId: id.awsString()}
+	}
+	{
+		id := awsInstanceID("i-23456789")
+		snapshot.instances[id] = &ec2.Instance{InstanceId: id.awsString()}
+	}
+
+	instances := snapshot.FindInstances([]awsInstanceID{awsInstanceID("i-12345678"), awsInstanceID("i-23456789"), awsInstanceID("i-00000000")})
+	if len(instances) != 2 {
+		t.Errorf("findInstances returned %d results, expected 2", len(instances))
+	}
+
+	for _, id := range []awsInstanceID{awsInstanceID("i-12345678"), awsInstanceID("i-23456789")} {
+		i := instances[id]
+		if i == nil {
+			t.Errorf("findInstances did not return %s", id)
+			continue
+		}
+		if aws.StringValue(i.InstanceId) != string(id) {
+			t.Errorf("findInstances did not return expected instanceId for %s", id)
+		}
+		if i != snapshot.instances[id] {
+			t.Errorf("findInstances did not return expected instance (reference equality) for %s", id)
+		}
+	}
+}

--- a/pkg/cloudprovider/providers/aws/log_handler.go
+++ b/pkg/cloudprovider/providers/aws/log_handler.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/request"
+	"k8s.io/klog"
+)
+
+// Handler for aws-sdk-go that logs all requests
+func awsHandlerLogger(req *request.Request) {
+	service, name := awsServiceAndName(req)
+	klog.V(4).Infof("AWS request: %s %s", service, name)
+}
+
+func awsSendHandlerLogger(req *request.Request) {
+	service, name := awsServiceAndName(req)
+	klog.V(4).Infof("AWS API Send: %s %s %v %v", service, name, req.Operation, req.Params)
+}
+
+func awsValidateResponseHandlerLogger(req *request.Request) {
+	service, name := awsServiceAndName(req)
+	klog.V(4).Infof("AWS API ValidateResponse: %s %s %v %v %s", service, name, req.Operation, req.Params, req.HTTPResponse.Status)
+}
+
+func awsServiceAndName(req *request.Request) (string, string) {
+	service := req.ClientInfo.ServiceName
+
+	name := "?"
+	if req.Operation != nil {
+		name = req.Operation.Name
+	}
+	return service, name
+}

--- a/pkg/cloudprovider/providers/aws/regions.go
+++ b/pkg/cloudprovider/providers/aws/regions.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"sync"
+
+	"k8s.io/klog"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	awscredentialprovider "k8s.io/kubernetes/pkg/credentialprovider/aws"
+)
+
+// wellKnownRegions is the complete list of regions known to the AWS cloudprovider
+// and credentialprovider.
+var wellKnownRegions = [...]string{
+	// from `aws ec2 describe-regions --region us-east-1 --query Regions[].RegionName | sort`
+	"ap-northeast-1",
+	"ap-northeast-2",
+	"ap-northeast-3",
+	"ap-south-1",
+	"ap-southeast-1",
+	"ap-southeast-2",
+	"ca-central-1",
+	"eu-central-1",
+	"eu-west-1",
+	"eu-west-2",
+	"eu-west-3",
+	"sa-east-1",
+	"us-east-1",
+	"us-east-2",
+	"us-west-1",
+	"us-west-2",
+
+	// these are not registered in many / most accounts
+	"cn-north-1",
+	"cn-northwest-1",
+	"us-gov-west-1",
+}
+
+// awsRegionsMutex protects awsRegions
+var awsRegionsMutex sync.Mutex
+
+// awsRegions is a set of recognized regions
+var awsRegions sets.String
+
+// recognizeRegion is called for each AWS region we know about.
+// It currently registers a credential provider for that region.
+// There are two paths to discovering a region:
+//  * we hard-code some well-known regions
+//  * if a region is discovered from instance metadata, we add that
+func recognizeRegion(region string) {
+	awsRegionsMutex.Lock()
+	defer awsRegionsMutex.Unlock()
+
+	if awsRegions == nil {
+		awsRegions = sets.NewString()
+	}
+
+	if awsRegions.Has(region) {
+		klog.V(6).Infof("found AWS region %q again - ignoring", region)
+		return
+	}
+
+	klog.V(4).Infof("found AWS region %q", region)
+
+	awscredentialprovider.RegisterCredentialsProvider(region)
+
+	awsRegions.Insert(region)
+}
+
+// recognizeWellKnownRegions calls RecognizeRegion on each WellKnownRegion
+func recognizeWellKnownRegions() {
+	for _, region := range wellKnownRegions {
+		recognizeRegion(region)
+	}
+}
+
+// isRegionValid checks if the region is in the set of known regions
+func isRegionValid(region string) bool {
+	awsRegionsMutex.Lock()
+	defer awsRegionsMutex.Unlock()
+
+	return awsRegions.Has(region)
+}

--- a/pkg/cloudprovider/providers/aws/regions_test.go
+++ b/pkg/cloudprovider/providers/aws/regions_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+)
+
+// TestRegions does basic checking of region verification / addition
+func TestRegions(t *testing.T) {
+	recognizeWellKnownRegions()
+
+	tests := []struct {
+		Add            string
+		Lookup         string
+		ExpectIsRegion bool
+	}{
+		{
+			Lookup:         "us-east-1",
+			ExpectIsRegion: true,
+		},
+		{
+			Lookup:         "us-east-1a",
+			ExpectIsRegion: false,
+		},
+		{
+			Add:            "us-test-1",
+			Lookup:         "us-east-1",
+			ExpectIsRegion: true,
+		},
+		{
+			Lookup:         "us-test-1",
+			ExpectIsRegion: true,
+		},
+		{
+			Add:            "us-test-1",
+			Lookup:         "us-test-1",
+			ExpectIsRegion: true,
+		},
+	}
+
+	for _, test := range tests {
+		if test.Add != "" {
+			recognizeRegion(test.Add)
+		}
+
+		if test.Lookup != "" {
+			if isRegionValid(test.Lookup) != test.ExpectIsRegion {
+				t.Fatalf("region valid mismatch: %q", test.Lookup)
+			}
+		}
+	}
+}
+
+// TestRecognizesNewRegion verifies that we see a region from metadata, we recognize it as valid
+func TestRecognizesNewRegion(t *testing.T) {
+	region := "us-testrecognizesnewregion-1"
+	if isRegionValid(region) {
+		t.Fatalf("region already valid: %q", region)
+	}
+
+	awsServices := NewFakeAWSServices(TestClusterID).WithAz(region + "a")
+	_, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("error building AWS cloud: %v", err)
+	}
+
+	if !isRegionValid(region) {
+		t.Fatalf("newly discovered region not valid: %q", region)
+	}
+}

--- a/pkg/cloudprovider/providers/aws/retry_handler.go
+++ b/pkg/cloudprovider/providers/aws/retry_handler.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"k8s.io/klog"
+)
+
+const (
+	decayIntervalSeconds = 20
+	decayFraction        = 0.8
+	maxDelay             = 60 * time.Second
+)
+
+// CrossRequestRetryDelay inserts delays before AWS calls, when we are observing RequestLimitExceeded errors
+// Note that we share a CrossRequestRetryDelay across multiple AWS requests; this is a process-wide back-off,
+// whereas the aws-sdk-go implements a per-request exponential backoff/retry
+type CrossRequestRetryDelay struct {
+	backoff Backoff
+}
+
+// NewCrossRequestRetryDelay creates a new CrossRequestRetryDelay
+func NewCrossRequestRetryDelay() *CrossRequestRetryDelay {
+	c := &CrossRequestRetryDelay{}
+	c.backoff.init(decayIntervalSeconds, decayFraction, maxDelay)
+	return c
+}
+
+// BeforeSign is added to the Sign chain; called before each request
+func (c *CrossRequestRetryDelay) BeforeSign(r *request.Request) {
+	now := time.Now()
+	delay := c.backoff.ComputeDelayForRequest(now)
+	if delay > 0 {
+		klog.Warningf("Inserting delay before AWS request (%s) to avoid RequestLimitExceeded: %s",
+			describeRequest(r), delay.String())
+
+		if sleepFn := r.Config.SleepDelay; sleepFn != nil {
+			// Support SleepDelay for backwards compatibility
+			sleepFn(delay)
+		} else if err := aws.SleepWithContext(r.Context(), delay); err != nil {
+			r.Error = awserr.New(request.CanceledErrorCode, "request context canceled", err)
+			r.Retryable = aws.Bool(false)
+			return
+		}
+
+		// Avoid clock skew problems
+		r.Time = now
+	}
+}
+
+// Return the operation name, for use in log messages and metrics
+func operationName(r *request.Request) string {
+	name := "?"
+	if r.Operation != nil {
+		name = r.Operation.Name
+	}
+	return name
+}
+
+// Return a user-friendly string describing the request, for use in log messages
+func describeRequest(r *request.Request) string {
+	service := r.ClientInfo.ServiceName
+	return service + "::" + operationName(r)
+}
+
+// AfterRetry is added to the AfterRetry chain; called after any error
+func (c *CrossRequestRetryDelay) AfterRetry(r *request.Request) {
+	if r.Error == nil {
+		return
+	}
+	awsError, ok := r.Error.(awserr.Error)
+	if !ok {
+		return
+	}
+	if awsError.Code() == "RequestLimitExceeded" {
+		c.backoff.ReportError()
+		recordAWSThrottlesMetric(operationName(r))
+		klog.Warningf("Got RequestLimitExceeded error on AWS request (%s)",
+			describeRequest(r))
+	}
+}
+
+// Backoff manages a backoff that varies based on the recently observed failures
+type Backoff struct {
+	decayIntervalSeconds int64
+	decayFraction        float64
+	maxDelay             time.Duration
+
+	mutex sync.Mutex
+
+	// We count all requests & the number of requests which hit a
+	// RequestLimit.  We only really care about 'recent' requests, so we
+	// decay the counts exponentially to bias towards recent values.
+	countErrorsRequestLimit float32
+	countRequests           float32
+	lastDecay               int64
+}
+
+func (b *Backoff) init(decayIntervalSeconds int, decayFraction float64, maxDelay time.Duration) {
+	b.lastDecay = time.Now().Unix()
+	// Bias so that if the first request hits the limit we don't immediately apply the full delay
+	b.countRequests = 4
+	b.decayIntervalSeconds = int64(decayIntervalSeconds)
+	b.decayFraction = decayFraction
+	b.maxDelay = maxDelay
+}
+
+// ComputeDelayForRequest computes the delay required for a request, also
+// updates internal state to count this request
+func (b *Backoff) ComputeDelayForRequest(now time.Time) time.Duration {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	// Apply exponential decay to the counters
+	timeDeltaSeconds := now.Unix() - b.lastDecay
+	if timeDeltaSeconds > b.decayIntervalSeconds {
+		intervals := float64(timeDeltaSeconds) / float64(b.decayIntervalSeconds)
+		decay := float32(math.Pow(b.decayFraction, intervals))
+		b.countErrorsRequestLimit *= decay
+		b.countRequests *= decay
+		b.lastDecay = now.Unix()
+	}
+
+	// Count this request
+	b.countRequests += 1.0
+
+	// Compute the failure rate
+	errorFraction := float32(0.0)
+	if b.countRequests > 0.5 {
+		// Avoid tiny residuals & rounding errors
+		errorFraction = b.countErrorsRequestLimit / b.countRequests
+	}
+
+	// Ignore a low fraction of errors
+	// This also allows them to time-out
+	if errorFraction < 0.1 {
+		return time.Duration(0)
+	}
+
+	// Delay by the max delay multiplied by the recent error rate
+	// (i.e. we apply a linear delay function)
+	// TODO: This is pretty arbitrary
+	delay := time.Nanosecond * time.Duration(float32(b.maxDelay.Nanoseconds())*errorFraction)
+	// Round down to the nearest second for sanity
+	return time.Second * time.Duration(int(delay.Seconds()))
+}
+
+// ReportError is called when we observe a throttling error
+func (b *Backoff) ReportError() {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	b.countErrorsRequestLimit += 1.0
+}

--- a/pkg/cloudprovider/providers/aws/retry_handler_test.go
+++ b/pkg/cloudprovider/providers/aws/retry_handler_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+	"time"
+)
+
+// There follows a group of tests for the backoff logic.  There's nothing
+// particularly special about the values chosen: if we tweak the values in the
+// backoff logic then we might well have to update the tests.  However the key
+// behavioural elements should remain (e.g. no errors => no backoff), and these
+// are each tested by one of the tests below.
+
+// Test that we don't apply any delays when there are no errors
+func TestBackoffNoErrors(t *testing.T) {
+	b := &Backoff{}
+	b.init(decayIntervalSeconds, decayFraction, maxDelay)
+
+	now := time.Now()
+	for i := 0; i < 100; i++ {
+		d := b.ComputeDelayForRequest(now)
+		if d.Nanoseconds() != 0 {
+			t.Fatalf("unexpected delay during no-error case")
+		}
+		now = now.Add(time.Second)
+	}
+}
+
+// Test that we always apply a delay when there are errors, and also that we
+// don't "flap" - that our own delay doesn't cause us to oscillate between
+// delay and no-delay.
+func TestBackoffAllErrors(t *testing.T) {
+	b := &Backoff{}
+	b.init(decayIntervalSeconds, decayFraction, maxDelay)
+
+	now := time.Now()
+	// Warm up
+	for i := 0; i < 10; i++ {
+		_ = b.ComputeDelayForRequest(now)
+		b.ReportError()
+		now = now.Add(time.Second)
+	}
+
+	for i := 0; i < 100; i++ {
+		d := b.ComputeDelayForRequest(now)
+		b.ReportError()
+		if d.Seconds() < 5 {
+			t.Fatalf("unexpected short-delay during all-error case: %v", d)
+		}
+		t.Logf("delay @%d %v", i, d)
+		now = now.Add(d)
+	}
+}
+
+// Test that we do come close to our max delay, when we see all errors at 1
+// second intervals (this simulates multiple concurrent requests, because we
+// don't wait for delay in between requests)
+func TestBackoffHitsMax(t *testing.T) {
+	b := &Backoff{}
+	b.init(decayIntervalSeconds, decayFraction, maxDelay)
+
+	now := time.Now()
+	for i := 0; i < 100; i++ {
+		_ = b.ComputeDelayForRequest(now)
+		b.ReportError()
+		now = now.Add(time.Second)
+	}
+
+	for i := 0; i < 10; i++ {
+		d := b.ComputeDelayForRequest(now)
+		b.ReportError()
+		if float32(d.Nanoseconds()) < (float32(maxDelay.Nanoseconds()) * 0.95) {
+			t.Fatalf("expected delay to be >= 95 percent of max delay, was %v", d)
+		}
+		t.Logf("delay @%d %v", i, d)
+		now = now.Add(time.Second)
+	}
+}
+
+// Test that after a phase of errors, we eventually stop applying a delay once there are
+// no more errors.
+func TestBackoffRecovers(t *testing.T) {
+	b := &Backoff{}
+	b.init(decayIntervalSeconds, decayFraction, maxDelay)
+
+	now := time.Now()
+
+	// Phase of all-errors
+	for i := 0; i < 100; i++ {
+		_ = b.ComputeDelayForRequest(now)
+		b.ReportError()
+		now = now.Add(time.Second)
+	}
+
+	for i := 0; i < 10; i++ {
+		d := b.ComputeDelayForRequest(now)
+		b.ReportError()
+		if d.Seconds() < 5 {
+			t.Fatalf("unexpected short-delay during all-error phase: %v", d)
+		}
+		t.Logf("error phase delay @%d %v", i, d)
+		now = now.Add(time.Second)
+	}
+
+	// Phase of no errors
+	for i := 0; i < 100; i++ {
+		_ = b.ComputeDelayForRequest(now)
+		now = now.Add(3 * time.Second)
+	}
+
+	for i := 0; i < 10; i++ {
+		d := b.ComputeDelayForRequest(now)
+		if d.Seconds() != 0 {
+			t.Fatalf("unexpected delay during error recovery phase: %v", d)
+		}
+		t.Logf("no-error phase delay @%d %v", i, d)
+		now = now.Add(time.Second)
+	}
+}

--- a/pkg/cloudprovider/providers/aws/sets_ippermissions.go
+++ b/pkg/cloudprovider/providers/aws/sets_ippermissions.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// IPPermissionSet maps IP strings of strings to EC2 IpPermissions
+type IPPermissionSet map[string]*ec2.IpPermission
+
+// NewIPPermissionSet creates a new IPPermissionSet
+func NewIPPermissionSet(items ...*ec2.IpPermission) IPPermissionSet {
+	s := make(IPPermissionSet)
+	s.Insert(items...)
+	return s
+}
+
+// Ungroup splits permissions out into individual permissions
+// EC2 will combine permissions with the same port but different SourceRanges together, for example
+// We ungroup them so we can process them
+func (s IPPermissionSet) Ungroup() IPPermissionSet {
+	l := []*ec2.IpPermission{}
+	for _, p := range s.List() {
+		if len(p.IpRanges) <= 1 {
+			l = append(l, p)
+			continue
+		}
+		for _, ipRange := range p.IpRanges {
+			c := &ec2.IpPermission{}
+			*c = *p
+			c.IpRanges = []*ec2.IpRange{ipRange}
+			l = append(l, c)
+		}
+	}
+
+	l2 := []*ec2.IpPermission{}
+	for _, p := range l {
+		if len(p.UserIdGroupPairs) <= 1 {
+			l2 = append(l2, p)
+			continue
+		}
+		for _, u := range p.UserIdGroupPairs {
+			c := &ec2.IpPermission{}
+			*c = *p
+			c.UserIdGroupPairs = []*ec2.UserIdGroupPair{u}
+			l2 = append(l, c)
+		}
+	}
+
+	l3 := []*ec2.IpPermission{}
+	for _, p := range l2 {
+		if len(p.PrefixListIds) <= 1 {
+			l3 = append(l3, p)
+			continue
+		}
+		for _, v := range p.PrefixListIds {
+			c := &ec2.IpPermission{}
+			*c = *p
+			c.PrefixListIds = []*ec2.PrefixListId{v}
+			l3 = append(l3, c)
+		}
+	}
+
+	return NewIPPermissionSet(l3...)
+}
+
+// Insert adds items to the set.
+func (s IPPermissionSet) Insert(items ...*ec2.IpPermission) {
+	for _, p := range items {
+		k := keyForIPPermission(p)
+		s[k] = p
+	}
+}
+
+// List returns the contents as a slice.  Order is not defined.
+func (s IPPermissionSet) List() []*ec2.IpPermission {
+	res := make([]*ec2.IpPermission, 0, len(s))
+	for _, v := range s {
+		res = append(res, v)
+	}
+	return res
+}
+
+// IsSuperset returns true if and only if s is a superset of s2.
+func (s IPPermissionSet) IsSuperset(s2 IPPermissionSet) bool {
+	for k := range s2 {
+		_, found := s[k]
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s IPPermissionSet) Equal(s2 IPPermissionSet) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s IPPermissionSet) Difference(s2 IPPermissionSet) IPPermissionSet {
+	result := NewIPPermissionSet()
+	for k, v := range s {
+		_, found := s2[k]
+		if !found {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+// Len returns the size of the set.
+func (s IPPermissionSet) Len() int {
+	return len(s)
+}
+
+func keyForIPPermission(p *ec2.IpPermission) string {
+	v, err := json.Marshal(p)
+	if err != nil {
+		panic(fmt.Sprintf("error building JSON representation of ec2.IpPermission: %v", err))
+	}
+	return string(v)
+}

--- a/pkg/cloudprovider/providers/aws/tags.go
+++ b/pkg/cloudprovider/providers/aws/tags.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/klog"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// TagNameKubernetesClusterPrefix is the tag name we use to differentiate multiple
+// logically independent clusters running in the same AZ.
+// The tag key = TagNameKubernetesClusterPrefix + clusterID
+// The tag value is an ownership value
+const TagNameKubernetesClusterPrefix = "kubernetes.io/cluster/"
+
+// TagNameKubernetesClusterLegacy is the legacy tag name we use to differentiate multiple
+// logically independent clusters running in the same AZ.  The problem with it was that it
+// did not allow shared resources.
+const TagNameKubernetesClusterLegacy = "KubernetesCluster"
+
+// ResourceLifecycle is the cluster lifecycle state used in tagging
+type ResourceLifecycle string
+
+const (
+	// ResourceLifecycleOwned is the value we use when tagging resources to indicate
+	// that the resource is considered owned and managed by the cluster,
+	// and in particular that the lifecycle is tied to the lifecycle of the cluster.
+	ResourceLifecycleOwned = "owned"
+	// ResourceLifecycleShared is the value we use when tagging resources to indicate
+	// that the resource is shared between multiple clusters, and should not be destroyed
+	// if the cluster is destroyed.
+	ResourceLifecycleShared = "shared"
+)
+
+type awsTagging struct {
+	// ClusterID is our cluster identifier: we tag AWS resources with this value,
+	// and thus we can run two independent clusters in the same VPC or subnets.
+	// This gives us similar functionality to GCE projects.
+	ClusterID string
+
+	// usesLegacyTags is true if we are using the legacy TagNameKubernetesClusterLegacy tags
+	usesLegacyTags bool
+}
+
+func (t *awsTagging) init(legacyClusterID string, clusterID string) error {
+	if legacyClusterID != "" {
+		if clusterID != "" && legacyClusterID != clusterID {
+			return fmt.Errorf("ClusterID tags did not match: %q vs %q", clusterID, legacyClusterID)
+		}
+		t.usesLegacyTags = true
+		clusterID = legacyClusterID
+	}
+
+	t.ClusterID = clusterID
+
+	if clusterID != "" {
+		klog.Infof("AWS cloud filtering on ClusterID: %v", clusterID)
+	} else {
+		return fmt.Errorf("AWS cloud failed to find ClusterID")
+	}
+
+	return nil
+}
+
+// Extracts a clusterID from the given tags, if one is present
+// If no clusterID is found, returns "", nil
+// If multiple (different) clusterIDs are found, returns an error
+func (t *awsTagging) initFromTags(tags []*ec2.Tag) error {
+	legacyClusterID, newClusterID, err := findClusterIDs(tags)
+	if err != nil {
+		return err
+	}
+
+	if legacyClusterID == "" && newClusterID == "" {
+		klog.Errorf("Tag %q nor %q not found; Kubernetes may behave unexpectedly.", TagNameKubernetesClusterLegacy, TagNameKubernetesClusterPrefix+"...")
+	}
+
+	return t.init(legacyClusterID, newClusterID)
+}
+
+// Extracts the legacy & new cluster ids from the given tags, if they are present
+// If duplicate tags are found, returns an error
+func findClusterIDs(tags []*ec2.Tag) (string, string, error) {
+	legacyClusterID := ""
+	newClusterID := ""
+
+	for _, tag := range tags {
+		tagKey := aws.StringValue(tag.Key)
+		if strings.HasPrefix(tagKey, TagNameKubernetesClusterPrefix) {
+			id := strings.TrimPrefix(tagKey, TagNameKubernetesClusterPrefix)
+			if newClusterID != "" {
+				return "", "", fmt.Errorf("Found multiple cluster tags with prefix %s (%q and %q)", TagNameKubernetesClusterPrefix, newClusterID, id)
+			}
+			newClusterID = id
+		}
+
+		if tagKey == TagNameKubernetesClusterLegacy {
+			id := aws.StringValue(tag.Value)
+			if legacyClusterID != "" {
+				return "", "", fmt.Errorf("Found multiple %s tags (%q and %q)", TagNameKubernetesClusterLegacy, legacyClusterID, id)
+			}
+			legacyClusterID = id
+		}
+	}
+
+	return legacyClusterID, newClusterID, nil
+}
+
+func (t *awsTagging) clusterTagKey() string {
+	return TagNameKubernetesClusterPrefix + t.ClusterID
+}
+
+func (t *awsTagging) hasClusterTag(tags []*ec2.Tag) bool {
+	// if the clusterID is not configured -- we consider all instances.
+	if len(t.ClusterID) == 0 {
+		return true
+	}
+	clusterTagKey := t.clusterTagKey()
+	for _, tag := range tags {
+		tagKey := aws.StringValue(tag.Key)
+		// For 1.6, we continue to recognize the legacy tags, for the 1.5 -> 1.6 upgrade
+		// Note that we want to continue traversing tag list if we see a legacy tag with value != ClusterID
+		if (tagKey == TagNameKubernetesClusterLegacy) && (aws.StringValue(tag.Value) == t.ClusterID) {
+			return true
+		}
+		if tagKey == clusterTagKey {
+			return true
+		}
+	}
+	return false
+}
+
+// Ensure that a resource has the correct tags
+// If it has no tags, we assume that this was a problem caused by an error in between creation and tagging,
+// and we add the tags.  If it has a different cluster's tags, that is an error.
+func (t *awsTagging) readRepairClusterTags(client EC2, resourceID string, lifecycle ResourceLifecycle, additionalTags map[string]string, observedTags []*ec2.Tag) error {
+	actualTagMap := make(map[string]string)
+	for _, tag := range observedTags {
+		actualTagMap[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
+	}
+
+	expectedTags := t.buildTags(lifecycle, additionalTags)
+
+	addTags := make(map[string]string)
+	for k, expected := range expectedTags {
+		actual := actualTagMap[k]
+		if actual == expected {
+			continue
+		}
+		if actual == "" {
+			klog.Warningf("Resource %q was missing expected cluster tag %q.  Will add (with value %q)", resourceID, k, expected)
+			addTags[k] = expected
+		} else {
+			return fmt.Errorf("resource %q has tag belonging to another cluster: %q=%q (expected %q)", resourceID, k, actual, expected)
+		}
+	}
+
+	if len(addTags) == 0 {
+		return nil
+	}
+
+	if err := t.createTags(client, resourceID, lifecycle, addTags); err != nil {
+		return fmt.Errorf("error adding missing tags to resource %q: %q", resourceID, err)
+	}
+
+	return nil
+}
+
+// createTags calls EC2 CreateTags, but adds retry-on-failure logic
+// We retry mainly because if we create an object, we cannot tag it until it is "fully created" (eventual consistency)
+// The error code varies though (depending on what we are tagging), so we simply retry on all errors
+func (t *awsTagging) createTags(client EC2, resourceID string, lifecycle ResourceLifecycle, additionalTags map[string]string) error {
+	tags := t.buildTags(lifecycle, additionalTags)
+
+	if tags == nil || len(tags) == 0 {
+		return nil
+	}
+
+	var awsTags []*ec2.Tag
+	for k, v := range tags {
+		tag := &ec2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+		awsTags = append(awsTags, tag)
+	}
+
+	backoff := wait.Backoff{
+		Duration: createTagInitialDelay,
+		Factor:   createTagFactor,
+		Steps:    createTagSteps,
+	}
+	request := &ec2.CreateTagsInput{}
+	request.Resources = []*string{&resourceID}
+	request.Tags = awsTags
+
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		_, err := client.CreateTags(request)
+		if err == nil {
+			return true, nil
+		}
+
+		// We could check that the error is retryable, but the error code changes based on what we are tagging
+		// SecurityGroup: InvalidGroup.NotFound
+		klog.V(2).Infof("Failed to create tags; will retry.  Error was %q", err)
+		lastErr = err
+		return false, nil
+	})
+	if err == wait.ErrWaitTimeout {
+		// return real CreateTags error instead of timeout
+		err = lastErr
+	}
+	return err
+}
+
+// Add additional filters, to match on our tags
+// This lets us run multiple k8s clusters in a single EC2 AZ
+func (t *awsTagging) addFilters(filters []*ec2.Filter) []*ec2.Filter {
+	// if there are no clusterID configured - no filtering by special tag names
+	// should be applied to revert to legacy behaviour.
+	if len(t.ClusterID) == 0 {
+		if len(filters) == 0 {
+			// We can't pass a zero-length Filters to AWS (it's an error)
+			// So if we end up with no filters; just return nil
+			return nil
+		}
+		return filters
+	}
+	// For 1.6, we always recognize the legacy tag, for the 1.5 -> 1.6 upgrade
+	// There are no "or" filters by key, so we look for both the legacy and new key, and then we have to post-filter
+	f := newEc2Filter("tag-key", TagNameKubernetesClusterLegacy, t.clusterTagKey())
+
+	// We can't pass a zero-length Filters to AWS (it's an error)
+	// So if we end up with no filters; we need to return nil
+	filters = append(filters, f)
+	return filters
+}
+
+func (t *awsTagging) buildTags(lifecycle ResourceLifecycle, additionalTags map[string]string) map[string]string {
+	tags := make(map[string]string)
+	for k, v := range additionalTags {
+		tags[k] = v
+	}
+
+	// no clusterID is a sign of misconfigured cluster, but we can't be tagging the resources with empty
+	// strings
+	if len(t.ClusterID) == 0 {
+		return tags
+	}
+
+	// We only create legacy tags if we are using legacy tags, i.e. if we have seen a legacy tag on our instance
+	if t.usesLegacyTags {
+		tags[TagNameKubernetesClusterLegacy] = t.ClusterID
+	}
+	tags[t.clusterTagKey()] = string(lifecycle)
+
+	return tags
+}
+
+func (t *awsTagging) clusterID() string {
+	return t.ClusterID
+}

--- a/pkg/cloudprovider/providers/aws/tags_test.go
+++ b/pkg/cloudprovider/providers/aws/tags_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func TestFilterTags(t *testing.T) {
+	awsServices := NewFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+
+	if c.tagging.ClusterID != TestClusterID {
+		t.Errorf("unexpected ClusterID: %v", c.tagging.ClusterID)
+	}
+}
+
+func TestFindClusterID(t *testing.T) {
+	grid := []struct {
+		Tags           map[string]string
+		ExpectedNew    string
+		ExpectedLegacy string
+		ExpectError    bool
+	}{
+		{
+			Tags: map[string]string{},
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterLegacy: "a",
+			},
+			ExpectedLegacy: "a",
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterPrefix + "a": "owned",
+			},
+			ExpectedNew: "a",
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterPrefix + "a": "shared",
+			},
+			ExpectedNew: "a",
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterPrefix + "a": "",
+			},
+			ExpectedNew: "a",
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterLegacy:       "a",
+				TagNameKubernetesClusterPrefix + "a": "",
+			},
+			ExpectedLegacy: "a",
+			ExpectedNew:    "a",
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterPrefix + "a": "",
+				TagNameKubernetesClusterPrefix + "b": "",
+			},
+			ExpectError: true,
+		},
+	}
+	for _, g := range grid {
+		var ec2Tags []*ec2.Tag
+		for k, v := range g.Tags {
+			ec2Tags = append(ec2Tags, &ec2.Tag{Key: aws.String(k), Value: aws.String(v)})
+		}
+		actualLegacy, actualNew, err := findClusterIDs(ec2Tags)
+		if g.ExpectError {
+			if err == nil {
+				t.Errorf("expected error for tags %v", g.Tags)
+				continue
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error for tags %v: %v", g.Tags, err)
+				continue
+			}
+
+			if g.ExpectedNew != actualNew {
+				t.Errorf("unexpected new clusterid for tags %v: %s vs %s", g.Tags, g.ExpectedNew, actualNew)
+				continue
+			}
+
+			if g.ExpectedLegacy != actualLegacy {
+				t.Errorf("unexpected new clusterid for tags %v: %s vs %s", g.Tags, g.ExpectedLegacy, actualLegacy)
+				continue
+			}
+		}
+	}
+}
+
+func TestHasClusterTag(t *testing.T) {
+	awsServices := NewFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+	grid := []struct {
+		Tags     map[string]string
+		Expected bool
+	}{
+		{
+			Tags: map[string]string{},
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterLegacy: TestClusterID,
+			},
+			Expected: true,
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterLegacy: "a",
+			},
+			Expected: false,
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterPrefix + TestClusterID: "owned",
+			},
+			Expected: true,
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterPrefix + TestClusterID: "",
+			},
+			Expected: true,
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterLegacy:                 "a",
+				TagNameKubernetesClusterPrefix + TestClusterID: "shared",
+			},
+			Expected: true,
+		},
+		{
+			Tags: map[string]string{
+				TagNameKubernetesClusterPrefix + TestClusterID: "shared",
+				TagNameKubernetesClusterPrefix + "b":           "shared",
+			},
+			Expected: true,
+		},
+	}
+	for _, g := range grid {
+		var ec2Tags []*ec2.Tag
+		for k, v := range g.Tags {
+			ec2Tags = append(ec2Tags, &ec2.Tag{Key: aws.String(k), Value: aws.String(v)})
+		}
+		result := c.tagging.hasClusterTag(ec2Tags)
+		if result != g.Expected {
+			t.Errorf("Unexpected result for tags %v: %t", g.Tags, result)
+		}
+	}
+}

--- a/pkg/cloudprovider/providers/aws/volumes.go
+++ b/pkg/cloudprovider/providers/aws/volumes.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/klog"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// awsVolumeRegMatch represents Regex Match for AWS volume.
+var awsVolumeRegMatch = regexp.MustCompile("^vol-[^/]*$")
+
+// EBSVolumeID represents the ID of the volume in the AWS API, e.g.
+// vol-12345678 The "traditional" format is "vol-12345678" A new longer format
+// is also being introduced: "vol-12345678abcdef01" We should not assume
+// anything about the length or format, though it seems reasonable to assume
+// that volumes will continue to start with "vol-".
+type EBSVolumeID string
+
+func (i EBSVolumeID) awsString() *string {
+	return aws.String(string(i))
+}
+
+// KubernetesVolumeID represents the id for a volume in the kubernetes API;
+// a few forms are recognized:
+//  * aws://<zone>/<awsVolumeId>
+//  * aws:///<awsVolumeId>
+//  * <awsVolumeId>
+type KubernetesVolumeID string
+
+// DiskInfo returns aws disk information in easy to use manner
+type diskInfo struct {
+	ec2Instance     *ec2.Instance
+	nodeName        types.NodeName
+	volumeState     string
+	attachmentState string
+	hasAttachment   bool
+	disk            *awsDisk
+}
+
+// MapToAWSVolumeID extracts the EBSVolumeID from the KubernetesVolumeID
+func (name KubernetesVolumeID) MapToAWSVolumeID() (EBSVolumeID, error) {
+	// name looks like aws://availability-zone/awsVolumeId
+
+	// The original idea of the URL-style name was to put the AZ into the
+	// host, so we could find the AZ immediately from the name without
+	// querying the API.  But it turns out we don't actually need it for
+	// multi-AZ clusters, as we put the AZ into the labels on the PV instead.
+	// However, if in future we want to support multi-AZ cluster
+	// volume-awareness without using PersistentVolumes, we likely will
+	// want the AZ in the host.
+
+	s := string(name)
+
+	if !strings.HasPrefix(s, "aws://") {
+		// Assume a bare aws volume id (vol-1234...)
+		// Build a URL with an empty host (AZ)
+		s = "aws://" + "" + "/" + s
+	}
+	url, err := url.Parse(s)
+	if err != nil {
+		// TODO: Maybe we should pass a URL into the Volume functions
+		return "", fmt.Errorf("Invalid disk name (%s): %v", name, err)
+	}
+	if url.Scheme != "aws" {
+		return "", fmt.Errorf("Invalid scheme for AWS volume (%s)", name)
+	}
+
+	awsID := url.Path
+	awsID = strings.Trim(awsID, "/")
+
+	// We sanity check the resulting volume; the two known formats are
+	// vol-12345678 and vol-12345678abcdef01
+	if !awsVolumeRegMatch.MatchString(awsID) {
+		return "", fmt.Errorf("Invalid format for AWS volume (%s)", name)
+	}
+
+	return EBSVolumeID(awsID), nil
+}
+
+// GetAWSVolumeID converts a Kubernetes volume ID to an AWS volume ID
+func GetAWSVolumeID(kubeVolumeID string) (string, error) {
+	kid := KubernetesVolumeID(kubeVolumeID)
+	awsID, err := kid.MapToAWSVolumeID()
+	return string(awsID), err
+}
+
+func (c *Cloud) checkIfAttachedToNode(diskName KubernetesVolumeID, nodeName types.NodeName) (*diskInfo, bool, error) {
+	disk, err := newAWSDisk(c, diskName)
+
+	if err != nil {
+		return nil, true, err
+	}
+
+	awsDiskInfo := &diskInfo{
+		disk: disk,
+	}
+
+	info, err := disk.describeVolume()
+
+	if err != nil {
+		klog.Warningf("Error describing volume %s with %v", diskName, err)
+		awsDiskInfo.volumeState = "unknown"
+		return awsDiskInfo, false, err
+	}
+
+	awsDiskInfo.volumeState = aws.StringValue(info.State)
+
+	if len(info.Attachments) > 0 {
+		attachment := info.Attachments[0]
+		awsDiskInfo.attachmentState = aws.StringValue(attachment.State)
+		instanceID := aws.StringValue(attachment.InstanceId)
+		instanceInfo, err := c.getInstanceByID(instanceID)
+
+		// This should never happen but if it does it could mean there was a race and instance
+		// has been deleted
+		if err != nil {
+			fetchErr := fmt.Errorf("Error fetching instance %s for volume %s", instanceID, diskName)
+			klog.Warning(fetchErr)
+			return awsDiskInfo, false, fetchErr
+		}
+
+		awsDiskInfo.ec2Instance = instanceInfo
+		awsDiskInfo.nodeName = mapInstanceToNodeName(instanceInfo)
+		awsDiskInfo.hasAttachment = true
+		if awsDiskInfo.nodeName == nodeName {
+			return awsDiskInfo, true, nil
+		}
+	}
+	return awsDiskInfo, false, nil
+}


### PR DESCRIPTION
Copies the latest version of the AWS cloud provider from kubernetes/kubernetes@0df79e4daa into this package. Future maintenance will occur here and patches from in-tree updates will be applied regularly to keep the code-bases in sync.

There is nothing that needs detailed review in this commit as the code was copied completely unmodified from kubernetes/kubernetes.

/cc @d-nishi 
/milestone v1.13
/kind feature
/sig aws
/sig cloud-provider