### PR TITLE
add initial gitbooks configuration for documentation site

### DIFF
--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -1,0 +1,8 @@
+# Kubernetes AWS Cloud Provider
+
+## Introduction
+
+This is the official documentation for the Kubernetes AWS cloud provider.
+
+WARNING: this docs site is actively under development.
+

--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -1,0 +1,4 @@
+# Summary
+
+* [Introduction](README.md)
+

--- a/hack/build-gitbooks.sh
+++ b/hack/build-gitbooks.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+pushd docs/book/
+npm install gitbook-cli -g
+npm install phantomjs-prebuilt
+gitbook install
+gitbook build
+popd

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,24 @@
+# Netlify build
+[build]
+    command = "./hack/build-gitbooks.sh"
+    publish = "docs/book/_book"
+
+# Netlify redirects
+[[redirects]]
+    from = "https://kubernetes-sigs-cloud-provider-aws.netlify.com/*"
+    to = "https://cloud-provider-aws.sigs.k8s.io/:splat"
+    status = 301
+    force = true
+
+# HTTP -> HTTPS
+[[redirects]]
+    from = "http://cloud-provider-aws.sigs.k8s.io/*"
+    to = "https://cloud-provider-aws.sigs.k8s.io/:splat"
+    status = 301
+    force = true
+
+[[redirects]]
+    from = "http://kubernetes-sigs-cloud-provider-aws.netlify.com/*"
+    to = "http://cloud-provider-aws.sigs.k8s.io/:splat"
+    status = 301
+    force = true


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR contains the bare minimum Netlify configuration for setting up a [subproject site](https://github.com/kubernetes/community/blob/master/github-management/subproject-site-requests.md).

Some discussion pending on what the content will look like but figured we can get the site plumbing done prior to that.   

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/cloud-provider-aws/issues/86 and https://github.com/kubernetes/cloud-provider-aws/issues/42

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
