### PR TITLE
zones: initial implementation of Zones interface

### DIFF
--- a/pkg/providers/v2/cloud.go
+++ b/pkg/providers/v2/cloud.go
@@ -53,6 +53,7 @@ type cloud struct {
 	region    string
 	ec2       EC2
 	metadata  EC2Metadata
+	zones     cloudprovider.Zones
 }
 
 // EC2Metadata is an abstraction over the AWS metadata service.
@@ -117,6 +118,11 @@ func newCloud() (cloudprovider.Interface, error) {
 		return nil, err
 	}
 
+	zones, err := newZones(az, creds)
+	if err != nil {
+		return nil, err
+	}
+
 	ec2Sess, err := session.NewSession(&aws.Config{
 		Region:      aws.String(region),
 		Credentials: creds,
@@ -136,6 +142,7 @@ func newCloud() (cloudprovider.Interface, error) {
 		region:    region,
 		metadata:  metadataClient,
 		ec2:       ec2Service,
+		zones:     zones,
 	}
 
 	return awsCloud, nil
@@ -167,7 +174,7 @@ func (c *cloud) Instances() (cloudprovider.Instances, bool) {
 
 // Zones returns an implementation of Zones for Amazon Web Services.
 func (c *cloud) Zones() (cloudprovider.Zones, bool) {
-	return nil, false
+	return c.zones, true
 }
 
 // Routes returns an implementation of Routes for Amazon Web Services.

--- a/pkg/providers/v2/zones.go
+++ b/pkg/providers/v2/zones.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v2 is an out-of-tree only implementation of the AWS cloud provider.
+// It is not compatible with v1 and should only be used on new clusters.
+package v2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/apimachinery/pkg/types"
+	cloudprovider "k8s.io/cloud-provider"
+)
+
+// newZones returns an implementation of cloudprovider.Zones
+// TODO:
+// We should add zones / region support via InstancesV2 since kubernetes/kubernetes#93569 was merged in v1.20, where zone/region is just added to InstanceMetadata and implemented as part of InstancesV2
+func newZones(az string, creds *credentials.Credentials) (cloudprovider.Zones, error) {
+	region, err := azToRegion(az)
+	if err != nil {
+		return nil, err
+	}
+
+	awsConfig := &aws.Config{
+		Region:      aws.String(region),
+		Credentials: creds,
+	}
+	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
+
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating new session: %v", err)
+	}
+	ec2Service := ec2.New(sess)
+
+	return &zones{
+		availabilityZone: az,
+		ec2:              ec2Service,
+		region:           region,
+	}, nil
+}
+
+// zones is an implementation of cloudprovider.Zones
+type zones struct {
+	availabilityZone string
+	ec2              EC2
+	region           string
+}
+
+// GetZone returns the Zone containing the current failure zone and locality region that the program is running in
+func (z *zones) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
+	return cloudprovider.Zone{
+		FailureDomain: z.availabilityZone,
+		Region:        z.region,
+	}, nil
+}
+
+// GetZoneByProviderID returns the Zone containing the current zone and locality region of the node specified by providerID
+func (z *zones) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
+	instance, err := getInstanceByProviderID(ctx, providerID, z.ec2)
+	if err != nil {
+		return cloudprovider.Zone{}, err
+	}
+
+	az := instance.Placement.AvailabilityZone
+	regionName, err := azToRegion(*az)
+	if err != nil {
+		return cloudprovider.Zone{}, err
+	}
+
+	return cloudprovider.Zone{
+		FailureDomain: *az,
+		Region:        regionName,
+	}, nil
+}
+
+// GetZoneByNodeName returns the Zone containing the current zone and locality region of the node specified by node name
+func (z *zones) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
+	instance, err := getInstanceByPrivateDNSName(ctx, nodeName, z.ec2)
+	if err != nil {
+		return cloudprovider.Zone{}, err
+	}
+
+	az := instance.Placement.AvailabilityZone
+	regionName, err := azToRegion(*az)
+	if err != nil {
+		return cloudprovider.Zone{}, err
+	}
+
+	return cloudprovider.Zone{
+		FailureDomain: *az,
+		Region:        regionName,
+	}, nil
+}

