### PR TITLE
Add support for RBN-based node names

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -287,6 +287,9 @@ const (
 
 	// privateDNSNamePrefix is the prefix added to ENI Private DNS Name.
 	privateDNSNamePrefix = "ip-"
+
+	// rbnNamePrefix is the prefix added to ENI Private DNS Name with RBN.
+	rbnNamePrefix = "i-"
 )
 
 const (
@@ -5233,6 +5236,9 @@ func isFargateNode(nodeName string) bool {
 }
 
 func (c *Cloud) nodeNameToProviderID(nodeName types.NodeName) (InstanceID, error) {
+	if strings.HasPrefix(string(nodeName), rbnNamePrefix) {
+		return InstanceID(nodeName), nil
+	}
 	if len(nodeName) == 0 {
 		return "", fmt.Errorf("no nodeName provided")
 	}


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
 /kind feature

**What this PR does / why we need it**:

AWS recently launched support for instance DNS host names based on instance ID rather than ipv4.
This PR adds support for nodes with those DNS hostnames

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #285 

**Special notes for your reviewer**:

Originally, node names were suffixed with the domain name. AWS CCM is to my knowledge the only CCM that do not use only the hostnames. As a consequence, all relevant k8s components need set `--hostname-override` as kubelet et.al cannot automatically determine the hostname. Because of this, with RBN, CCM expects only the hostname. The `kubectl get nodes` output then looks like this:

```
$ kubectl get nodes
NAME                  STATUS   ROLES                  AGE   VERSION
i-03a7726a034596f51   Ready    node                   81m   v1.21.3
i-0e0d7ce03d5827f91   Ready    control-plane,master   91m   v1.21.3
```

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Added support for instances with Resource Based Naming.
```
