### PR TITLE
Add support for returning IPv6 node addresses

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"path"
 	"regexp"
 	"sort"
@@ -1449,6 +1450,17 @@ func (c *Cloud) HasClusterID() bool {
 	return len(c.tagging.clusterID()) > 0
 }
 
+// isAWSNotFound returns true if the error was caused by an AWS API 404 response.
+func isAWSNotFound(err error) bool {
+	if err != nil {
+		var aerr awserr.RequestFailure
+		if errors.As(err, &aerr) {
+			return aerr.StatusCode() == http.StatusNotFound
+		}
+	}
+	return false
+}
+
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.NodeAddress, error) {
 	if c.selfAWSInstance.nodeName == name || len(name) == 0 {
@@ -1500,6 +1512,25 @@ func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.No
 					continue
 				}
 				addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIP})
+			}
+		}
+
+		for _, macID := range macIDs {
+			ipv6Path := path.Join("network/interfaces/macs/", macID, "ipv6s")
+			internalIPv6s, err := c.metadata.GetMetadata(ipv6Path)
+			if isAWSNotFound(err) {
+				// 404 -> no IPv6 addresses
+				continue
+			} else if err != nil {
+				return nil, fmt.Errorf("error querying AWS metadata for %q: %q", ipv6Path, err)
+			}
+			// return only the "first" address for each ENI
+			for _, internalIPv6 := range strings.Split(internalIPv6s, "\n") {
+				if internalIPv6 == "" {
+					continue
+				}
+				addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIPv6})
+				break
 			}
 		}
 
@@ -1590,6 +1621,22 @@ func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
 				addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: ip.String()})
 			}
 		}
+	}
+
+	// handle internal network interfaces with IPv6 addresses
+	for _, networkInterface := range instance.NetworkInterfaces {
+		// skip network interfaces that are not currently in use
+		if aws.StringValue(networkInterface.Status) != ec2.NetworkInterfaceStatusInUse || len(networkInterface.Ipv6Addresses) == 0 {
+			continue
+		}
+
+		// return only the "first" address for each ENI
+		internalIPv6 := aws.StringValue(networkInterface.Ipv6Addresses[0].Ipv6Address)
+		ip := net.ParseIP(internalIPv6)
+		if ip == nil {
+			return nil, fmt.Errorf("EC2 instance had invalid IPv6 address: %s (%q)", aws.StringValue(instance.InstanceId), internalIPv6)
+		}
+		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: ip.String()})
 	}
 
 	// TODO: Other IP addresses (multiple ips)?


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/priority important-longterm

**What this PR does / why we need it**:
IPv6 support has been around for some time now both in AWS and Kubernetes. [Dual-Stack](https://kubernetes.io/blog/2021/04/08/kubernetes-1-21-release-announcement/#ipv4-ipv6-dual-stack-support) is also one of the major themes in Kubernetes 1.21.
I am trying to add IPv6 support for kOps and bumping into various issues because the IPv6 addresses are not returned by the cloud provider implementation.
xRef: https://github.com/kubernetes/kops/issues/8432

I am not sure if there was any reason for not implementing this until now, but this PR should be a good conversation starter.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
I added the IPv6 addresses to the internal address list as it seems to be the convention in the related feature docs.
I also considered that adding the IPv6 addresses after all internal IPv4 would best preserve current behavior.

**Does this PR introduce a user-facing change?**:
```release-note
Added support for returning IPv6 node addresses
```

/cc @nckturner @wongma7 @justinsb @aojea 