### PR TITLE
Add changelog for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+changelogs/CHANGELOG-0.1.md

--- a/changelogs/CHANGELOG-0.1.md
+++ b/changelogs/CHANGELOG-0.1.md
@@ -1,0 +1,17 @@
+# v0.1.0
+[Documentation](https://github.com/kubernetes/cloud-provider-aws/blob/v0.1.0/docs/README.md)
+
+## Downloads for v0.1.0
+
+filename  | sha512 hash
+--------- | ------------
+[v0.1.0.tar.gz](https://github.com/kubernetes/cloud-provider-aws/archive/v0.1.0.tar.gz) | `52874333f27b9c747e39103866d1d4c06f2f4531075494a65d8d4fa82f319257fe837b1f72f3df98b3dc146fe34ad32c6a220abcc7cbba649e06ab42d213e62e`
+[v0.1.0.zip](https://github.com/kubernetes/cloud-provider-aws/archive/v0.1.0.zip) | `a8d7573c7710174563eb0afbdcfec38e61787f242e4f280303bdce21bb9eca503a56cdb3b73af0752d1de2693e462914d35a7ce72e49ff0b4f159c10ba121c83`
+
+## Changelog since initial commit
+
+### Notable changes
+* Update cloud provider to work out-of-tree ([#19](https://github.com/kubernetes/cloud-provider-aws/pull/19))
+* Bring dependencies up-to-date ([#18](https://github.com/kubernetes/cloud-provider-aws/pull/18))
+* Synchronization of cloud provider code from kubernetes/kubernetes ([#17](https://github.com/kubernetes/cloud-provider-aws/pull/17))
+* Initial commit ([b377713](https://github.com/kubernetes/cloud-provider-aws/commit/b377713a2f1de9d744a6f706b77b9d16f72012ed))


### PR DESCRIPTION
This adds the changelog for the alpha v0.1.0 release. The hashes are provisional based on my fork as I don't yet have access to create tags in this repo.

/milestone v1.13
/kind feature
/sig aws
/sig cloud-provider
/assign @d-nishi 