### PR TITLE
Trim date prefix from tag in GCB image build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
     - build
     - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:$_GIT_TAG
     - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:latest
-    - --build-arg=VERSION=$_GIT_TAG
+    - --build-arg=VERSION=$(echo $_GIT_TAG | awk -F - '{print $2}')
     - --output=type=registry
     - --platform=linux/amd64,linux/arm64
     - .

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
     - build
     - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:$_GIT_TAG
     - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:latest
-    - --build-arg=VERSION=$(echo $_GIT_TAG | awk -F - '{print $2}')
+    - --build-arg=VERSION=$(echo $_GIT_TAG | cut -d - -f2-)
     - --output=type=registry
     - --platform=linux/amd64,linux/arm64
     - .


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The image pushing setup in test-infra defines `_GIT_TAG` with a `vYYYYMMDD` prefix to `git describe`.

This format isn't allowed by k8s.io/component-base panicking on startup.

By trimming the date prefix from the tag, image builds will only contain the `git describe` output, matching the binaries built from the Makefile


**Which issue(s) this PR fixes**: 
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #339

**Special notes for your reviewer**:

I copied this solution from another project's build process that also utilizes GCB and k8s.io/component-base:

https://github.com/kubernetes-sigs/scheduler-plugins/blob/1c90b0d319f33c7a33d9456ba412be0b6ffb61bc/Makefile#L31-L36

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
