### PR TITLE
move inactive approvers to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,27 +1,20 @@
 approvers:
 - justinsb
-- zmerlynn
-- gnufied
-- jsafrane
 - nckturner
-- micahhausler
-- mcrute
-- gyuho
-- d-nishi
 - M00nF1sh
 - leakingtapan
 - andrewsykim
 reviewers:
+- justinsb
+- nckturner
+- M00nF1sh
+- leakingtapan
+- andrewsykim
+emeritus_approvers:
+- zmerlynn
 - gnufied
 - jsafrane
-- justinsb
-- zmerlynn
-- chrislovecnm
-- nckturner
 - micahhausler
 - mcrute
 - gyuho
 - d-nishi
-- M00nF1sh
-- leakingtapan
-- andrewsykim


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently going through subproject OWNER files under SIG Cloud Provider and moving approvers that have been inactive for more than 1 year to emeritus status.

I'm going to time box this PR til May 15th (next Provider AWS meeting) in case any of the approvers express interest in contributing to the project. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
