### PR TITLE
Make Node IP families configurable

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -640,6 +640,9 @@ type CloudConfig struct {
 		//yourself in an non-AWS cloud and open an issue, please indicate that in the
 		//issue body.
 		DisableStrictZoneCheck bool
+
+		// NodeIPFamilies determines which IP addresses are added to node objects and their ordering.
+		NodeIPFamilies []string
 	}
 	// [ServiceOverride "1"]
 	//  Service = s3
@@ -1387,6 +1390,12 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 			return nil, err
 		}
 	}
+
+	if len(cfg.Global.NodeIPFamilies) == 0 {
+		cfg.Global.NodeIPFamilies = []string{"ipv4"}
+	}
+	klog.Infof("The following IP families will be added to nodes: %v", cfg.Global.NodeIPFamilies)
+
 	return awsCloud, nil
 }
 
@@ -1488,116 +1497,196 @@ func isAWSNotFound(err error) bool {
 
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.NodeAddress, error) {
-	if c.selfAWSInstance.nodeName == name || len(name) == 0 {
-		addresses := []v1.NodeAddress{}
+	addresses := []v1.NodeAddress{}
 
-		macs, err := c.metadata.GetMetadata("network/interfaces/macs/")
-		if err != nil {
-			return nil, fmt.Errorf("error querying AWS metadata for %q: %q", "network/interfaces/macs", err)
-		}
-
-		// We want the IPs to end up in order by interface (in particular, we want eth0's
-		// IPs first), but macs isn't necessarily sorted in that order so we have to
-		// explicitly order by device-number (device-number == the "0" in "eth0").
-
-		var macIDs []string
-		macDevNum := make(map[string]int)
-		for _, macID := range strings.Split(macs, "\n") {
-			if macID == "" {
-				continue
-			}
-			numPath := path.Join("network/interfaces/macs/", macID, "device-number")
-			numStr, err := c.metadata.GetMetadata(numPath)
-			if err != nil {
-				return nil, fmt.Errorf("error querying AWS metadata for %q: %q", numPath, err)
-			}
-			num, err := strconv.Atoi(strings.TrimSpace(numStr))
-			if err != nil {
-				klog.Warningf("Bad device-number %q for interface %s\n", numStr, macID)
-				continue
-			}
-			macIDs = append(macIDs, macID)
-			macDevNum[macID] = num
-		}
-
-		// Sort macIDs by interface device-number
-		sort.Slice(macIDs, func(i, j int) bool {
-			return macDevNum[macIDs[i]] < macDevNum[macIDs[j]]
-		})
-
-		for _, macID := range macIDs {
-			ipPath := path.Join("network/interfaces/macs/", macID, "local-ipv4s")
-			internalIPs, err := c.metadata.GetMetadata(ipPath)
-			if err != nil {
-				return nil, fmt.Errorf("error querying AWS metadata for %q: %q", ipPath, err)
-			}
-
-			for _, internalIP := range strings.Split(internalIPs, "\n") {
-				if internalIP == "" {
-					continue
+	for _, family := range c.cfg.Global.NodeIPFamilies {
+		switch family {
+		case "ipv4":
+			if c.selfAWSInstance.nodeName == name || len(name) == 0 {
+				addrs, err := c.ipv4AddressesFromMetadata()
+				if err != nil {
+					return nil, err
 				}
-				addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIP})
-			}
-		}
-
-		for _, macID := range macIDs {
-			ipv6Path := path.Join("network/interfaces/macs/", macID, "ipv6s")
-			internalIPv6s, err := c.metadata.GetMetadata(ipv6Path)
-			if isAWSNotFound(err) {
-				// 404 -> no IPv6 addresses
-				continue
-			} else if err != nil {
-				return nil, fmt.Errorf("error querying AWS metadata for %q: %q", ipv6Path, err)
-			}
-			// return only the "first" address for each ENI
-			for _, internalIPv6 := range strings.Split(internalIPv6s, "\n") {
-				if internalIPv6 == "" {
-					continue
+				addresses = append(addresses, addrs...)
+			} else {
+				instance, err := c.getInstanceByNodeName(name)
+				if err != nil {
+					return nil, fmt.Errorf("getInstanceByNodeName failed for %q with %q", name, err)
 				}
-				addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIPv6})
-				break
+
+				addrs, err := extractIPv4NodeAddresses(instance)
+				if err != nil {
+					return nil, fmt.Errorf("getInstanceByNodeName failed for %q with %q", name, err)
+				}
+				addresses = append(addresses, addrs...)
+			}
+		case "ipv6":
+			if c.selfAWSInstance.nodeName == name || len(name) == 0 {
+				addrs, err := c.ipv6AddressesFromMetadata()
+				if err != nil {
+					return nil, err
+				}
+				addresses = append(addresses, addrs...)
+			} else {
+				instance, err := c.getInstanceByNodeName(name)
+				if err != nil {
+					return nil, fmt.Errorf("getInstanceByNodeName failed for %q with %q", name, err)
+				}
+
+				addrs, err := extractIPv6NodeAddresses(instance)
+				if err != nil {
+					return nil, fmt.Errorf("getInstanceByNodeName failed for %q with %q", name, err)
+				}
+				addresses = append(addresses, addrs...)
 			}
 		}
-
-		externalIP, err := c.metadata.GetMetadata("public-ipv4")
-		if err != nil {
-			//TODO: It would be nice to be able to determine the reason for the failure,
-			// but the AWS client masks all failures with the same error description.
-			klog.V(4).Info("Could not determine public IP from AWS metadata.")
-		} else {
-			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: externalIP})
-		}
-
-		localHostname, err := c.metadata.GetMetadata("local-hostname")
-		if err != nil || len(localHostname) == 0 {
-			//TODO: It would be nice to be able to determine the reason for the failure,
-			// but the AWS client masks all failures with the same error description.
-			klog.V(4).Info("Could not determine private DNS from AWS metadata.")
-		} else {
-			hostname, internalDNS := parseMetadataLocalHostname(localHostname)
-			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeHostName, Address: hostname})
-			for _, d := range internalDNS {
-				addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalDNS, Address: d})
-			}
-		}
-
-		externalDNS, err := c.metadata.GetMetadata("public-hostname")
-		if err != nil || len(externalDNS) == 0 {
-			//TODO: It would be nice to be able to determine the reason for the failure,
-			// but the AWS client masks all failures with the same error description.
-			klog.V(4).Info("Could not determine public DNS from AWS metadata.")
-		} else {
-			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalDNS, Address: externalDNS})
-		}
-
-		return addresses, nil
 	}
