### PR TITLE
Add script to generate changelog

### DIFF
--- a/hack/changelog.py
+++ b/hack/changelog.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+from subprocess import Popen, PIPE
+import sys
+from github import Github
+
+# Generate a changelog from github commit history (pull request merges)
+
+class ChangelogGenerator:
+    def __init__(self, github_repo, token):
+        self._github = Github(token)
+        self._github_repo = self._github.get_repo(github_repo)
+
+    def generate(self, pr_id):
+        pr = self._github_repo.get_pull(pr_id)
+        return f'{pr.title} ([#{pr_id}]({pr.html_url}), @{pr.user.login})'
+
+def git_log(range=''):
+    process = Popen(['git', 'log', range], stdout=PIPE, stderr=PIPE)
+    stdout, stderr = process.communicate()
+    if process.returncode != 0:
+        raise RuntimeError(f'git log returned {process.returncode} and failed with error: {stderr.decode("utf-8")}')
+    return stdout.decode("utf-8")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(prog='changelog')
+    parser.add_argument('--token', help='Your github token.')
+    parser.add_argument('--changelog-file', help='The path to the changelog output file.')
+    parser.add_argument('--print-only', action='store_true', help='Only print the output.')
+    parser.add_argument('--range', help='The range of commit logs to inspect in the repository.  You can (and should) use tags here.  Example: v5..v10 (This argument is passed to git log, so read the git log documentation for clarification.')
+    parser.add_argument('--section-title', help='The title for the section in the changelog that is generated')
+    args = parser.parse_args()
+
+    if args.section_title is None:
+        print('--section-title is required')
+        sys.exit(1)
+    if args.token is None:
+        print('--token is required')
+        sys.exit(1)
+    if args.range is None:
+        print('--range is required')
+        sys.exit(1)
+    if args.changelog_file is None and args.print_only is None:
+        print('Either --print-only or --changelog-file is required.')
+        sys.exit(1)
+
+    logs = git_log(args.range)
+
+    changelog = f'{args.section_title}\n'
+    g = ChangelogGenerator('kubernetes/cloud-provider-aws', args.token)
+    for pr_match in re.finditer(r'Merge pull request #(\d+)', logs):
+        pr_id = int(pr_match.group(1))
+        changelog += f'* {g.generate(pr_id)}\n'
+
+    if args.print_only:
+        print(changelog)
+        sys.exit(0)
+    else:
+        with open(args.changelog_file, 'r+') as f:
+            existing = f.read()
+            f.write(changelog)
+            f.write(existing)


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:
Adds a script to generate changelog between two tags. Example output between v1.19 tag and HEAD:
```
➜  cloud-provider-aws git:(changelog_script) ✗ 02/19 14:14 python3 hack/changelog.py --token $TOKEN --print-only --section-title Release --range v1.19.0-alpha.1.. 
Release
* Replace book homepage with README ([#176](https://github.com/kubernetes/cloud-provider-aws/pull/176), @ayberk)
* update klog library from 2.4.0 to 2.5.0 ([#170](https://github.com/kubernetes/cloud-provider-aws/pull/170), @dineshkumar181094)
* Add documentation for cred provider ([#174](https://github.com/kubernetes/cloud-provider-aws/pull/174), @ayberk)
* Add released versions to README ([#175](https://github.com/kubernetes/cloud-provider-aws/pull/175), @nckturner)
* feat: Helm chart for aws cloud controller manager ([#173](https://github.com/kubernetes/cloud-provider-aws/pull/173), @JESWINKNINAN)
* Merge legacy provider ([#160](https://github.com/kubernetes/cloud-provider-aws/pull/160), @nckturner)
* Add wongma7 to owners ([#172](https://github.com/kubernetes/cloud-provider-aws/pull/172), @nckturner)
* tags: initial implementation of tags ([#149](https://github.com/kubernetes/cloud-provider-aws/pull/149), @nicolehanjing)
* Migrate to mkdocs ([#167](https://github.com/kubernetes/cloud-provider-aws/pull/167), @ayberk)
* Update Documentation ([#165](https://github.com/kubernetes/cloud-provider-aws/pull/165), @ayberk)
* Add ECR creds provider ([#157](https://github.com/kubernetes/cloud-provider-aws/pull/157), @ayberk)
* Pass in cloud config file to initialize cloud provider ([#164](https://github.com/kubernetes/cloud-provider-aws/pull/164), @nicolehanjing)
* Bump k8s.io/kubernetes@v1.20.0 ([#151](https://github.com/kubernetes/cloud-provider-aws/pull/151), @nicolehanjing)
* Fix cloudbuild image name ([#163](https://github.com/kubernetes/cloud-provider-aws/pull/163), @nckturner)
* Fix cloudbuild and simplify Makefile & cloudbuild ([#162](https://github.com/kubernetes/cloud-provider-aws/pull/162), @nckturner)
* Add docs publishing script and improve documentation ([#161](https://github.com/kubernetes/cloud-provider-aws/pull/161), @nckturner)
* Fix build command ([#159](https://github.com/kubernetes/cloud-provider-aws/pull/159), @ayberk)
* Makefile target to build and push image for release ([#138](https://github.com/kubernetes/cloud-provider-aws/pull/138), @nckturner)
* add verify-codegen in CI check ([#153](https://github.com/kubernetes/cloud-provider-aws/pull/153), @nicolehanjing)
* Add cloud config for tags ([#152](https://github.com/kubernetes/cloud-provider-aws/pull/152), @nicolehanjing)
* Bump the go version to v1.15 latest ([#150](https://github.com/kubernetes/cloud-provider-aws/pull/150), @nicolehanjing)
* Update go modules to include latest k8s.io/kubernetes module on v-1.19 ([#146](https://github.com/kubernetes/cloud-provider-aws/pull/146), @nicolehanjing)
* Update Flags section of README ([#147](https://github.com/kubernetes/cloud-provider-aws/pull/147), @ayberk)
* instances: initial implementation of instancesV2 interface ([#131](https://github.com/kubernetes/cloud-provider-aws/pull/131), @nicolehanjing)
* latest manifest should point to v1.19.0-alpha.1, not v1.19.1-alpha.1 ([#140](https://github.com/kubernetes/cloud-provider-aws/pull/140), @andrewsykim)
```

**Special notes for your reviewer**:
Copy pasted from the authenticator as is.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
