### PR TITLE
Add release github workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+jobs:
+  build:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: |
+            AWS Cloud Provider
+
+            The cloud provider now runs out-of-tree in a new component called aws-cloud-controller-manager.
+            The external provider preserves all existing behavior/functionality from the legacy in-tree provider.
+
+            Example manifests to deploy the external cloud provider can be found [here](https://github.com/kubernetes/cloud-provider-aws/tree/master/manifests).
+
+            ## CHANGELOG
+            See [CHANGELOG](https://github.com/kubernetes/cloud-provider-aws/blob/master/CHANGELOG.md) for full list of changes.
+          draft: false
+          prerelease: false


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
It adds a workflow that creates a github release whenever a version tag is pushed.

**Special notes for your reviewer**:
An example can be seen [here](https://github.com/ayberk/cloud-provider-aws/releases/tag/v-test).

```release-note
NONE
```
