### PR TITLE
Add local-up-cluster script for testing the aws cloud provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /aws-cloud-controller-manager
+/cloudconfig

--- a/README.md
+++ b/README.md
@@ -109,5 +109,14 @@ For the `aws-cloud-controller-manager` to be able to communicate to AWS APIs, yo
 The cloud provider currently uses the instance private DNS name as the node name, but this is subject to change in the future.
 
 # Development
+A local single node cluster can be brought up on AWS by running the local up script while on an AWS EC2 instance.
+Before running this, ensure that the instance you are running on has the `KubernetesCluster` tag. The tag can be any value.
+
+```
+./hack/local-up-cluster.sh
+```
+
+By default this script will use the cloud provider binary from this repository. You will need to have the k8s main repo cloned before running this script.
+
 ## Note 
 * All the EBS volume plugin related logic will be in maintenance mode. For new feature request or bug fixes, please create issue or pull reequest in [EBS CSI Driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+CLOUD_PROVIDER_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+export KUBE_ROOT="$GOPATH/src/k8s.io/kubernetes"
+export NODE_ROLE_ARN=${NODE_ROLE_ARN:-""}
+export CLOUD_PROVIDER=aws
+export EXTERNAL_CLOUD_PROVIDER=true
+export CLOUD_CONFIG=$(pwd)/cloudconfig
+export EXTERNAL_CLOUD_PROVIDER_BINARY="$GOPATH/src/k8s.io/cloud-provider-aws/aws-cloud-controller-manager"
+export NODE_ZONE=${AWS_NODE_ZONE:-"us-west-2a"}
+
+# Stop right away if the build fails
+set -e
+
+make -C "${CLOUD_PROVIDER_ROOT}"
+
+write_cloudconfig() {
+    rm -f $CLOUD_CONFIG
+    cat <<EOF >> $CLOUD_CONFIG
+[Global]
+Zone=$NODE_ZONE
+RoleARN="$NODE_ROLE_ARN"
+EOF
+}
+
+write_cloudconfig
+
+$KUBE_ROOT/hack/local-up-cluster.sh "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

This PR adds a local-up-cluster script for bringing up a single node cluster on an AWS EC2 instance. The benefit is to allow new developers to easily set up a single node cluster on EC2 for developing and debugging the aws-cloud-provider. 

**Special notes for your reviewer**:
Feel free to make any suggestions as to any additional setup steps should be included for this script.
I figured this would be a "test" kind of PR. Not really a real "feature". 

**Does this PR introduce a user-facing change?**:
NONE