### PR TITLE
small fixups to README and a-c-c-m comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # cloud-provider-aws
-The AWS cloud provider provides the interface between a Kubernetes cluster and AWS service APIs. This project allows a Kubernetes cluster to provision, monitor and remove resources necessary for operation of the cluster.
+The AWS cloud provider provides the interface between a Kubernetes cluster and AWS service APIs. This project allows a Kubernetes cluster to provision, monitor and remove AWS resources necessary for operation of the cluster.
 
 ## Flags
 The flag `--cloud-provider=external` needs to be passed to kubelet, kube-apiserver, and kube-controller-manager. You should not pass the --cloud-provider flag to `aws-cloud-controller-manager`.
 
 ## IAM Policy
-For the aws-cloud-controller-manager to be able to communicate to AWS APIs, you will need to create a few IAM policies for your EC2 instances. The master policy is a bit open and can be scaled back depending on the use case. Adjust these based on your needs.
+For the `aws-cloud-controller-manager` to be able to communicate to AWS APIs, you will need to create a few IAM policies for your EC2 instances. The master policy is a bit open and can be scaled back depending on the use case. Adjust these based on your needs.
 
 1. Master Policy
 
@@ -106,9 +106,6 @@ For the aws-cloud-controller-manager to be able to communicate to AWS APIs, you 
   
 ## Proper Node Names
 The cloud provider currently uses the instance private DNS name as the node name, but this is subject to change in the future.
-
-### NOTE
-Currently the implementation of the cloud provider is found in https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/aws, and vendored into this repository. In the future, the implementation will be migrated here and out of Kubernetes core.
 
 # Development
 ## Note 

--- a/cmd/aws-cloud-controller-manager/main.go
+++ b/cmd/aws-cloud-controller-manager/main.go
@@ -14,8 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// The external controller manager is responsible for running controller loops that
-// are cloud provider dependent. It uses the API to listen to new events on resources.
+// aws-cloud-controller-manager is responsible for running controller loops
+// that create, delete and monitor cloud resources on AWS. These cloud
+// resources include EC2 instances and autoscaling groups, along with network
+// load balancers (NLB) and application load balancers (ALBs) The cloud
+// resources help provide a place for both control plane components -- e.g. EC2
+// instances might house Kubernetes worker nodes -- as well as data plane
+// components -- e.g. a Kubernetes Ingress object might be mapped to an EC2
+// application load balancer.
 
 package main
 
@@ -61,8 +67,8 @@ func main() {
 
 	command := &cobra.Command{
 		Use: "aws-cloud-controller-manager",
-		Long: `The Cloud controller manager is a daemon that embeds
-the cloud specific control loops shipped with Kubernetes.`,
+		Long: `aws-cloud-controller-manager manages AWS cloud resources
+for a Kubernetes cluster.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			verflag.PrintAndExitIfRequested()
 			utilflag.PrintFlags(cmd.Flags())


### PR DESCRIPTION
Due to copy-paste from the external cloud controller manager code, some
of the comments in cmd/aws-cloud-controller-manager/main.go were
outdated, so this patch makes those comments specific to the AWS cloud
provider. Also removes a note in the README that no longer applies now
that the cloud-provider-aws code has been split out from k/k.

```release-note
NONE
```