### PR TITLE
use the correct cloudprovider package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,6 @@ require (
 	k8s.io/apimachinery v0.0.0-20180913025736-6dd46049f395
 	k8s.io/apiserver v0.0.0-20181004124341-e85ad7b666fe
 	k8s.io/client-go v9.0.0+incompatible
-	k8s.io/cloud-provider v0.0.0-20181110194211-3a19c034b793
 	k8s.io/csi-api v0.0.0-20181110193203-3ace7a84ffef // indirect
 	k8s.io/klog v0.1.0
 	k8s.io/kube-controller-manager v0.0.0-20181110193944-1c4e86102515 // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,6 @@ k8s.io/apiserver v0.0.0-20181004124341-e85ad7b666fe h1:QNs3vf1GO871H/R8rUYJpiXjp
 k8s.io/apiserver v0.0.0-20181004124341-e85ad7b666fe/go.mod h1:6bqaTSOSJavUIXUtfaR9Os9JtTCm8ZqH2SUl2S60C4w=
 k8s.io/client-go v9.0.0+incompatible h1:2kqW3X2xQ9SbFvWZjGEHBLlWc1LG9JIJNXWkuqwdZ3A=
 k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
-k8s.io/cloud-provider v0.0.0-20181110194211-3a19c034b793 h1:K5QHP5ATvQLs9PW9S9o3BR1gxZ7V51cz/W8mQRGbyiU=
-k8s.io/cloud-provider v0.0.0-20181110194211-3a19c034b793/go.mod h1:LlIffnLBu+GG7d4ppPzC8UnA1Ex8S+ntmSRVsnr7Xy4=
 k8s.io/csi-api v0.0.0-20181110193203-3ace7a84ffef h1:DmRrl2VELxcrsA2gONfirs7nAZ7Oj+4QDXqGkPozAZE=
 k8s.io/csi-api v0.0.0-20181110193203-3ace7a84ffef/go.mod h1:GH854hXKH+vaEO06X/DMiE/o3rVO1aw8dXJJpP7awjA=
 k8s.io/klog v0.1.0 h1:I5HMfc/DtuVaGR1KPwUrTc476K8NCqNBldC7H4dYEzk=

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -45,7 +45,7 @@ import (
 	gcfg "gopkg.in/gcfg.v1"
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -55,8 +55,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
-	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/kubernetes/pkg/api/v1/service"
+	cloudprovider "k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/volume"
@@ -1157,7 +1157,7 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 }
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
-func (c *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
+func (c *Cloud) Initialize(clientBuilder controller.ControllerClientBuilder) {
 	c.clientBuilder = clientBuilder
 	c.kubeClient = clientBuilder.ClientOrDie("aws-cloud-provider")
 	c.eventBroadcaster = record.NewBroadcaster()

--- a/pkg/cloudprovider/providers/aws/aws_routes.go
+++ b/pkg/cloudprovider/providers/aws/aws_routes.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog"
 
-	cloudprovider "k8s.io/cloud-provider"
+	cloudprovider "k8s.io/kubernetes/pkg/cloudprovider"
 )
 
 func (c *Cloud) findRouteTable(clusterName string) (*ec2.RouteTable, error) {


### PR DESCRIPTION
/kind api-change

There are two implementations of the cloudprovider API in the current code. The package registers with one and the k8s command uses the other and fails to find the aws cloud-provider. This update removes the second implementation.
