### PR TITLE
Add documentation for cred provider

### DIFF
--- a/docs/book/credential_provider.md
+++ b/docs/book/credential_provider.md
@@ -1,0 +1,29 @@
+# Credential Provider
+
+This feature is still in alpha and shouldn't be used in production environments.
+
+As part of the cloud provider extraction, [KEP-2133](https://github.com/kubernetes/enhancements/pull/2151), proposed an extensible way to fetch credentials for pulling images. When kubelet needs credentials to fetch an image, it will now invoke a plugin based on the configuration provided by the cluster operator. Please see the original KEP for details.
+
+We currently have the implementation for fetching ECR credentials. In order to use this new plugin, you'll have to
+
+- Pass the folder where the binary is located as `--image-credential-provider-bin-dir` to the kubelet.
+- Create a new `CredentialProviderConfig` and pass its location to the kubelet via `--image-credential-provider-config`.
+
+Example config:
+```
+{
+    "providers": [
+        {
+            "name": "ecr-credential-provider",
+            "matchImages" : [
+                "*.dkr.ecr.*.amazonaws.com,
+                "*.dkr.ecr.*.amazonaws.com.cn,
+            ],
+            "apiVersion": "credentialprovider.kubelet.k8s.io/v1alpha1",
+            "defaultCacheDuration": "0"
+        }
+    ]
+}
+```
+
+Once you pass this config to the kubelet, everytime it needs to fetch an image that matches one of the "matchImages" patterns, it will invoke the "ecr-credential-provider" binary in the `--image-credential-provider-bin-dir` folder. In turn, the plugin will fetch the credentials for kubelet and send it back via stdio. Note that the name of the "provider" in your config has to match the name of the binary.

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -7,4 +7,5 @@ WARNING: this docs site is actively under development.
 * Cloud Controller Manager
     * [Prerequisites](prerequisites.md)
     * [Getting Started](getting_started.md)
+    * [Credential Provider](credential_provider.md)
     * [Development](development.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,5 +7,6 @@ theme: material
 nav:
   - index.md
   - prerequisites.md
+  - credential_provider.md
   - getting_started.md
   - development.md


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Adds documentation for the new ECR credential provider. I tried to explain how to use it and also provided an example configuration that should satisfy the general use case.

Rendered docs can be seen here: https://ayberk.github.io/cloud-provider-aws/credential_provider/

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
