### PR TITLE
add sts regional endpoint logic

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1209,8 +1209,12 @@ func init() {
 			return nil, fmt.Errorf("unable to validate custom endpoint overrides: %v", err)
 		}
 
+		regionName, err := getRegionFromMetadata(cfg)
+		if err != nil {
+			return nil, err
+		}
 		sess, err := session.NewSessionWithOptions(session.Options{
-			Config:            aws.Config{},
+			Config:            *aws.NewConfig().WithRegion(regionName).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint),
 			SharedConfigState: session.SharedConfigEnable,
 		})
 		if err != nil {
@@ -5129,4 +5133,29 @@ func (c *Cloud) describeNetworkInterfaces(nodeName string) (*ec2.NetworkInterfac
 		return nil, fmt.Errorf("multiple interfaces found with same id %q", eni.NetworkInterfaces)
 	}
 	return eni.NetworkInterfaces[0], nil
+}
+
+func getRegionFromMetadata(cfg *CloudConfig) (string, error) {
+	klog.Infof("Get AWS region from metadata client")
+	metadata, err := newAWSSDKProvider(nil, cfg).Metadata()
+	if err != nil {
+		return "", fmt.Errorf("error creating AWS metadata client: %q", err)
+	}
+
+	err = updateConfigZone(cfg, metadata)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
+	}
+
+	zone := cfg.Global.Zone
+	if len(zone) <= 1 {
+		return "", fmt.Errorf("invalid AWS zone in config file: %s", zone)
+	}
+
+	regionName, err := azToRegion(zone)
+	if err != nil {
+		return "", err
+	}
+
+	return regionName, nil
 }

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1214,13 +1214,13 @@ func init() {
 			return nil, fmt.Errorf("error creating AWS metadata client: %q", err)
 		}
 
-		regiondetails, err := getRegionFromMetadata(*cfg, metadata)
+		regionName, _, err := getRegionFromMetadata(*cfg, metadata)
 		if err != nil {
 			return nil, err
 		}
 
 		sess, err := session.NewSessionWithOptions(session.Options{
-			Config:            *aws.NewConfig().WithRegion(regiondetails.regionName).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint),
+			Config:            *aws.NewConfig().WithRegion(regionName).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint),
 			SharedConfigState: session.SharedConfigEnable,
 		})
 		if err != nil {
@@ -1312,9 +1312,7 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 		return nil, fmt.Errorf("error creating AWS metadata client: %q", err)
 	}
 