--- a/pkg/providers/v2/zones_test.go
+++ b/pkg/providers/v2/zones_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v2 is an out-of-tree only implementation of the AWS cloud provider.
+// It is not compatible with v1 and should only be used on new clusters.
+package v2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cloud-provider-aws/pkg/providers/v2/mocks"
+)
+
+func TestGetZone(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockEC2 := mocks.NewMockEC2(mockCtrl)
+
+	testCases := []struct {
+		name                  string
+		region                string
+		az                    string
+		expectedRegion        string
+		expectedFailureDomain string
+	}{
+		{
+			name:                  "regular zones",
+			region:                "us-west-2",
+			az:                    "us-west-2a",
+			expectedRegion:        "us-west-2",
+			expectedFailureDomain: "us-west-2a",
+		},
+		{
+			name:                  "availability zone not set",
+			region:                "us-west-2",
+			az:                    "",
+			expectedRegion:        "us-west-2",
+			expectedFailureDomain: "",
+		},
+		{
+			name:                  "region not set",
+			region:                "",
+			az:                    "us-west-2a",
+			expectedRegion:        "",
+			expectedFailureDomain: "us-west-2a",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fakeZones := &zones{
+				availabilityZone: testCase.az,
+				ec2:              mockEC2,
+				region:           testCase.region,
+			}
+
+			zone, err := fakeZones.GetZone(context.TODO())
+			if err != nil {
+				t.Fatalf("GetZone failed: %v", err)
+			}
+			if zone.Region != testCase.expectedRegion {
+				t.Errorf("Unexpected region: %s", zone.Region)
+			}
+			if zone.FailureDomain != testCase.expectedFailureDomain {
+				t.Errorf("Unexpected FailureDomain: %s", zone.FailureDomain)
+			}
+		})
+	}
+}
+
+func TestGetZoneByProviderID(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockEC2 := mocks.NewMockEC2(mockCtrl)
+
+	testCases := []struct {
+		name                  string
+		providerID            string
+		expectedEc2Output     *ec2.DescribeInstancesOutput
+		expectedRegion        string
+		expectedFailureDomain string
+	}{
+		{
+			name:       "GetZoneByProviderID with running instances",
+			providerID: "aws:///us-west-1a/i-0",
+			expectedEc2Output: &ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{
+							makeInstance(0, "192.168.0.1", "1.2.3.4", "instance-same.ec2.internal", "instance-same.ec2.external", "running"),
+						},
+					},
+				},
+			},
+			expectedRegion:        "us-west-1",
+			expectedFailureDomain: "us-west-1a",
+		},
+		{
+			name:       "GetZoneByProviderID with terminated instances",
+			providerID: "aws://us-west-1a/i-0",
+			expectedEc2Output: &ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{},
+					},
+				},
+			},
+			expectedRegion:        "",
+			expectedFailureDomain: "",
+		},
+		{
+			name:       "GetZoneByProviderID with invalid providerID",
+			providerID: "aws:////us-where-1a/i-0",
+			expectedEc2Output: &ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{},
+					},
+				},
+			},
+			expectedRegion:        "",
+			expectedFailureDomain: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mockEC2.EXPECT().DescribeInstances(gomock.Any()).Return(testCase.expectedEc2Output, nil)
+
+			fakeZones := &zones{
+				ec2: mockEC2,
+			}
+
+			zone, err := fakeZones.GetZoneByProviderID(context.TODO(), testCase.providerID)
+			if err != nil {
+				t.Logf("GetZoneByProviderID failed with providerID %v: %v", testCase.providerID, err)
+			}
+			if zone.Region != testCase.expectedRegion {
+				t.Errorf("Unexpected region: %s", zone.Region)
+			}
+			if zone.FailureDomain != testCase.expectedFailureDomain {
+				t.Errorf("Unexpected FailureDomain: %s", zone.FailureDomain)
+			}
+		})
+	}
+}
+
+func TestGetZoneByNodeName(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockEC2 := mocks.NewMockEC2(mockCtrl)
+
+	testCases := []struct {
+		name                  string
+		nodeName              types.NodeName
+		expectedEc2Output     *ec2.DescribeInstancesOutput
+		expectedRegion        string
+		expectedFailureDomain string
+	}{
+		{
+			name:     "GetZoneByNodeName with running instances",
+			nodeName: "instance-same.ec2.external",
+			expectedEc2Output: &ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{
+							makeInstance(0, "192.168.0.1", "1.2.3.4", "instance-same.ec2.internal", "instance-same.ec2.external", "running"),
+						},
+					},
+				},
+			},
+			expectedRegion:        "us-west-1",
+			expectedFailureDomain: "us-west-1a",
+		},
+		{
+			name:     "GetZoneByNodeName with terminated instances",
+			nodeName: "instance-same.ec2.external",
+			expectedEc2Output: &ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{},
+					},
+				},
+			},
+			expectedRegion:        "",
+			expectedFailureDomain: "",
+		},
+		{
+			name:     "GetZoneByNodeName with empty nodeName",
+			nodeName: "",
+			expectedEc2Output: &ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{},
+					},
+				},
+			},
+			expectedRegion:        "",
+			expectedFailureDomain: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mockEC2.EXPECT().DescribeInstances(gomock.Any()).Return(testCase.expectedEc2Output, nil)
+
+			fakeZones := &zones{
+				ec2: mockEC2,
+			}
+
+			zone, err := fakeZones.GetZoneByNodeName(context.TODO(), testCase.nodeName)
+			if err != nil {
+				t.Logf("GetZoneByNodeName failed with nodeName %v: %v", testCase.nodeName, err)
+			}
+			if zone.Region != testCase.expectedRegion {
+				t.Errorf("Unexpected region: %s", zone.Region)
+			}
+			if zone.FailureDomain != testCase.expectedFailureDomain {
+				t.Errorf("Unexpected FailureDomain: %s", zone.FailureDomain)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This is a first pass at implementing Zones. 
Verified after node registration, the node has labels with zone/region information:
```
labels:
    beta.kubernetes.io/arch: amd64
    beta.kubernetes.io/instance-type: t3.large
    beta.kubernetes.io/os: linux
    failure-domain.beta.kubernetes.io/region: us-west-2
    failure-domain.beta.kubernetes.io/zone: us-west-2a
    kubernetes.io/arch: amd64
    kubernetes.io/hostname: ip-10-0-0-162.us-west-2.compute.internal
    kubernetes.io/os: linux
    node.kubernetes.io/instance-type: t3.large
    topology.kubernetes.io/region: us-west-2
    topology.kubernetes.io/zone: us-west-2a
```
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #125

**Special notes for your reviewer**:
`TODO: `
We should add zones / region support via InstancesV2 since https://github.com/kubernetes/kubernetes/pull/93569 was merged in v1.20, where zone/region is just added to InstanceMetadata and implemented as part of InstancesV2
Will update zones after v1.20

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Add the initial implementation of Zones for the v2 provider.
```
