### PR TITLE
Migrate to mkdocs

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,20 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v1
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -5,3 +5,4 @@
 This is the official documentation for the Kubernetes AWS cloud provider.
 
 WARNING: this docs site is actively under development.
+

--- a/docs/book/getting_started.md
+++ b/docs/book/getting_started.md
@@ -1,14 +1,13 @@
 # Getting Started
 
-## AWS Cloud Controller Manager
-
-Before you start, make sure you go through the [prerequisites](../prerequisites.md).
+Before you start, make sure you go through the [prerequisites](prerequisites.md).
 
 In order to launch a cluster running the aws-cloud-controller-manager, you can run the appropriate container image release from this repository on an existing cluster, or you can use a deployment tool that has support for deploying it, like kops.
 
 ## Running on an Existing Cluster
 
 Follow these steps when upgrading an existing cluster by launching the aws-cloud-controller-manager as a pod:
+
 1. Temporarily stop the kube-controller-managers from running.
 1. Add the `--cloud-provider=external` to the kube-controller-manager config.
 1. Add the `--cloud-provider=external` to the kube-apiserver config.

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -1,6 +1,9 @@
-# Summary
+# Home
 
-* [Introduction](README.md)
+This is the official documentation for the Kubernetes AWS cloud provider.
+
+WARNING: this docs site is actively under development.
+
 * Cloud Controller Manager
     * [Prerequisites](prerequisites.md)
     * [Getting Started](getting_started.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,11 @@
+site_name: Kubernetes AWS Cloud Provider
+docs_dir: ./docs/book
+site_description: Documentation for AWS Cloud Provider for Kubernetes
+repo_name: kubernetes/cloud-provider-aws/
+repo_url: https://github.com/kubernetes/cloud-provider-aws/
+theme: readthedocs
+nav:
+  - index.md
+  - prerequisites.md
+  - getting_started.md
+  - development.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ docs_dir: ./docs/book
 site_description: Documentation for AWS Cloud Provider for Kubernetes
 repo_name: kubernetes/cloud-provider-aws/
 repo_url: https://github.com/kubernetes/cloud-provider-aws/
-theme: readthedocs
+theme: material
 nav:
   - index.md
   - prerequisites.md


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
- Migrates the docs from gitbook to mkdocs because gitbook is deprecated. Here's what the new docs looks like: https://ayberk.github.io/cloud-provider-aws/
- Adds a new github action to deploy docs automatically when they're updated

**PS**: `mkdocs` doesn't builds the site into the root folder, so we'll have to change the folder for Github Pages to `/` (from repo settings).

I'll delete the gitbook related stuff on a different PR. If I delete the netlify.toml, checks fail.

```release-note
NONE
```
