### PR TITLE
add initial experimental v2 AWS cloud provider

### DIFF
--- a/pkg/providers/v1/install.go
+++ b/pkg/providers/v1/install.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1 is the legacy cloud provider imported from the main kubernetes repo.
+// This is the same implemention used the in-tree Kubernetes components (kubelet,
+// kube-controller-manager, etc) but works out-of-tree as well.
+package v1
+
+import (
+	// install the legacy provider by importing it
+	"k8s.io/legacy-cloud-providers/aws"
+)
+
+const (
+	// ProviderName is the name of the v1 AWS cloud provider
+	ProviderName = aws.ProviderName
+)

--- a/pkg/providers/v2/interface.go
+++ b/pkg/providers/v2/interface.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v2 is an out-of-tree only implementation of the AWS cloud provider.
+// It is not compatible with v1 and should only be used on new clusters.
+package v2
+
+import (
+	"io"
+
+	"k8s.io/cloud-provider"
+)
+
+func init() {
+	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
+		return &cloud{}, nil
+	})
+}
+
+const (
+	// ProviderName is the name of the v2 AWS cloud provider
+	ProviderName = "aws/v2"
+)
+
+var _ cloudprovider.Interface = (*cloud)(nil)
+
+// cloud is the AWS v2 implementation of the cloud provider interface
+type cloud struct {
+}
+
+// Initialize passes a Kubernetes clientBuilder interface to the cloud provider
+func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
+}
+
+// Clusters returns the list of clusters.
+func (c *cloud) Clusters() (cloudprovider.Clusters, bool) {
+	return nil, false
+}
+
+// ProviderName returns the cloud provider ID.
+func (c *cloud) ProviderName() string {
+	return ProviderName
+}
+
+// LoadBalancer returns an implementation of LoadBalancer for Amazon Web Services.
+func (c *cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	return nil, false
+}
+
+// Instances returns an implementation of Instances for Amazon Web Services.
+func (c *cloud) Instances() (cloudprovider.Instances, bool) {
+	return nil, false
+}
+
+// Zones returns an implementation of Zones for Amazon Web Services.
+func (c *cloud) Zones() (cloudprovider.Zones, bool) {
+	return nil, false
+}
+
+// Routes returns an implementation of Routes for Amazon Web Services.
+func (c *cloud) Routes() (cloudprovider.Routes, bool) {
+	return nil, false
+}
+
+// HasClusterID returns true if the cluster has a clusterID
+func (c *cloud) HasClusterID() bool {
+	return false
+}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds an initial implementation of an experimental v2 provider that is exclusively out-of-tree. The actual implementation is incomplete, this just adds the initial boilerplate code for the cloud provider interface. Future PRs will incrementally implement the entire interface.

There are many requested features about the existing AWS cloud provider that are difficult to implement since we can't break behavior against existing clusters. Some of these include but are not limited to:
* allowing node names that are not the ec2 private DNS
* better naming of ELB/NLB resources

In addition, the existing provider is catered towards the deprecated in-tree architecture where it relies on the kubelet, kube-controller-manager and kube-apiserver to be AWS aware. As we approach a future of only out-of-tree providers, starting fresh on a v2 provider under these new assumptions may be the right direction. The v2 provider would be a breaking change from v1, meaning existing clusters shouldn't migrate to the v2 provider. The v2 provider will only support new clusters that enable the out-of-tree cloud provider (i.e. setting --cloud-provider=external on kube components). The v1 provider is **NOT** being deprecated and will continue to be supported in this repo. However, a future version of Kubernetes will remove the in-tree provider from the core Kubernetes release. 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
add initial experimental v2 AWS cloud provider
```
