### PR TITLE
Use Makefile in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,16 +3,19 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
-    entrypoint: /buildx-entrypoint
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20220324-0d59b58358
+    id: image-push
+    entrypoint: make
+    env:
+    - PULL_BASE_REF=$_PULL_BASE_REF
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - DOCKER_BUILDKIT=1
+    - DOCKER_REGISTRY=$_DOCKER_REGISTRY
+    - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
     args:
-    - build
-    - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:$_GIT_TAG
-    - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:latest
-    - --build-arg=VERSION=$_GIT_TAG
-    - --output=type=registry
-    - --platform=linux/amd64,linux/arm64
-    - .
+    - docker-build-push
 substitutions:
-  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'dev'
+  _DOCKER_REGISTRY: 'gcr.io'
+  _DOCKER_IMAGE_PREFIX: 'k8s-staging-provider-aws'
 timeout: 1200s


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

* We need to use the makefile in cloudbuild so that we can have more
  control over our versions.  Currently we use GIT_TAG but we want
  it to always be semver compatible (expected by component-base)
  and we want to be able to filter out the helm chart tags
  (currently done by the Makefile but not by cloudbuild).


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
