### PR TITLE
Correct the invalid tag for the DaemonSet pull URL

### DIFF
--- a/charts/aws-cloud-controller-manager/values.yaml
+++ b/charts/aws-cloud-controller-manager/values.yaml
@@ -5,7 +5,7 @@ extraArgs: {}
 
 image:
     repository: gcr.io/k8s-staging-provider-aws/cloud-controller-manager
-    tag:  v1.21.0-alpha.0
+    tag: v20210510-v1.21.0-alpha.0
 
 # nameOverride -- String to partially override `aws-cloud-controller-manager.fullname`
 nameOverride: "aws-cloud-controller-manager"

--- a/manifests/base/aws-cloud-controller-manager-daemonset.yaml
+++ b/manifests/base/aws-cloud-controller-manager-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: aws-cloud-controller-manager
-          image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+          image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v20210510-v1.21.0-alpha.0
           args:
             - --v=2
             - --cloud-provider=aws


### PR DESCRIPTION

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

The image tag for  cloud-controller-manager is not correct and fails when deploying.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #244


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Fixes incorrect tag for cloud-controller-manager image.
```
