### PR TITLE
Fix 1.22 e2e failures

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -47,7 +47,7 @@ UP="${UP:-yes}"
 # if DOWN==yes, delete cluster after test
 DOWN="${DOWN:-yes}"
 
-KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.23.2}"
+KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.22.7}"
 CLUSTER_NAME="test-cluster-${test_run_id}.k8s.local"
 KOPS_STATE_STORE="${KOPS_STATE_STORE:-}"
 REGION="${AWS_REGION:-us-west-2}"


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Fixes failing tests on release-1.22.

**Special notes for your reviewer**:
Tests are failing because the test cluster doesn't have permissions to create an untagged security group.  Tag-on-create was added recently so checking to see if kops changed permissions from 1.22 to 1.23.  If this doesn't work we can try cherry-picking https://github.com/kubernetes/cloud-provider-aws/pull/293.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
