### PR TITLE
Pass in cloud config file to initialize cloud provider

### DIFF
--- a/cmd/aws-cloud-controller-manager/main.go
+++ b/cmd/aws-cloud-controller-manager/main.go
@@ -109,6 +109,11 @@ func main() {
 				}
 			}
 
+			cloudConfigFlag := cmd.Flags().Lookup("cloud-config")
+			if cloudConfigFlag.Value.String() == "" {
+				klog.Warning("empty cloud config file path")
+			}
+
 			cliflag.PrintFlags(cmd.Flags())
 
 			c, err := s.Config(KnownControllers(), app.ControllersDisabledByDefault.List())
@@ -118,7 +123,8 @@ func main() {
 			}
 
 			// initialize cloud provider with the cloud provider name and config file provided
-			cloud, err := cloudprovider.InitCloudProvider(cloudProvider, "")
+			cloudConfigFile := cloudConfigFlag.Value.String()
+			cloud, err := cloudprovider.InitCloudProvider(cloudProvider, cloudConfigFile)
 			if err != nil {
 				klog.Fatalf("Cloud provider could not be initialized: %v", err)
 			}

--- a/cmd/aws-cloud-controller-manager/main.go
+++ b/cmd/aws-cloud-controller-manager/main.go
@@ -109,11 +109,6 @@ func main() {
 				}
 			}
 
-			cloudConfigFlag := cmd.Flags().Lookup("cloud-config")
-			if cloudConfigFlag.Value.String() == "" {
-				klog.Warning("empty cloud config file path")
-			}
-
 			cliflag.PrintFlags(cmd.Flags())
 
 			c, err := s.Config(KnownControllers(), app.ControllersDisabledByDefault.List())
@@ -122,8 +117,9 @@ func main() {
 				os.Exit(1)
 			}
 
+			cloudConfigFile := c.ComponentConfig.KubeCloudShared.CloudProvider.CloudConfigFile
+
 			// initialize cloud provider with the cloud provider name and config file provided
-			cloudConfigFile := cloudConfigFlag.Value.String()
 			cloud, err := cloudprovider.InitCloudProvider(cloudProvider, cloudConfigFile)
 			if err != nil {
 				klog.Fatalf("Cloud provider could not be initialized: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
pass the value from `--cloud-config` flag for reading the **clusterName** value
initialize cloud provider with the cloud provider name and config file provided

**What type of PR is this?**
/kind feature
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
