### PR TITLE
removed trailing comma from Master policy in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For the aws-cloud-controller-manager to be able to communicate to AWS APIs, you 
       "Resource": [
         "*"
       ]
-    },
+    }
   ]
 }
 


### PR DESCRIPTION
In `README.md` Master policy section trailing section had a `'` (comma). If you don't have multiple section this code be syntax issue for json.