### PR TITLE
validate service with mixed protocols

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -4161,6 +4161,9 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 	if len(apiService.Spec.Ports) == 0 {
 		return nil, fmt.Errorf("requested load balancer with no ports")
 	}
+	if err := checkMixedProtocol(apiService.Spec.Ports); err != nil {
+		return nil, err
+	}
 	// Figure out what mappings we want on the load balancer
 	listeners := []*elb.Listener{}
 	v2Mappings := []nlbPortMapping{}
@@ -5250,6 +5253,19 @@ func (c *Cloud) nodeNameToProviderID(nodeName types.NodeName) (InstanceID, error
 	}
 
 	return KubernetesInstanceID(node.Spec.ProviderID).MapToAWSInstanceID()
+}
+
+func checkMixedProtocol(ports []v1.ServicePort) error {
+	if len(ports) == 0 {
+		return nil
+	}
+	firstProtocol := ports[0].Protocol
+	for _, port := range ports[1:] {
+		if port.Protocol != firstProtocol {
+			return fmt.Errorf("mixed protocol is not supported for LoadBalancer")
+		}
+	}
+	return nil
 }
 
 func checkProtocol(port v1.ServicePort, annotations map[string]string) error {

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -1854,6 +1854,65 @@ func TestDescribeLoadBalancerOnEnsure(t *testing.T) {
 	c.EnsureLoadBalancer(context.TODO(), TestClusterName, &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "myservice", UID: "id"}}, []*v1.Node{})
 }
 
+func TestCheckMixedProtocol(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		ports       []v1.ServicePort
+		wantErr     error
+	}{
+		{
+			name:        "TCP",
+			annotations: make(map[string]string),
+			ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(8080),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "UDP",
+			annotations: map[string]string{ServiceAnnotationLoadBalancerType: "nlb"},
+			ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolUDP,
+					Port:     int32(8080),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "TCP and UDP",
+			annotations: map[string]string{ServiceAnnotationLoadBalancerType: "nlb"},
+			ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolUDP,
+					Port:     int32(53),
+				},
+				{
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(53),
+				},
+			},
+			wantErr: errors.New("mixed protocol is not supported for LoadBalancer"),
+		},
+	}
+	for _, test := range tests {
+		tt := test
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkMixedProtocol(tt.ports)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.Equal(t, err, nil)
+			}
+		})
+	}
+}
+
 func TestCheckProtocol(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>

/kind cleanup


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Cherry pick https://github.com/kubernetes/kubernetes/pull/105361 from upstream.  This is required until we explicitly support mixed protocols in the external CCM.  

> The AWS in-tree controller doesn't support mixed protocols for service. This PR adds validation logic to the AWS cloudprovider to not provision any load balancer for service with mixed protocols so that the MixedProtocolLBService feature gate can be enabled safely on AWS.

> kubernetes/enhancements#1435

**Special notes for your reviewer**:

> Manually tested with feature-gate MixedProtocolLBService=true

> * services with mixed protocol do not get reconciled, controller reports event "... mixed protocol is not supported for LoadBalancer"
> * CLB with TCP works as expected, CLB with UDP does not get reconciled as usual
> * NLB with TCP, or NLB with UDP protocol is functional
> * empty protocol defaults to TCP


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
