### PR TITLE
Double load balancer timeout from 5 mins to 10

### DIFF
--- a/tests/e2e/loadbalancer.go
+++ b/tests/e2e/loadbalancer.go
@@ -83,7 +83,7 @@ var _ = Describe("[cloud-provider-aws-e2e] loadbalancer", func() {
 		ingressIP := e2eservice.GetIngressPoint(&lbService.Status.LoadBalancer.Ingress[0])
 		framework.Logf("Load balancer's ingress IP: %s", ingressIP)
 
-		e2eservice.TestReachableHTTP(ingressIP, svcPort, e2eservice.KubeProxyLagTimeout)
+		e2eservice.TestReachableHTTP(ingressIP, svcPort, e2eservice.LoadBalancerLagTimeoutAWS)
 
 		// Update the service to cluster IP
 		By("changing TCP service back to type=ClusterIP")


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
This test sometimes times out at 5 mins, especially in aws china. We just have to wait longer for the load balancer to be ready.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
