### PR TITLE
use sts regional endpoint for aws session

### DIFF
--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -3881,5 +3881,4 @@ func TestRegionalSession(t *testing.T) {
 			assert.Equal(t, test.expectEndpoint, session.STSRegionalEndpoint)
 		})
 	}
-
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
STS [suggests](https://docs.aws.amazon.com/general/latest/gr/sts.html) using regional endpoints. 
```
AWS recommends using Regional STS endpoints to reduce latency, build in redundancy, and increase session token validity
```
The PR creates a way for CCM users to set an env var `USE_REGIONAL_STS` to use regional endpoints. The default when the flag is unset is false. Only when the flag is explicitly `true`/`TRUE` the regional endpoint is chosen.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
CCM users can set an env var `USE_REGIONAL_STS` to use regional endpoints for sts calls. The default when the flag is unset is false. Only when the flag is explicitly `true`/`TRUE` the regional endpoint is chosen.

```
