### PR TITLE
Set custom service account names for controllers

### DIFF
--- a/cmd/aws-cloud-controller-manager/main.go
+++ b/cmd/aws-cloud-controller-manager/main.go
@@ -63,13 +63,34 @@ func main() {
 		klog.Fatalf("unable to initialize command options: %v", err)
 	}
 
-	controllerInitializers := app.DefaultInitFuncConstructors
 	fss := cliflag.NamedFlagSets{}
-	command := app.NewCloudControllerManagerCommand(opts, cloudInitializer, controllerInitializers, fss, wait.NeverStop)
+	command := app.NewCloudControllerManagerCommand(opts, cloudInitializer, controllerInitializers(), fss, wait.NeverStop)
+	klog.Infof("Starting the AWS cloud controller manager.")
 
 	if err := command.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+func controllerInitializers() map[string]app.ControllerInitializerConstructor {
+	controllerInitializers := app.DefaultInitFuncConstructors
+	if constructor, ok := controllerInitializers["cloud-node"]; ok {
+		constructor.InitContext.ClientName = "aws-external-cloud-node-controller"
+		controllerInitializers["cloud-node"] = constructor
+	}
+	if constructor, ok := controllerInitializers["cloud-node-lifecycle"]; ok {
+		constructor.InitContext.ClientName = "aws-external-cloud-node-lifecycle-controller"
+		controllerInitializers["cloud-node-lifecycle"] = constructor
+	}
+	if constructor, ok := controllerInitializers["service"]; ok {
+		constructor.InitContext.ClientName = "aws-external-service-controller"
+		controllerInitializers["service"] = constructor
+	}
+	if constructor, ok := controllerInitializers["route"]; ok {
+		constructor.InitContext.ClientName = "aws-external-route-controller"
+		controllerInitializers["route"] = constructor
+	}
+	return controllerInitializers
 }
 
 func cloudInitializer(config *cloudcontrollerconfig.CompletedConfig) cloudprovider.Interface {

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -26,9 +26,10 @@ export KUBE_ROOT="$GOPATH/src/k8s.io/kubernetes"
 export NODE_ROLE_ARN=${NODE_ROLE_ARN:-""}
 export CLOUD_PROVIDER=aws
 export EXTERNAL_CLOUD_PROVIDER=true
-export CLOUD_CONFIG=$(pwd)/cloudconfig
+export CLOUD_CONFIG=${CLOUD_PROVIDER_ROOT}/cloudconfig
 export EXTERNAL_CLOUD_PROVIDER_BINARY="$GOPATH/src/k8s.io/cloud-provider-aws/aws-cloud-controller-manager"
 export NODE_ZONE=${AWS_NODE_ZONE:-"us-west-2a"}
+export CONFIGURE_CLOUD_ROUTES="${CONFIGURE_CLOUD_ROUTES:-false}"
 
 # Stop right away if the build fails
 set -e


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:

> /kind feature

**What this PR does / why we need it**:
If https://github.com/kubernetes/kubernetes/pull/103178 is merged, we can set custom controller client/service accounts names, and use RBAC that is managed in this repository, rather than relying on the upstream bootstrapped RBAC, like the "node-controller" role.  

Ref: https://github.com/kubernetes/cloud-provider/issues/48.
Depends on: https://github.com/kubernetes/kubernetes/pull/103178
Depends on: https://github.com/kubernetes/kubernetes/pull/103710

Also set --configure-cloud-routes to false in hack/local-up-cluster.sh, because [a recent change in the route controller](https://github.com/kubernetes/kubernetes/pull/97029) means that the route controller starts now when it didn't before.  We don't want the route controller to start if we are using the VPC CNI plugin, for example, but we can still override the flag if we want to test with kubenet.  (Arguably this should be the other way around, but I'm basing the default off my own most frequent testing needs).   

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Use custom service account names for controllers.
```

/hold
