### PR TITLE
Add test for DescribeInstances

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/kms"
@@ -732,7 +733,7 @@ func (cfg *CloudConfig) getResolver() endpoints.ResolverFunc {
 
 // awsSdkEC2 is an implementation of the EC2 interface, backed by aws-sdk-go
 type awsSdkEC2 struct {
-	ec2 *ec2.EC2
+	ec2 ec2iface.EC2API
 }
 
 // Interface to make the CloudConfig immutable for awsSDKProvider
@@ -971,7 +972,7 @@ func (s *awsSdkEC2) DescribeInstances(request *ec2.DescribeInstancesInput) ([]*e
 	var nextToken *string
 	requestTime := time.Now()
 
-	if request.MaxResults == nil && request.InstanceIds == nil {
+	if request.MaxResults == nil && len(request.InstanceIds) == 0 {
 		// MaxResults must be set in order for pagination to work
 		// MaxResults cannot be set with InstanceIds
 		request.MaxResults = aws.Int64(1000)


### PR DESCRIPTION
* Add test for DescribeInstances (the lower level wrapper around the API call).
* Use interface in awsSdkEC2 to allow for mock.
* Check `len(request.InstanceIds) == 0` to account for both empty structs and nil pointers.

See https://github.com/kubernetes/cloud-provider-aws/pull/274 for the change and https://github.com/kubernetes/cloud-provider-aws/issues/269 for some context.  

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
Add a test and make a comparison more resilient. 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
