### PR TITLE
Use promoted images

### DIFF
--- a/charts/aws-cloud-controller-manager/values.yaml
+++ b/charts/aws-cloud-controller-manager/values.yaml
@@ -2,16 +2,14 @@ namespace: "kube-system"
 
 extraArgs: {}
 
-
 image:
-    repository: gcr.io/k8s-staging-provider-aws/cloud-controller-manager
-    tag:  v1.21.0-alpha.0
+    repository: us.gcr.io/k8s-artifacts-prod/provider-aws/cloud-controller-manager
+    tag: v1.22.0-alpha.0
 
-# nameOverride -- String to partially override `aws-cloud-controller-manager.fullname`
+# nameOverride overrides `cloud-controller-manager.fullname`
 nameOverride: "aws-cloud-controller-manager"
 
 # nodeSelector -- Node labels for pod assignment. Ref: https://kubernetes.io/docs/user-guide/node-selection/.
-
 nodeSelector:
   node-role.kubernetes.io/master: ""
 

--- a/manifests/base/aws-cloud-controller-manager-daemonset.yaml
+++ b/manifests/base/aws-cloud-controller-manager-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: aws-cloud-controller-manager
-          image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+          image: us.gcr.io/k8s-artifacts-prod/provider-aws/cloud-controller-manager:v1.22.0-alpha.0
           args:
             - --v=2
             - --cloud-provider=aws


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>

/kind cleanup


**What this PR does / why we need it**:
We recently started promoting the tagged ccm images to k8s-artifacts-prod so we should use those instead of the images in k8s-staging-provider-aws.  See [k8s-artifacts-prod](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/provider-aws/cloud-controller-manager?tab=vulnz) for the list of promoted images. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/cloud-provider-aws/issues/228

**Special notes for your reviewer**: 
* Supersedes https://github.com/kubernetes/cloud-provider-aws/pull/245
* Wait for https://github.com/kubernetes/k8s.io/pull/2667

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
