### PR TITLE
latest manifest should point to v1.19.0-alpha.1, not v1.19.1-alpha.1

### DIFF
--- a/manifests/aws-cloud-controller-manager-daemonset.yaml
+++ b/manifests/aws-cloud-controller-manager-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: aws-cloud-controller-manager
-          image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.19.1-alpha.1
+          image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.19.0-alpha.1
           args:
             - --v=2
             - --cloud-provider=aws


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Latest tag is v1.19.0-alpha.1, not v1.19.1-alpha.1, our example manifests should reflect that.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
