### PR TITLE
Set EC2 instance cache max age to 10 mins

### DIFF
--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -50,6 +51,9 @@ const (
 	lbAttrAccessLogsS3Enabled           = "access_logs.s3.enabled"
 	lbAttrAccessLogsS3Bucket            = "access_logs.s3.bucket"
 	lbAttrAccessLogsS3Prefix            = "access_logs.s3.prefix"
+
+	// defaultEC2InstanceCacheMaxAge is the max age for the EC2 instance cache
+	defaultEC2InstanceCacheMaxAge = 10 * time.Minute
 )
 
 var (
@@ -1604,7 +1608,7 @@ func (c *Cloud) findInstancesForELB(nodes []*v1.Node, annotations map[string]str
 	instanceIDs := mapToAWSInstanceIDsTolerant(targetNodes)
 
 	cacheCriteria := cacheCriteria{
-		// MaxAge not required, because we only care about security groups, which should not change
+		MaxAge:       defaultEC2InstanceCacheMaxAge,
 		HasInstances: instanceIDs, // Refresh if any of the instance ids are missing
 	}
 	snapshot, err := c.instanceCache.describeAllInstancesCached(cacheCriteria)

--- a/pkg/providers/v1/aws_loadbalancer_test.go
+++ b/pkg/providers/v1/aws_loadbalancer_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package aws
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/stretchr/testify/assert"
@@ -538,6 +543,86 @@ func TestFilterTargetNodes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func makeNodeInstancePair(offset int) (*v1.Node, *ec2.Instance) {
+	instanceID := fmt.Sprintf("i-%x", int64(0x03bcc3496da09f78e)+int64(offset))
+	instance := &ec2.Instance{
+		InstanceId: aws.String(instanceID),
+		Placement: &ec2.Placement{
+			AvailabilityZone: aws.String("us-east-1b"),
+		},
+		PrivateDnsName:   aws.String(fmt.Sprintf("ip-192-168-32-%d.ec2.internal", 101+offset)),
+		PrivateIpAddress: aws.String(fmt.Sprintf("192.168.32.%d", 101+offset)),
+		PublicIpAddress:  aws.String(fmt.Sprintf("1.2.3.%d", 1+offset)),
+	}
+
+	var tag ec2.Tag
+	tag.Key = aws.String(fmt.Sprintf("%s%s", TagNameKubernetesClusterPrefix, TestClusterID))
+	tag.Value = aws.String("owned")
+	instance.Tags = []*ec2.Tag{&tag}
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("ip-192-168-0-%d.ec2.internal", 101+offset),
+		},
+		Spec: v1.NodeSpec{
+			ProviderID: fmt.Sprintf("aws:///us-east-1b/%s", instanceID),
+		},
+	}
+	return node, instance
+}
+
+func TestCloud_findInstancesForELB(t *testing.T) {
+	defaultNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ip-172-20-0-100.ec2.internal",
+		},
+		Spec: v1.NodeSpec{
+			ProviderID: "aws:///us-east-1a/i-self",
+		},
+	}
+	newNode, newInstance := makeNodeInstancePair(1)
+	awsServices := NewFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+
+	want := map[InstanceID]*ec2.Instance{
+		"i-self": awsServices.selfInstance,
+	}
+	got, err := c.findInstancesForELB([]*v1.Node{defaultNode}, nil)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(want, got))
+
+	// Add a new EC2 instance
+	awsServices.instances = append(awsServices.instances, newInstance)
+	want = map[InstanceID]*ec2.Instance{
+		"i-self": awsServices.selfInstance,
+		InstanceID(aws.StringValue(newInstance.InstanceId)): newInstance,
+	}
+	got, err = c.findInstancesForELB([]*v1.Node{defaultNode, newNode}, nil)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(want, got))
+
+	// Verify existing instance cache gets used
+	cacheExpiryOld := c.instanceCache.snapshot.timestamp
+	got, err = c.findInstancesForELB([]*v1.Node{defaultNode, newNode}, nil)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(want, got))
+	cacheExpiryNew := c.instanceCache.snapshot.timestamp
+	assert.Equal(t, cacheExpiryOld, cacheExpiryNew)
+
+	// Force cache expiry and verify cache gets updated with new timestamp
+	cacheExpiryOld = c.instanceCache.snapshot.timestamp
+	c.instanceCache.snapshot.timestamp = c.instanceCache.snapshot.timestamp.Add(-(defaultEC2InstanceCacheMaxAge + 1*time.Second))
+	got, err = c.findInstancesForELB([]*v1.Node{defaultNode, newNode}, nil)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(want, got))
+	cacheExpiryNew = c.instanceCache.snapshot.timestamp
+	assert.True(t, cacheExpiryNew.After(cacheExpiryOld))
 }
 
 func TestCloud_chunkTargetDescriptions(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The AWS in-tree controller caches the EC2 instance information indefinitely unless the nodes get scaled up. In case the EC2 instances have multiple security groups attached, this caching strategy leads to inconsistency between the actual EC2 instance configuration in AWS and the controller's view of the EC2 instance information. This PR sets the maximum age of 10 minutes to the EC2 instance cache.

Once the security group requirements are satisfied, controller will be able to fetch the new EC2 information, and get past the following errors without scaling up the nodes -

* Multiple tagged security groups found for instance i-xxxx ...
* Multiple untagged security groups found for instance i-xxx ...


**Which issue(s) this PR fixes**:
Fixes #255

**Special notes for your reviewer**:

Testing

* First setup an EC2 instance with at least 2 security groups, none of them contain the cluster tag. As expected, the in-tree controller fails to provision the load balancer. Attach a cluster tagged security group to the EC2 instances, and verify after the cache expiry controller is able to fetch the updated information without having to scale up the k8s worker nodes.
* Update the EC2 instance security groups configuration, and verify the the controller is able to update the correct security group after the cache expiry.


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
