### PR TITLE
[WIP] Add ENI support for nodes address (for Fargate nodes)

### DIFF
--- a/pkg/providers/v1/instances.go
+++ b/pkg/providers/v1/instances.go
@@ -73,17 +73,13 @@ func (name KubernetesInstanceID) MapToAWSInstanceID() (InstanceID, error) {
 
 	awsID := ""
 	tokens := strings.Split(strings.Trim(url.Path, "/"), "/")
-	if len(tokens) == 1 {
-		// instanceId
-		awsID = tokens[0]
-	} else if len(tokens) == 2 {
-		// az/instanceId
-		awsID = tokens[1]
+	if len(tokens) > 0 {
+		awsID = tokens[len(tokens)-1]
 	}
 
 	// We sanity check the resulting volume; the two known formats are
 	// i-12345678 and i-12345678abcdef01
-	if awsID == "" || !awsInstanceRegMatch.MatchString(awsID) {
+	if awsID == "" || !(awsInstanceRegMatch.MatchString(awsID) || isFargateNode(awsID)) {
 		return "", fmt.Errorf("Invalid format for AWS instance (%s)", name)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds support for adding Fargate worker nodes to Kubernetes cluster. To add Fargate worker nodes, aws.config needs to supply privateIP, privateDNSName and providerID prefix which can be taskID itself.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I'm running conformance test but would like to get early feedback/suggestions. Unit tests seems to be missed with commit. Will update the PR.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note

```
