### PR TITLE
Use go-runner as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,16 +14,15 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.17.4
+ARG GOLANG_IMAGE=golang:1.17.5
 
 # The distroless image on which the CPI manager image is built.
 #
 # Please do not use "latest". Explicit tags should be used to provide
-# deterministic builds. This image doesn't have semantic version tags, but
-# the fully-qualified image can be obtained by entering
-# "gcr.io/distroless/static:latest" in a browser and then copying the
-# fully-qualified image from the web page.
-ARG DISTROLESS_IMAGE=gcr.io/distroless/static@sha256:1cc74da80bbf80d89c94e0c7fe22830aa617f47643f2db73f66c8bd5bf510b25
+# deterministic builds. Follow what kubernetes uses to build
+# kube-controller-manager, for example for 1.23.x:
+# https://github.com/kubernetes/kubernetes/blob/release-1.23/build/common.sh#L94
+ARG DISTROLESS_IMAGE=k8s.gcr.io/build-image/go-runner:v2.3.1-go1.17.5-bullseye.0
 
 ################################################################################
 ##                              BUILD STAGE                                   ##


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: To collect/persist logs (versus just emitting to stdout/stderr and letting container runtime deal with them) go-runner should be used. kubernetes already uses this image as base for apiserver, scheduler, and KCM https://github.com/kubernetes/kubernetes/blob/release-1.23/build/common.sh#L94. Since cloud provider is a "kubernetes component" basically split off from KCM it makes sense to use this image as base for cloud provider as well. More details are here: https://github.com/kubernetes/release/tree/master/images/build/go-runner. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
