### PR TITLE
run hack/update-netparse-cve.sh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,5 +19,6 @@ require (
 	k8s.io/csi-translation-lib v0.22.1
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kubelet v0.22.1
+	k8s.io/utils v0.0.0-20210707171843-4b05e18ac7d9 // indirect
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -48,6 +48,7 @@ import (
 	"gopkg.in/gcfg.v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1637,7 +1638,7 @@ func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
 
 		for _, internalIP := range networkInterface.PrivateIpAddresses {
 			if ipAddress := aws.StringValue(internalIP.PrivateIpAddress); ipAddress != "" {
-				ip := net.ParseIP(ipAddress)
+				ip := netutils.ParseIPSloppy(ipAddress)
 				if ip == nil {
 					return nil, fmt.Errorf("EC2 instance had invalid private address: %s (%q)", aws.StringValue(instance.InstanceId), ipAddress)
 				}
@@ -1665,7 +1666,7 @@ func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
 	// TODO: Other IP addresses (multiple ips)?
 	publicIPAddress := aws.StringValue(instance.PublicIpAddress)
 	if publicIPAddress != "" {
-		ip := net.ParseIP(publicIPAddress)
+		ip := netutils.ParseIPSloppy(publicIPAddress)
 		if ip == nil {
 			return nil, fmt.Errorf("EC2 instance had invalid public address: %s (%s)", aws.StringValue(instance.InstanceId), publicIPAddress)
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

> Since golang 1.17, golang/go#30999, "In both net.ParseIP and net.ParseCIDR reject leading zeros in the dot-decimal notation of IPv4 addresses."

> This can cause that previous valid data becomes invalid, so we should guarantee that this doesn't happen.

> In addition, since this change in the golang stdlib as associated a security CVE-2021-29923, we should check

> > While you triage those callsites, it would be good to also check if they are affected by the kind of issues that are motivating the change: if you are validating the inputs with Go and then passing the inputs to the OS or to non-Go applications, the two might disagree on the inputs validity or meaning. This can cause issues, which we would love to hear about at security@golang.org or on the issue, to assess the security risk.


**Which issue(s) this PR fixes**:
Fixes #260

**Special notes for your reviewer**:

Cherry pick kubernetes/kubernetes#104368

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Since golang 1.17 both net.ParseIP and net.ParseCIDR rejects leading zeros in the dot-decimal notation of IPv4 addresses.
Kubernetes will keep allowing leading zeros on IPv4 address to not break the compatibility.
IMPORTANT: Kubernetes interprets leading zeros on IPv4 addresses as decimal, users must not rely on parser alignment to not being impacted by the associated security advisory:
CVE-2021-29923 golang standard library "net" - Improper Input Validation of octal literals in golang 1.16.2 and below standard library "net" results in indeterminate SSRF & RFI vulnerabilities.
Reference: https://nvd.nist.gov/vuln/detail/CVE-2021-29923```
