### PR TITLE
Automated cherry pick of #345: Double load balancer timeout from 5 mins to 10

### DIFF
--- a/tests/e2e/loadbalancer.go
+++ b/tests/e2e/loadbalancer.go
@@ -83,7 +83,7 @@ var _ = Describe("[cloud-provider-aws-e2e] loadbalancer", func() {
 		ingressIP := e2eservice.GetIngressPoint(&lbService.Status.LoadBalancer.Ingress[0])
 		framework.Logf("Load balancer's ingress IP: %s", ingressIP)
 
-		e2eservice.TestReachableHTTP(ingressIP, svcPort, e2eservice.KubeProxyLagTimeout)
+		e2eservice.TestReachableHTTP(ingressIP, svcPort, e2eservice.LoadBalancerLagTimeoutAWS)
 
 		// Update the service to cluster IP
 		By("changing TCP service back to type=ClusterIP")


### PR DESCRIPTION
Cherry pick of #345 on release-1.22.

#345: Double load balancer timeout from 5 mins to 10

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```