### PR TITLE
Cherry-pick: Use GA topoogy labels for EBS (#99130)

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -2739,12 +2739,12 @@ func (c *Cloud) GetVolumeLabels(volumeName KubernetesVolumeID) (map[string]strin
 		return nil, fmt.Errorf("volume did not have AZ information: %q", aws.StringValue(info.VolumeId))
 	}
 
-	labels[v1.LabelFailureDomainBetaZone] = az
+	labels[v1.LabelTopologyZone] = az
 	region, err := azToRegion(az)
 	if err != nil {
 		return nil, err
 	}
-	labels[v1.LabelFailureDomainBetaRegion] = region
+	labels[v1.LabelTopologyRegion] = region
 
 	return labels, nil
 }

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -1225,8 +1225,8 @@ func TestGetVolumeLabels(t *testing.T) {
 
 	assert.Nil(t, err, "Error creating Volume %v", err)
 	assert.Equal(t, map[string]string{
-		v1.LabelFailureDomainBetaZone:   "us-east-1a",
-		v1.LabelFailureDomainBetaRegion: "us-east-1"}, labels)
+		v1.LabelTopologyZone:   "us-east-1a",
+		v1.LabelTopologyRegion: "us-east-1"}, labels)
 	awsServices.ec2.(*MockedFakeEC2).AssertExpectations(t)
 }
 
@@ -1299,8 +1299,8 @@ func TestGetLabelsForVolume(t *testing.T) {
 				AvailabilityZone: aws.String("us-east-1a"),
 			}},
 			map[string]string{
-				v1.LabelFailureDomainBetaZone:   "us-east-1a",
-				v1.LabelFailureDomainBetaRegion: "us-east-1",
+				v1.LabelTopologyZone:   "us-east-1a",
+				v1.LabelTopologyRegion: "us-east-1",
 			},
 			nil,
 		},


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes/kubernetes/pull/99130

---
Use GA topoogy labels for EBS

/kind cleanup

```release-note
NONE
```