+	return addresses, nil
+}
 
-	instance, err := c.getInstanceByNodeName(name)
+func (c *Cloud) ipv4AddressesFromMetadata() ([]v1.NodeAddress, error) {
+	addresses := []v1.NodeAddress{}
+
+	macs, err := c.metadata.GetMetadata("network/interfaces/macs/")
 	if err != nil {
-		return nil, fmt.Errorf("getInstanceByNodeName failed for %q with %q", name, err)
+		return nil, fmt.Errorf("error querying AWS metadata for %q: %q", "network/interfaces/macs", err)
 	}
-	return extractNodeAddresses(instance)
+
+	// We want the IPs to end up in order by interface (in particular, we want eth0's
+	// IPs first), but macs isn't necessarily sorted in that order so we have to
+	// explicitly order by device-number (device-number == the "0" in "eth0").
+
+	var macIDs []string
+	macDevNum := make(map[string]int)
+	for _, macID := range strings.Split(macs, "\n") {
+		if macID == "" {
+			continue
+		}
+		numPath := path.Join("network/interfaces/macs/", macID, "device-number")
+		numStr, err := c.metadata.GetMetadata(numPath)
+		if err != nil {
+			return nil, fmt.Errorf("error querying AWS metadata for %q: %q", numPath, err)
+		}
+		num, err := strconv.Atoi(strings.TrimSpace(numStr))
+		if err != nil {
+			klog.Warningf("Bad device-number %q for interface %s\n", numStr, macID)
+			continue
+		}
+		macIDs = append(macIDs, macID)
+		macDevNum[macID] = num
+	}
+
+	// Sort macIDs by interface device-number
+	sort.Slice(macIDs, func(i, j int) bool {
+		return macDevNum[macIDs[i]] < macDevNum[macIDs[j]]
+	})
+
+	for _, macID := range macIDs {
+		ipPath := path.Join("network/interfaces/macs/", macID, "local-ipv4s")
+		internalIPs, err := c.metadata.GetMetadata(ipPath)
+		if err != nil {
+			return nil, fmt.Errorf("error querying AWS metadata for %q: %q", ipPath, err)
+		}
+
+		for _, internalIP := range strings.Split(internalIPs, "\n") {
+			if internalIP == "" {
+				continue
+			}
+			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIP})
+		}
+	}
+
+	externalIP, err := c.metadata.GetMetadata("public-ipv4")
+	if err != nil {
+		//TODO: It would be nice to be able to determine the reason for the failure,
+		// but the AWS client masks all failures with the same error description.
+		klog.V(4).Info("Could not determine public IP from AWS metadata.")
+	} else {
+		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: externalIP})
+	}
+
+	localHostname, err := c.metadata.GetMetadata("local-hostname")
+	if err != nil || len(localHostname) == 0 {
+		//TODO: It would be nice to be able to determine the reason for the failure,
+		// but the AWS client masks all failures with the same error description.
+		klog.V(4).Info("Could not determine private DNS from AWS metadata.")
+	} else {
+		hostname, internalDNS := parseMetadataLocalHostname(localHostname)
+		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeHostName, Address: hostname})
+		for _, d := range internalDNS {
+			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalDNS, Address: d})
+		}
+	}
+
+	externalDNS, err := c.metadata.GetMetadata("public-hostname")
+	if err != nil || len(externalDNS) == 0 {
+		//TODO: It would be nice to be able to determine the reason for the failure,
+		// but the AWS client masks all failures with the same error description.
+		klog.V(4).Info("Could not determine public DNS from AWS metadata.")
+	} else {
+		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalDNS, Address: externalDNS})
+	}
+
+	return addresses, nil
+}
+
+func (c *Cloud) ipv6AddressesFromMetadata() ([]v1.NodeAddress, error) {
+	addresses := []v1.NodeAddress{}
+
+	macs, err := c.metadata.GetMetadata("network/interfaces/macs/")
+	if err != nil {
+		return nil, fmt.Errorf("error querying AWS metadata for %q: %q", "network/interfaces/macs", err)
+	}
+
+	// We want the IPs to end up in order by interface (in particular, we want eth0's
+	// IPs first), but macs isn't necessarily sorted in that order so we have to
+	// explicitly order by device-number (device-number == the "0" in "eth0").
+
+	var macIDs []string
+	macDevNum := make(map[string]int)
+	for _, macID := range strings.Split(macs, "\n") {
+		if macID == "" {
+			continue
+		}
+		numPath := path.Join("network/interfaces/macs/", macID, "device-number")
+		numStr, err := c.metadata.GetMetadata(numPath)
+		if err != nil {
+			return nil, fmt.Errorf("error querying AWS metadata for %q: %q", numPath, err)
+		}
+		num, err := strconv.Atoi(strings.TrimSpace(numStr))
+		if err != nil {
+			klog.Warningf("Bad device-number %q for interface %s\n", numStr, macID)
+			continue
+		}
+		macIDs = append(macIDs, macID)
+		macDevNum[macID] = num
+	}
+
+	// Sort macIDs by interface device-number
+	sort.Slice(macIDs, func(i, j int) bool {
+		return macDevNum[macIDs[i]] < macDevNum[macIDs[j]]
+	})
+
+	for _, macID := range macIDs {
+		ipv6Path := path.Join("network/interfaces/macs/", macID, "ipv6s")
+		internalIPv6s, err := c.metadata.GetMetadata(ipv6Path)
+		if isAWSNotFound(err) {
+			// 404 -> no IPv6 addresses
+			continue
+		} else if err != nil {
+			return nil, fmt.Errorf("error querying AWS metadata for %q: %q", ipv6Path, err)
+		}
+		// return only the "first" address for each ENI
+		for _, internalIPv6 := range strings.Split(internalIPv6s, "\n") {
+			if internalIPv6 == "" {
+				continue
+			}
+			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIPv6})
+			break
+		}
+	}
+
+	return addresses, nil
 }
 
 // parseMetadataLocalHostname parses the output of "local-hostname" metadata.
