### PR TITLE
Automated cherry pick of #312: Fix e2e failures

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -29,10 +29,10 @@ test_output_root="${output}/test"
 test_run="${test_output_root}/${test_run_id}"
 
 # Set in Makefile
-MAKE_VERSION="${MAKE_VERSION:-}"
-MAKE_IMAGE="${MAKE_IMAGE:-}"
+BUILD_VERSION="${BUILD_VERSION:-}"
+BUILD_IMAGE="${BUILD_IMAGE:-}"
 
-if [[ -z "${MAKE_VERSION}" || -z "${MAKE_IMAGE}" ]]; then
+if [[ -z "${BUILD_VERSION}" || -z "${BUILD_IMAGE}" ]]; then
     echo "$0: Execute with 'make test-e2e'"
     exit 1
 fi
@@ -48,15 +48,13 @@ UP="${UP:-yes}"
 DOWN="${DOWN:-yes}"
 
 KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.23.2}"
-GINKGO_VERSION="v1.14.0"
 CLUSTER_NAME="test-cluster-${test_run_id}.k8s.local"
 KOPS_STATE_STORE="${KOPS_STATE_STORE:-}"
 REGION="${AWS_REGION:-us-west-2}"
 ZONES="${AWS_AVAILABILITY_ZONES:-us-west-2a,us-west-2b,us-west-2c}"
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 IMAGE_NAME=${IMAGE_NAME:-${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/amazon/cloud-controller-manager}
-# $VERSION is set in Makefile
-IMAGE_TAG=${IMAGE_TAG:-${MAKE_VERSION}-${test_run_id}}
+IMAGE_TAG=${IMAGE_TAG:-${BUILD_VERSION}-${test_run_id}}
 
 # Test args
 GINKGO_FOCUS=${GINKGO_FOCUS:-"\[cloud-provider-aws-e2e\]"}
@@ -64,6 +62,8 @@ GINKGO_SKIP=${GINKGO_SKIP:-"\[Disruptive\]"}
 GINKGO_NODES=${GINKGO_NODES:-4}
 
 EXPANDED_TEST_EXTRA_FLAGS="${EXPANDED_TEST_EXTRA_FLAGS:-}"
+
+mkdir -p "${test_run}"
 
 if [[ -z "${KOPS_STATE_STORE}" ]]; then
     echo "KOPS_STATE_STORE must be set"
@@ -83,19 +83,22 @@ fi
 
 yes_or_no="^(yes|no)$"
 
-if [[ "${UP}" =~ $yes_or_no ]]; then
-    echo "Creating cluster: ${UP}"
-else
+if [[ ! "${UP}" =~ $yes_or_no ]]; then
     echo "Invalid UP: ${UP} (valid: [yes|no])"
     exit 1
 fi
 
-if [[ "${DOWN}" =~ $yes_or_no ]]; then
-    echo "Deleting cluster: ${DOWN}"
-else
+if [[ ! "${DOWN}" =~ $yes_or_no ]]; then
     echo "Invalid DOWN: ${DOWN} (valid: [yes|no])"
     exit 1
 fi
+
+if [[ -z "${INSTALL_PATH}" ]]; then
+    echo "INSTALL_PATH must be set"
+    exit 1
+fi
+
+export PATH="${INSTALL_PATH}:${PATH}"
 
 echo "Starting test run ---"
 echo " + Region:              ${REGION} (${ZONES})"
@@ -108,29 +111,20 @@ echo " + SSH public key path: ${SSH_PUBLIC_KEY_PATH}"
 echo " + Test run ID:         ${test_run_id}"
 echo " + Kubetest run dir:    ${test_run}"
 echo " + Image:               ${IMAGE_NAME}:${IMAGE_TAG}"
-echo " + Up:                  ${UP}"
-echo " + Down:                ${DOWN}"
-
-mkdir -p "${test_run}"
+echo " + Create cluster:      ${UP}"
+echo " + Delete cluster:      ${DOWN}"
 
 export KOPS_STATE_STORE
 # kubetest2 sets RunDir as filepath.Join(artifacts.BaseDir(), o.RunID())
 export ARTIFACTS="${test_output_root}"
 export KUBETEST2_RUN_DIR="${test_run}"
-export PATH="${PATH}"
 
 echo "Installing e2e.test to ${test_run}"
 cp "${repo_root}/e2e.test" "${test_run}"
 
-echo "Installing ginkgo to ${test_run}"
-GINKGO_BIN="${test_run}/ginkgo"
-if [[ ! -f ${GINKGO_BIN} ]]; then
-  GOBIN=${test_run} go install "github.com/onsi/ginkgo/ginkgo@${GINKGO_VERSION}"
-fi
-
 echo "Building and pushing test driver image to ${IMAGE_NAME}:${IMAGE_TAG}"
 aws ecr get-login-password --region "${REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
-docker tag "${MAKE_IMAGE}" "${IMAGE_NAME}:${IMAGE_TAG}"
+docker tag "${BUILD_IMAGE}" "${IMAGE_NAME}:${IMAGE_TAG}"
 docker push "${IMAGE_NAME}:${IMAGE_TAG}"
 
 if [[ "${UP}" = "yes" ]]; then
@@ -155,9 +149,9 @@ if [[ "${UP}" = "yes" ]]; then
 fi
 
 pushd ./tests/e2e
-${GINKGO_BIN} . -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINKGO_SKIP}" "" -- -kubeconfig="${KUBECONFIG}" -report-dir="${test_run}" -gce-zone="${ZONES%,*}" "${EXPANDED_TEST_EXTRA_FLAGS}"
+ginkgo . -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINKGO_SKIP}" "" -- -kubeconfig="${KUBECONFIG}" -report-dir="${test_run}" -gce-zone="${ZONES%,*}" "${EXPANDED_TEST_EXTRA_FLAGS}"
 popd
 
 if [[ "${DOWN}" = "yes" ]]; then
-    kops delete cluster --name "${CLUSTER_NAME}" --yes
+    ${test_run}/kops delete cluster --name "${CLUSTER_NAME}" --yes
 fi

--- a/hack/install-e2e-tools.sh
+++ b/hack/install-e2e-tools.sh
@@ -18,15 +18,31 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+GINKGO_VERSION="${GINKGO_VERSION:-v1.14.0}"
 KOPS_ROOT="${KOPS_ROOT:-}"
 export GO111MODULE=on
 
+if [[ -n ${INSTALL_PATH} ]]; then
+    export GOBIN="${INSTALL_PATH}"
+fi
+
+cd $(mktemp -d) > /dev/null
+
+echo " + Installing kubetest2"
+go install "sigs.k8s.io/kubetest2@latest"
+
+echo " + Installing ginkgo"
+go install "github.com/onsi/ginkgo/ginkgo@${GINKGO_VERSION}"
+
 if [[ -z "${KOPS_ROOT}" ]]; then
-    cd $(mktemp -d) > /dev/null
     git clone https://github.com/kubernetes/kops.git
-    KOPS_ROOT="$(cwd)/kops"
+    KOPS_ROOT="$(pwd)/kops"
 fi
 
 cd "${KOPS_ROOT}/tests/e2e" > /dev/null
+
+echo " + Installing kubetest2-tester-kops"
 go install ./kubetest2-tester-kops
+
+echo " + Installing kubetest2-kops"
 go install ./kubetest2-kops


### PR DESCRIPTION
Cherry pick of #312 on release-1.22.

#312: Fix e2e failures

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```