### PR TITLE
Remove inactive and add jaypipes

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,18 +2,16 @@ approvers:
 - justinsb
 - nckturner
 - M00nF1sh
-- leakingtapan
 - andrewsykim
 - wongma7
-- ayberk
+- jaypipes
 reviewers:
 - justinsb
 - nckturner
 - M00nF1sh
-- leakingtapan
 - andrewsykim
 - wongma7
-- ayberk
+- jaypipes
 emeritus_approvers:
 - zmerlynn
 - gnufied
@@ -22,3 +20,5 @@ emeritus_approvers:
 - mcrute
 - gyuho
 - d-nishi
+- leakingtapan
+- ayberk


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Remove inactive approvers and add @jaypipes, who is an active Kubernetes community member and contributer/maintainer of [AWS Controllers for Kubernetes (ACK)](https://github.com/aws-controllers-k8s/community/graphs/contributors) and a member of the EKS development team.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