@@ -1620,8 +1709,9 @@ func parseMetadataLocalHostname(metadata string) (string, []string) {
 	return hostname, internalDNS
 }
 
-// extractNodeAddresses maps the instance information from EC2 to an array of NodeAddresses
-func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
+// extractIPv4NodeAddresses maps the instance information from EC2 to an array of NodeAddresses.
+// This function will extract private and public IP addresses and their corresponding DNS names.
+func extractIPv4NodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
 	// Not clear if the order matters here, but we might as well indicate a sensible preference order
 
 	if instance == nil {
@@ -1648,22 +1738,6 @@ func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
 		}
 	}
 
-	// handle internal network interfaces with IPv6 addresses
-	for _, networkInterface := range instance.NetworkInterfaces {
-		// skip network interfaces that are not currently in use
-		if aws.StringValue(networkInterface.Status) != ec2.NetworkInterfaceStatusInUse || len(networkInterface.Ipv6Addresses) == 0 {
-			continue
-		}
-
-		// return only the "first" address for each ENI
-		internalIPv6 := aws.StringValue(networkInterface.Ipv6Addresses[0].Ipv6Address)
-		ip := net.ParseIP(internalIPv6)
-		if ip == nil {
-			return nil, fmt.Errorf("EC2 instance had invalid IPv6 address: %s (%q)", aws.StringValue(instance.InstanceId), internalIPv6)
-		}
-		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: ip.String()})
-	}
-
 	// TODO: Other IP addresses (multiple ips)?
 	publicIPAddress := aws.StringValue(instance.PublicIpAddress)
 	if publicIPAddress != "" {
@@ -1683,6 +1757,36 @@ func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
 	publicDNSName := aws.StringValue(instance.PublicDnsName)
 	if publicDNSName != "" {
 		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalDNS, Address: publicDNSName})
