### PR TITLE
Add make targets for pushing to staging GCR repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
                  git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 LDFLAGS   := "-w -s -X 'main.version=${VERSION}'"
 
+IMAGE ?= gcr.io/k8s-staging-provider-aws/cloud-controller-manager:$(VERSION)
+
 export GO111MODULE=on
 
 aws-cloud-controller-manager: $(SOURCES)
@@ -25,6 +27,10 @@ aws-cloud-controller-manager: $(SOURCES)
 		-ldflags $(LDFLAGS) \
 		-o aws-cloud-controller-manager \
 		cmd/aws-cloud-controller-manager/main.go
+
+.PHONY: build
+build:
+	docker build -t $(IMAGE) .
 
 .PHONY: check
 check: verify-fmt verify-lint vet

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ aws-cloud-controller-manager: $(SOURCES)
 build:
 	docker build -t $(IMAGE) .
 
+.PHONY: push
+push: build
+	docker push $(IMAGE)
+
 .PHONY: check
 check: verify-fmt verify-lint vet
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add new make targets for building and pushing cloud-controller-manager images to the new staging GCR repo. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
