### PR TITLE
Fix route controller create/delete spam: use instanceIDToNodeName in case node name != private DNS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GOARCH ?= $(shell go env GOARCH)
 GOPROXY ?= $(shell go env GOPROXY)
 GIT_VERSION := $(shell git describe --dirty --tags --match='v*')
 VERSION ?= $(GIT_VERSION)
-IMAGE := amazon/cloud-controller-manager:$(VERSION)
+IMAGE ?= amazon/cloud-controller-manager:$(VERSION)
 OUTPUT ?= $(shell pwd)/_output
 INSTALL_PATH ?= $(OUTPUT)/bin
 LDFLAGS ?= -w -s -X k8s.io/component-base/version.gitVersion=$(VERSION)

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -5107,11 +5107,6 @@ func (c *Cloud) instanceIDToNodeName(instanceID InstanceID) (types.NodeName, err
 		return "", fmt.Errorf("node informer has not synced yet")
 	}
 
-	_, err := c.nodeInformer.Lister().Get(string(instanceID))
-	if err == nil {
-		return types.NodeName(instanceID), nil
-	}
-
 	nodes, err := c.nodeInformer.Informer().GetIndexer().IndexKeys("instanceID", string(instanceID))
 	if err != nil {
 		return "", fmt.Errorf("error getting node with instanceID %q: %v", string(instanceID), err)

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1515,11 +1515,11 @@ func (c *Cloud) HasClusterID() bool {
 
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.NodeAddress, error) {
-	providerID, err := c.nodeNameToProviderID(name)
+	instanceID, err := c.nodeNameToInstanceID(name)
 	if err != nil {
-		return nil, fmt.Errorf("could not look up provider ID for node %q: %v", name, err)
+		return nil, fmt.Errorf("could not look up instance ID for node %q: %v", name, err)
 	}
-	return c.NodeAddressesByProviderID(ctx, string(providerID))
+	return c.NodeAddressesByProviderID(ctx, string(instanceID))
 }
 
 // extractIPv4NodeAddresses maps the instance information from EC2 to an array of NodeAddresses.
@@ -5014,10 +5014,10 @@ func (c *Cloud) findInstanceByNodeName(nodeName types.NodeName) (*ec2.Instance, 
 func (c *Cloud) getInstanceByNodeName(nodeName types.NodeName) (*ec2.Instance, error) {
 	var instance *ec2.Instance
 
-	// we leverage node cache to try to retrieve node's provider id first, as
-	// get instance by provider id is way more efficient than by filters in
+	// we leverage node cache to try to retrieve node's instance id first, as
+	// get instance by instance id is way more efficient than by filters in
 	// aws context
-	awsID, err := c.nodeNameToProviderID(nodeName)
+	awsID, err := c.nodeNameToInstanceID(nodeName)
 	if err != nil {
 		klog.V(3).Infof("Unable to convert node name %q to aws instanceID, fall back to findInstanceByNodeName: %v", nodeName, err)
 		instance, err = c.findInstanceByNodeName(nodeName)
@@ -5048,7 +5048,7 @@ func isFargateNode(nodeName string) bool {
 	return strings.HasPrefix(nodeName, fargateNodeNamePrefix)
 }
 
-func (c *Cloud) nodeNameToProviderID(nodeName types.NodeName) (InstanceID, error) {
+func (c *Cloud) nodeNameToInstanceID(nodeName types.NodeName) (InstanceID, error) {
 	if strings.HasPrefix(string(nodeName), rbnNamePrefix) {
 		return InstanceID(nodeName), nil
 	}

--- a/pkg/providers/v1/aws_routes.go
+++ b/pkg/providers/v1/aws_routes.go
@@ -112,9 +112,13 @@ func (c *Cloud) ListRoutes(ctx context.Context, clusterName string) ([]*cloudpro
 		// Capture instance routes
 		instanceID := aws.StringValue(r.InstanceId)
 		if instanceID != "" {
-			instance, found := instances[instanceID]
+			_, found := instances[instanceID]
 			if found {
-				route.TargetNode = mapInstanceToNodeName(instance)
+				node, err := c.instanceIDToNodeName(InstanceID(instanceID))
+				if err != nil {
+					return nil, err
+				}
+				route.TargetNode = node
 				routes = append(routes, route)
 			} else {
 				klog.Warningf("unable to find instance ID %s in the list of instances being routed to", instanceID)

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -2597,9 +2597,15 @@ func TestRegionIsValid(t *testing.T) {
 	assert.False(t, isRegionValid("pl-fake-991a", fake.metadata), "expected region 'pl-fake-991' to be invalid but it was not")
 }
 
+const (
+	testNodeName           = types.NodeName("ip-10-0-0-1.ec2.internal")
+	testInstanceIDNodeName = types.NodeName("i-02bce90670bb0c7cd")
+	testOverriddenNodeName = types.NodeName("foo")
+	testProviderID         = "aws:///us-east-1c/i-02bce90670bb0c7cd"
+	testInstanceID         = "i-02bce90670bb0c7cd"
+)
+
 func TestNodeNameToInstanceID(t *testing.T) {
-	testNodeName := types.NodeName("ip-10-0-0-1.ec2.internal")
-	testProviderID := "aws:///us-east-1c/i-02bce90670bb0c7cd"
 	fakeAWS := newMockedFakeAWSServices(TestClusterID)
 	c, err := newAWSCloud(CloudConfig{}, fakeAWS)
 	assert.NoError(t, err)
@@ -2634,6 +2640,99 @@ func TestNodeNameToInstanceID(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = c.nodeNameToInstanceID(testNodeName)
 	assert.NoError(t, err)
+}
+
+func TestInstanceIDToNodeName(t *testing.T) {
+	testCases := []struct {
+		name             string
+		instanceID       InstanceID
+		node             *v1.Node
+		expectedNodeName types.NodeName
+		expectedErr      error
+	}{
+		{
+			name:       "success: node with private DNS name",
+			instanceID: testInstanceID,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testNodeName),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: testProviderID,
+				},
+			},
+			expectedNodeName: testNodeName,
+			expectedErr:      nil,
+		},
+		{
+			name:       "success: node with instance ID name",
+			instanceID: testInstanceID,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testInstanceIDNodeName),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: testProviderID,
+				},
+			},
+			expectedNodeName: testInstanceIDNodeName,
+			expectedErr:      nil,
+		},
+		{
+			name:       "success: node with overridden name",
+			instanceID: testInstanceID,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testOverriddenNodeName),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: testProviderID,
+				},
+			},
+			expectedNodeName: testOverriddenNodeName,
+			expectedErr:      nil,
+		},
+		{
+			name:       "fail: no node with matching instance ID",
+			instanceID: testInstanceID,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testOverriddenNodeName),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "aws:///us-east-1c/i-foo",
+				},
+			},
+			expectedNodeName: types.NodeName(""),
+			expectedErr:      fmt.Errorf("node with instanceID \"i-02bce90670bb0c7cd\" not found"),
+		},
+		{
+			name:             "fail: no node at all",
+			instanceID:       testInstanceID,
+			node:             nil,
+			expectedNodeName: types.NodeName(""),
+			expectedErr:      fmt.Errorf("node with instanceID \"i-02bce90670bb0c7cd\" not found"),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			awsServices := newMockedFakeAWSServices(TestClusterID)
+			awsCloud, err := newAWSCloud(CloudConfig{}, awsServices)
+			if err != nil {
+				t.Fatalf("error creating mock cloud: %v", err)
+			}
+			awsCloud.kubeClient = fake.NewSimpleClientset()
+			fakeInformerFactory := informers.NewSharedInformerFactory(awsCloud.kubeClient, 0)
+			awsCloud.SetInformers(fakeInformerFactory)
+			if testCase.node != nil {
+				awsCloud.nodeInformer.Informer().GetStore().Add(testCase.node)
+			}
+			awsCloud.nodeInformerHasSynced = informerSynced
+			nodeName, err := awsCloud.instanceIDToNodeName(testCase.instanceID)
+			assert.Equal(t, testCase.expectedNodeName, nodeName)
+			assert.Equal(t, testCase.expectedErr, err)
+		})
+	}
 }
 
 func informerSynced() bool {

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -2597,7 +2597,7 @@ func TestRegionIsValid(t *testing.T) {
 	assert.False(t, isRegionValid("pl-fake-991a", fake.metadata), "expected region 'pl-fake-991' to be invalid but it was not")
 }
 
-func TestNodeNameToProviderID(t *testing.T) {
+func TestNodeNameToInstanceID(t *testing.T) {
 	testNodeName := types.NodeName("ip-10-0-0-1.ec2.internal")
 	testProviderID := "aws:///us-east-1c/i-02bce90670bb0c7cd"
 	fakeAWS := newMockedFakeAWSServices(TestClusterID)
@@ -2609,17 +2609,17 @@ func TestNodeNameToProviderID(t *testing.T) {
 	c.SetInformers(fakeInformerFactory)
 
 	// no node name
-	_, err = c.nodeNameToProviderID("")
+	_, err = c.nodeNameToInstanceID("")
 	assert.Error(t, err)
 
 	// informer has not synced
 	c.nodeInformerHasSynced = informerNotSynced
-	_, err = c.nodeNameToProviderID(testNodeName)
+	_, err = c.nodeNameToInstanceID(testNodeName)
 	assert.Error(t, err)
 
 	// informer has synced but node not found
 	c.nodeInformerHasSynced = informerSynced
-	_, err = c.nodeNameToProviderID(testNodeName)
+	_, err = c.nodeNameToInstanceID(testNodeName)
 	assert.Error(t, err)
 
 	// we are able to find the node in cache
@@ -2632,7 +2632,7 @@ func TestNodeNameToProviderID(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	_, err = c.nodeNameToProviderID(testNodeName)
+	_, err = c.nodeNameToInstanceID(testNodeName)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: 

The function `mapInstanceToNodeName` assumes that node names are always equal to private dns names. This assumption does not always hold, specifically in 1.23 kops clusters with CCM enabled where  node names are overridden to be instance IDs.

I added `instanceIDToNodeName` as a replacement. It relies on an indexer in the node informer to find nodeName by instance ID. This solution might be heavy-handed, I don't know how expensive exactly it is to have this indexer. If we assume that node names are going to be limited to either private dns or instance ids (or fargate?) then the solution could be simpler: it could check if a node with name equal to instance id exists, as suggested here https://github.com/kubernetes/kops/issues/13376#issuecomment-1069591289, and if not then fall back to assuming that node names are private dns names. Open to suggestions of course...

I tested this in my own cluster, I'll need to work on unit tests. And am considering how we can test this end to end or if such a test is necessary. We only caught this issue in the first place because AWS alerted us that we were making an unusual # of calls.

Test:
1. delete routes with destination 100.96.0.0/24 and 100.96.1.0/24 in VPC console
2. check logging of cloud controller: ~ $ k logs -n kube-system aws-cloud-controller-manager-xnmj5
```
I0317 21:29:45.399248       1 route_controller.go:194] Creating route for node i-001c99c6268df2574 100.96.1.0/24 with hint bd6fb3d1-708e-45ef-8019-01090827d461, throttled 10.433µs
I0317 21:29:45.399295       1 route_controller.go:194] Creating route for node i-001ab2674ef942145 100.96.0.0/24 with hint 24e777a5-cba7-4079-82c6-57d215eb4865, throttled 5.411µs
I0317 21:29:46.129790       1 route_controller.go:214] Created route for node i-001c99c6268df2574 100.96.1.0/24 with hint bd6fb3d1-708e-45ef-8019-01090827d461 after 730.545279ms
I0317 21:29:46.315747       1 route_controller.go:214] Created route for node i-001ab2674ef942145 100.96.0.0/24 with hint 24e777a5-cba7-4079-82c6-57d215eb4865 after 916.451209ms
```
3. check logging of cloud controller 5 mins later, there are no unnecessary Deletes or Creates:  ~ $ k logs -n kube-system aws-cloud-controller-manager-xnmj5

**Which issue(s) this PR fixes**: 
Fixes #318

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
5. 
-->
```release-note
Fix route controller making unnecessary CreateRoute/DeleteRoute AWS API requests in case node names are not private DNS names
```