+	}
+
+	return addresses, nil
+}
+
+// extractIPv6NodeAddresses maps the instance information from EC2 to an array of NodeAddresses
+// All IPv6 addresses are considered internal even if they are publicly routable. There are no instance DNS names associated with IPv6.
+func extractIPv6NodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
+	// Not clear if the order matters here, but we might as well indicate a sensible preference order
+
+	if instance == nil {
+		return nil, fmt.Errorf("nil instance passed to extractNodeAddresses")
+	}
+
+	addresses := []v1.NodeAddress{}
+
+	// handle internal network interfaces with IPv6 addresses
+	for _, networkInterface := range instance.NetworkInterfaces {
+		// skip network interfaces that are not currently in use
+		if aws.StringValue(networkInterface.Status) != ec2.NetworkInterfaceStatusInUse || len(networkInterface.Ipv6Addresses) == 0 {
+			continue
+		}
+
+		// return only the "first" address for each ENI
+		internalIPv6 := aws.StringValue(networkInterface.Ipv6Addresses[0].Ipv6Address)
+		ip := net.ParseIP(internalIPv6)
+		if ip == nil {
+			return nil, fmt.Errorf("EC2 instance had invalid IPv6 address: %s (%q)", aws.StringValue(instance.InstanceId), internalIPv6)
+		}
+		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: ip.String()})
 	}
 
 	return addresses, nil
@@ -1720,7 +1824,26 @@ func (c *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string
 		return nil, err
 	}
 
-	return extractNodeAddresses(instance)
+	var addresses []v1.NodeAddress
+
+	for _, family := range c.cfg.Global.NodeIPFamilies {
+		switch family {
+		case "ipv4":
+			ipv4addr, err := extractIPv4NodeAddresses(instance)
+			if err != nil {
+				return nil, err
+			}
+			addresses = append(addresses, ipv4addr...)
+		case "ipv6":
+			ipv6addr, err := extractIPv6NodeAddresses(instance)
+			if err != nil {
+				return nil, err
+			}
+			addresses = append(addresses, ipv6addr...)
+		}
+	}
+
+	return addresses, nil
 }
 
 // InstanceExistsByProviderID returns true if the instance with the given provider id still exists.

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -219,6 +219,48 @@ func TestReadAWSCloudConfig(t *testing.T) {
 	}
 }
 
