### PR TITLE
Automate helm chart release

### DIFF
--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -1,0 +1,1 @@
+release-name-template: "helm-chart-{{ .Name }}-{{ .Version }}"

--- a/.github/workflows/helm_chart_release.yaml
+++ b/.github/workflows/helm_chart_release.yaml
@@ -1,0 +1,27 @@
+name: Release Helm Charts
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "charts/**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          config: .github/cr.yaml

--- a/charts/aws-cloud-controller-manager/Chart.yaml
+++ b/charts/aws-cloud-controller-manager/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: aws-cloud-controller-manager
-description: This will install Cloud Controller Manager for AWS Cloud Provider
+description: Installs Cloud Controller Manager for AWS Cloud Provider
 version: 0.0.2
 appVersion: v1.20.0-alpha.0
 maintainers:

--- a/charts/aws-cloud-controller-manager/Chart.yaml
+++ b/charts/aws-cloud-controller-manager/Chart.yaml
@@ -7,4 +7,6 @@ appVersion: v1.20.0-alpha.0
 maintainers:
 - name: Jeswin K Ninan
   email: jeswinjkn@gmail.com
+- name: Ayberk Yilmaz
+  email: yayberk@amazon.com
 ---

--- a/charts/aws-cloud-controller-manager/Readme.md
+++ b/charts/aws-cloud-controller-manager/Readme.md
@@ -5,7 +5,7 @@ Installs the [aws cloud-controller-manager ](https://github.com/kubernetes/cloud
 ## Get Repo Info
 
 ```console
-helm repo add aws-cloud-controller-manager https://github.com/kubernetes/cloud-provider-aws
+helm repo add aws-cloud-controller-manager https://kubernetes.github.io/cloud-provider-aws
 helm repo update
 ```
 
@@ -15,7 +15,7 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 
 ```console
 # Helm 3
-$ helm install [RELEASE_NAME] cloud-provider-aws/charts/aws-cloud-controller-manager [flags]
+$ helm upgrade --install aws-cloud-controller-manager aws-cloud-controller-manager/aws-cloud-controller-manager
 
 ```
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- Helm chart releaser action will release a new chart whenever charts folder is updated on master branch.
- We will start hosting our chart index on gh-pages, so installation will be much simpler. I updated the helm README with the new commands.

**Which issue(s) this PR fixes**:
Fixes #188

**Special notes for your reviewer**:
I tested and verified on my fork that it works.

```release-note
NONE
```
