### PR TITLE
canonicalize ipv6 metadata ip address

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1691,7 +1691,7 @@ func (c *Cloud) ipv6AddressesFromMetadata() ([]v1.NodeAddress, error) {
 			if internalIPv6 == "" {
 				continue
 			}
-			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIPv6})
+			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: net.ParseIP(internalIPv6).String()})
 			break
 		}
 	}

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -373,6 +373,14 @@ func (m *FakeMetadata) GetMetadata(key string) (string, error) {
 			}
 		}
 
+		if len(keySplit) == 5 && keySplit[4] == "ipv6s" {
+			for i, macElem := range m.aws.networkInterfacesMacs {
+				if macParam == macElem {
+					return strings.Join(m.aws.networkInterfacesPrivateIPs[i], "/\n"), nil
+				}
+			}
+		}
+
 		return "", nil
 	}
 

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -831,6 +831,21 @@ func TestNodeAddressesWithMetadata(t *testing.T) {
 	}
 }
 
+func TestNodeAddressesWithIPv6Metadata(t *testing.T) {
+	instance := makeInstance(0, "", "2.3.4.5", "instance.ec2.internal", "", nil, false)
+	instances := []*ec2.Instance{&instance}
+	awsCloud, awsServices := mockInstancesResp(&instance, instances)
+	awsCloud.cfg.Global.NodeIPFamilies = []string{"ipv6"}
+
+	awsServices.networkInterfacesMacs = []string{"0a:26:64:c4:6a:48"}
+	awsServices.networkInterfacesPrivateIPs = [][]string{{"2600:1f14:1d4:d101:0:0:0:ba3d"}}
+	addrs, err := awsCloud.NodeAddresses(context.TODO(), "")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "2600:1f14:1d4:d101::ba3d")
+}
+
 func TestParseMetadataLocalHostname(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Signed-off-by: Jyoti Mahapatra <jyotima@amazon.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The ipv6 address from imds metadata endpoint is not a canonicalized format. This caused an issue in kubelet https://github.com/kubernetes/kubernetes/issues/107735 . Handling ip as string is error prone, hence this PR parses the ip before passing it to the kubelet.
**Which issue(s) this PR fixes**:
https://github.com/kubernetes/kubernetes/issues/107735
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note

```