+func TestReadAWSCloudConfigNodeIPFamilies(t *testing.T) {
+	tests := []struct {
+		name string
+
+		reader io.Reader
+		aws    Services
+
+		expectError    bool
+		nodeIPFamilies []string
+	}{
+		{
+			"Single IP family",
+			strings.NewReader("[global]\nNodeIPFamilies = ipv6"), nil,
+			false, []string{"ipv6"},
+		},
+		{
+			"Multiple IP families",
+			strings.NewReader("[global]\nNodeIPFamilies = ipv6\nNodeIPFamilies = ipv4"), nil,
+			false, []string{"ipv6", "ipv4"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Running test case %s", test.name)
+		cfg, err := readAWSCloudConfig(test.reader)
+
+		if test.expectError {
+			if err == nil {
+				t.Errorf("Should error for case %s (cfg=%v)", test.name, cfg)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Should succeed for case: %s", test.name)
+			}
+			if !reflect.DeepEqual(cfg.Global.NodeIPFamilies, test.nodeIPFamilies) {
+				t.Errorf("Incorrect ip family value (%s vs %v) for case: %s",
+					cfg.Global.NodeIPFamilies, test.nodeIPFamilies, test.name)
+			}
+		}
+	}
+}
+
 type ServiceDescriptor struct {
 	name                         string
 	region                       string
@@ -630,6 +672,68 @@ func makeInstance(num int, privateIP, publicIP, privateDNSName, publicDNSName st
 	return instance
 }
 
+func TestNodeAddressesByProviderID(t *testing.T) {
+	// Note instance0 and instance1 have the same name
+	// (we test that this produces an error)
+	instance0 := makeInstance(0, "192.168.0.1", "1.2.3.4", "instance-same.ec2.internal", "instance-same.ec2.external", nil, true)
+	instance1 := makeInstance(1, "192.168.0.2", "", "instance-same.ec2.internal", "", nil, false)
+	instance2 := makeInstance(2, "192.168.0.1", "1.2.3.4", "instance-other.ec2.internal", "", nil, false)
+	instance3 := makeInstance(3, "192.168.0.3", "", "instance-ipv6.ec2.internal", "", []string{"2a05:d014:aa7:911:fc7e:1600:fc4d:ab2", "2a05:d014:aa7:911:9f44:e737:1aa0:6489"}, true)
+	instances := []*ec2.Instance{&instance0, &instance1, &instance2, &instance3}
+
+	aws1, _ := mockInstancesResp(&instance0, []*ec2.Instance{&instance0})
+	_, err1 := aws1.NodeAddressesByProviderID(context.TODO(), "i-xxx")
+	if err1 == nil {
+		t.Errorf("Should error when no instance found")
+	}
+
+	aws2, _ := mockInstancesResp(&instance0, instances[0:1])
+	// change node name so it uses the instance instead of metadata
+	aws2.selfAWSInstance.nodeName = "foo"
+	addrs2, err2 := aws2.NodeAddressesByProviderID(context.TODO(), "i-0")
+	if err2 != nil {
+		t.Errorf("Should not error when instance found")
+	}
+	if len(addrs2) != 5 {
+		t.Errorf("Should return exactly 5 NodeAddresses")
+	}
+	testHasNodeAddress(t, addrs2, v1.NodeInternalIP, "192.168.0.1")
+	testHasNodeAddress(t, addrs2, v1.NodeExternalIP, "1.2.3.4")
+	testHasNodeAddress(t, addrs2, v1.NodeExternalDNS, "instance-same.ec2.external")
+	testHasNodeAddress(t, addrs2, v1.NodeInternalDNS, "instance-same.ec2.internal")
+	testHasNodeAddress(t, addrs2, v1.NodeHostName, "instance-same.ec2.internal")
+
+	aws3, _ := mockInstancesResp(&instance3, instances)
+	aws3.cfg.Global.NodeIPFamilies = []string{"ipv4", "ipv6"}
+	// change node name so it uses the instance instead of metadata
+	aws3.selfAWSInstance.nodeName = "foo"
+	addrs3, err3 := aws3.NodeAddressesByProviderID(context.TODO(), "i-3")
+	if err3 != nil {
+		t.Errorf("Should not error when instance found")
+	}
+	if len(addrs3) != 4 {
+		t.Errorf("Should return exactly 4 NodeAddresses")
+	}
+	testHasNodeAddress(t, addrs3, v1.NodeInternalIP, "192.168.0.3")
+	testHasNodeAddress(t, addrs3, v1.NodeInternalIP, "2a05:d014:aa7:911:fc7e:1600:fc4d:ab2")
+	testHasNodeAddress(t, addrs3, v1.NodeInternalDNS, "instance-ipv6.ec2.internal")
+	testHasNodeAddress(t, addrs3, v1.NodeHostName, "instance-ipv6.ec2.internal")
+
+	aws4, _ := mockInstancesResp(&instance3, instances)
+	aws4.cfg.Global.NodeIPFamilies = []string{"ipv6"}
+	// change node name so it uses the instance instead of metadata
+	aws4.selfAWSInstance.nodeName = "foo"
+	addrs4, err4 := aws4.NodeAddressesByProviderID(context.TODO(), "i-3")
+	if err4 != nil {
+		t.Errorf("Should not error when instance found")
+	}
+	if len(addrs4) != 1 {
+		t.Errorf("Should return exactly 1 NodeAddresses")
+	}
+	testHasNodeAddress(t, addrs4, v1.NodeInternalIP, "2a05:d014:aa7:911:fc7e:1600:fc4d:ab2")
+
+}
+
 func TestNodeAddresses(t *testing.T) {
 	// Note instance0 and instance1 have the same name
 	// (we test that this produces an error)
@@ -668,6 +772,7 @@ func TestNodeAddresses(t *testing.T) {
 	testHasNodeAddress(t, addrs3, v1.NodeHostName, "instance-same.ec2.internal")
 
 	aws4, _ := mockInstancesResp(&instance3, instances)
+	aws4.cfg.Global.NodeIPFamilies = []string{"ipv4", "ipv6"}
 	// change node name so it uses the instance instead of metadata
 	aws4.selfAWSInstance.nodeName = "foo"
 	addrs4, err4 := aws4.NodeAddresses(context.TODO(), "instance-ipv6.ec2.internal")
@@ -681,6 +786,20 @@ func TestNodeAddresses(t *testing.T) {
 	testHasNodeAddress(t, addrs4, v1.NodeInternalIP, "2a05:d014:aa7:911:fc7e:1600:fc4d:ab2")
 	testHasNodeAddress(t, addrs4, v1.NodeInternalDNS, "instance-ipv6.ec2.internal")
 	testHasNodeAddress(t, addrs4, v1.NodeHostName, "instance-ipv6.ec2.internal")
+
+	aws5, _ := mockInstancesResp(&instance3, instances)
+	aws5.cfg.Global.NodeIPFamilies = []string{"ipv6"}
+	// change node name so it uses the instance instead of metadata
+	aws5.selfAWSInstance.nodeName = "foo"
+	addrs5, err5 := aws5.NodeAddresses(context.TODO(), "instance-ipv6.ec2.internal")
+	if err5 != nil {
+		t.Errorf("Should not error when instance found")
+	}
+	if len(addrs5) != 1 {
+		t.Errorf("Should return exactly 1 NodeAddresses")
+	}
+	testHasNodeAddress(t, addrs5, v1.NodeInternalIP, "2a05:d014:aa7:911:fc7e:1600:fc4d:ab2")
+
 }
 
 func TestNodeAddressesWithMetadata(t *testing.T) {
@@ -697,6 +816,9 @@ func TestNodeAddressesWithMetadata(t *testing.T) {
 	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "192.168.0.1")
 	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "192.168.0.2")
 	testHasNodeAddress(t, addrs, v1.NodeExternalIP, "2.3.4.5")
+	if len(addrs) != 5 {
+		t.Errorf("should return exactly 5 addresses, got %v", addrs)
+	}
 	var index1, index2 int
 	for i, addr := range addrs {
 		if addr.Type == v1.NodeInternalIP && addr.Address == "192.168.0.1" {


### PR DESCRIPTION
Many pods (e.g metrics-server) will always pick the first InternalIP regardless of the family the pod itself has. This will break for any pod not running on host network if the Pod only has an ipv6 address.

This PR will make which IP families to add to Node objects configurable through cloud config.

**Does this PR introduce a user-facing change?**:

```release-note
IP families added to Node objects are now configurable though cloudconfig. The default configuration is ipv4 only.
```
