### PR TITLE
Tag on create

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -3595,6 +3595,21 @@ func (c *Cloud) ensureSecurityGroup(name string, description string, additionalT
 		createRequest.VpcId = &c.vpcID
 		createRequest.GroupName = &name
 		createRequest.Description = &description
+		tags := c.tagging.buildTags(ResourceLifecycleOwned, additionalTags)
+		var awsTags []*ec2.Tag
+		for k, v := range tags {
+			tag := &ec2.Tag{
+				Key:   aws.String(k),
+				Value: aws.String(v),
+			}
+			awsTags = append(awsTags, tag)
+		}
+		createRequest.TagSpecifications = []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String(ec2.ResourceTypeSecurityGroup),
+				Tags:         awsTags,
+			},
+		}
 
 		createResponse, err := c.ec2.CreateSecurityGroup(createRequest)
 		if err != nil {
@@ -3620,14 +3635,6 @@ func (c *Cloud) ensureSecurityGroup(name string, description string, additionalT
 		return "", fmt.Errorf("created security group, but id was not returned: %s", name)
 	}
 
-	err := c.tagging.createTags(c.ec2, groupID, ResourceLifecycleOwned, additionalTags)
-	if err != nil {
-		// If we retry, ensureClusterTags will recover from this - it
-		// will add the missing tags.  We could delete the security
-		// group here, but that doesn't feel like the right thing, as
-		// the caller is likely to retry the create
-		return "", fmt.Errorf("error tagging security group: %q", err)
-	}
 	return groupID, nil
 }
 

--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -525,6 +525,14 @@ func (c *Cloud) createListenerV2(loadBalancerArn *string, mapping nlbPortMapping
 		return nil, err
 	}
 
+	elbTags := []*elbv2.Tag{}
+	for k, v := range tags {
+		elbTags = append(elbTags, &elbv2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+
 	createListernerInput := &elbv2.CreateListenerInput{
 		LoadBalancerArn: loadBalancerArn,
 		Port:            aws.Int64(mapping.FrontendPort),
@@ -533,6 +541,7 @@ func (c *Cloud) createListenerV2(loadBalancerArn *string, mapping nlbPortMapping
 			TargetGroupArn: target.TargetGroupArn,
 			Type:           aws.String(elbv2.ActionTypeEnumForward),
 		}},
+		Tags: elbTags,
 	}
 	if mapping.FrontendProtocol == "TLS" {
 		if mapping.SSLPolicy != "" {
@@ -592,6 +601,15 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
 			input.HealthCheckPath = aws.String(mapping.HealthCheckConfig.Path)
 		}
 
+		if len(tags) != 0 {
+			targetGroupTags := make([]*elbv2.Tag, 0, len(tags))
+			for k, v := range tags {
+				targetGroupTags = append(targetGroupTags, &elbv2.Tag{
+					Key: aws.String(k), Value: aws.String(v),
+				})
+			}
+			input.Tags = targetGroupTags
+		}
 		result, err := c.elbv2.CreateTargetGroup(input)
 		if err != nil {
 			return nil, fmt.Errorf("error creating load balancer target group: %q", err)
@@ -600,27 +618,7 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
 			return nil, fmt.Errorf("expected only one target group on CreateTargetGroup, got %d groups", len(result.TargetGroups))
 		}
 
-		if len(tags) != 0 {
-			targetGroupTags := make([]*elbv2.Tag, 0, len(tags))
-			for k, v := range tags {
-				targetGroupTags = append(targetGroupTags, &elbv2.Tag{
-					Key: aws.String(k), Value: aws.String(v),
-				})
-			}
-			tgArn := aws.StringValue(result.TargetGroups[0].TargetGroupArn)
-			if _, err := c.elbv2.AddTags(&elbv2.AddTagsInput{
-				ResourceArns: []*string{aws.String(tgArn)},
-				Tags:         targetGroupTags,
-			}); err != nil {
-				return nil, fmt.Errorf("error adding tags for targetGroup %s due to %q", tgArn, err)
-			}
-		}
-
 		tg := result.TargetGroups[0]
-		tgARN := aws.StringValue(tg.TargetGroupArn)
-		if err := c.ensureTargetGroupTargets(tgARN, expectedTargets, nil); err != nil {
-			return nil, err
-		}
 		return tg, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

A few resources are tagged as separate requests. This PR tags the resources on create instead. In addition, target groups were not tagged before this PR

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Target groups, security groups and listeners are now tagged on creation rather than as separate API calls.
```
