### PR TITLE
Update charts for v1.23.0-alpha.0

### DIFF
--- a/charts/aws-cloud-controller-manager/Chart.yaml
+++ b/charts/aws-cloud-controller-manager/Chart.yaml
@@ -2,11 +2,9 @@
 apiVersion: v1
 name: aws-cloud-controller-manager
 description: Installs Cloud Controller Manager for AWS Cloud Provider
-version: 0.0.5
-appVersion: v1.22.0-alpha.0
+version: 0.0.6
+appVersion: v1.23.0-alpha.0
 maintainers:
-- name: Jeswin K Ninan
-  email: jeswinjkn@gmail.com
 - name: Nick Turner
   email: nic@amazon.com
 ---

--- a/charts/aws-cloud-controller-manager/values.yaml
+++ b/charts/aws-cloud-controller-manager/values.yaml
@@ -6,7 +6,7 @@ args:
 
 image:
     repository: us.gcr.io/k8s-artifacts-prod/provider-aws/cloud-controller-manager
-    tag: v1.22.0-alpha.0
+    tag: v1.23.0-alpha.0
 
 # nameOverride overrides `cloud-controller-manager.fullname`
 nameOverride: "aws-cloud-controller-manager"

--- a/examples/existing-cluster/base/aws-cloud-controller-manager-daemonset.yaml
+++ b/examples/existing-cluster/base/aws-cloud-controller-manager-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: aws-cloud-controller-manager
-          image: us.gcr.io/k8s-artifacts-prod/provider-aws/cloud-controller-manager:v1.22.0-alpha.0
+          image: us.gcr.io/k8s-artifacts-prod/provider-aws/cloud-controller-manager:v1.23.0-alpha.0
           args:
             - --v=2
             - --cloud-provider=aws


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

/hold
* Wait for https://github.com/kubernetes/k8s.io/pull/3287
* Check image is in us.gcr.io/k8s-artifacts-prod/provider-aws/cloud-controller-manager

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