-	regiondetails, err := getRegionFromMetadata(cfg, metadata)
-	regionName := regiondetails.regionName
-	zone := regiondetails.zone
+	regionName, zone, err := getRegionFromMetadata(cfg, metadata)
 
 	if !cfg.Global.DisableStrictZoneCheck {
 		if !isRegionValid(regionName, metadata) {
@@ -5131,33 +5129,22 @@ func (c *Cloud) describeNetworkInterfaces(nodeName string) (*ec2.NetworkInterfac
 	return eni.NetworkInterfaces[0], nil
 }
 
-type regionDetails struct {
-	regionName string
-	zone       string
-}
-
-func getRegionFromMetadata(cfg CloudConfig, metadata EC2Metadata) (*regionDetails, error) {
+func getRegionFromMetadata(cfg CloudConfig, metadata EC2Metadata) (string, string, error) {
 	klog.Infof("Get AWS region from metadata client")
 	err := updateConfigZone(&cfg, metadata)
 	if err != nil {
-		return nil, fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
+		return "", "", fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
 	}
 
 	zone := cfg.Global.Zone
 	if len(zone) <= 1 {
-		return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
+		return "", "", fmt.Errorf("invalid AWS zone in config file: %s", zone)
 	}
 
 	regionName, err := azToRegion(zone)
 	if err != nil {
-		return nil, err
+		return "", "", err
 	}
 
-	regiondetails := &regionDetails{
-		regionName: regionName,
-		zone:       zone,
-	}
-
-	return regiondetails, nil
+	return regionName, zone, nil
 }
-

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1313,6 +1313,9 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 	}
 
 	regionName, zone, err := getRegionFromMetadata(cfg, metadata)
+	if err != nil {
+		return nil, err
+	}
 
 	if !cfg.Global.DisableStrictZoneCheck {
 		if !isRegionValid(regionName, metadata) {

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1209,12 +1209,18 @@ func init() {
 			return nil, fmt.Errorf("unable to validate custom endpoint overrides: %v", err)
 		}
 
-		regionName, err := getRegionFromMetadata(cfg)
+		metadata, err := newAWSSDKProvider(nil, cfg).Metadata()
+		if err != nil {
+			return nil, fmt.Errorf("error creating AWS metadata client: %q", err)
+		}
+
+		regiondetails, err := getRegionFromMetadata(*cfg, metadata)
 		if err != nil {
 			return nil, err
 		}
+
 		sess, err := session.NewSessionWithOptions(session.Options{
-			Config:            *aws.NewConfig().WithRegion(regionName).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint),
+			Config:            *aws.NewConfig().WithRegion(regiondetails.regionName).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint),
 			SharedConfigState: session.SharedConfigEnable,
 		})
 		if err != nil {
@@ -1306,19 +1312,9 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 		return nil, fmt.Errorf("error creating AWS metadata client: %q", err)
 	}
 
-	err = updateConfigZone(&cfg, metadata)
-	if err != nil {
-		return nil, fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
-	}
-
-	zone := cfg.Global.Zone
-	if len(zone) <= 1 {
-		return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
-	}
-	regionName, err := azToRegion(zone)
-	if err != nil {
-		return nil, err
-	}
+	regiondetails, err := getRegionFromMetadata(cfg, metadata)
+	regionName := regiondetails.regionName
+	zone := regiondetails.zone
 
 	if !cfg.Global.DisableStrictZoneCheck {
 		if !isRegionValid(regionName, metadata) {
@@ -5135,27 +5131,33 @@ func (c *Cloud) describeNetworkInterfaces(nodeName string) (*ec2.NetworkInterfac
 	return eni.NetworkInterfaces[0], nil
 }
 
-func getRegionFromMetadata(cfg *CloudConfig) (string, error) {
-	klog.Infof("Get AWS region from metadata client")
-	metadata, err := newAWSSDKProvider(nil, cfg).Metadata()
-	if err != nil {
-		return "", fmt.Errorf("error creating AWS metadata client: %q", err)
-	}
+type regionDetails struct {
+	regionName string
+	zone       string
+}
 
-	err = updateConfigZone(cfg, metadata)
+func getRegionFromMetadata(cfg CloudConfig, metadata EC2Metadata) (*regionDetails, error) {
+	klog.Infof("Get AWS region from metadata client")
+	err := updateConfigZone(&cfg, metadata)
 	if err != nil {
-		return "", fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
+		return nil, fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
 	}
 
 	zone := cfg.Global.Zone
 	if len(zone) <= 1 {
-		return "", fmt.Errorf("invalid AWS zone in config file: %s", zone)
+		return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
 	}
 
 	regionName, err := azToRegion(zone)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return regionName, nil
+	regiondetails := &regionDetails{
+		regionName: regionName,
+		zone:       zone,
+	}
+
+	return regiondetails, nil
 }
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> kind bug

**What this PR does / why we need it**:
STS suggests using regional endpoints. ([source](https://docs.aws.amazon.com/general/latest/gr/sts.html))

> AWS recommends using Regional STS endpoints to reduce latency, build in redundancy, and increase session token validity.

The PR uses sts regional endpoints, fetched using the metadata, instead of global endpoints.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Updates to the cloud-controller-manager to use regional endpoint instead of global endpoint, as AWS recommends using Regional STS endpoints to reduce latency, build in redundancy, and increase session token validity.
```
