### PR TITLE
Add note about AWS CCM container images

### DIFF
--- a/charts/aws-cloud-controller-manager/values.yaml
+++ b/charts/aws-cloud-controller-manager/values.yaml
@@ -5,7 +5,7 @@ args:
   - --cloud-provider=aws
 
 image:
-    repository: us.gcr.io/k8s-artifacts-prod/provider-aws/cloud-controller-manager
+    repository: registry.k8s.io/provider-aws/cloud-controller-manager
     tag: v1.23.0-alpha.0
 
 # nameOverride overrides `cloud-controller-manager.fullname`

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,9 @@ The in-tree cloud provider code has mostly stopped accepting new features, so fu
 ### AWS Cloud Controller Manager
 The AWS Cloud Controller Manager is the controller that is primarily responsible for creating and updating AWS loadbalancers (classic and NLB) and node lifecycle management.  The controller loops that are migrating out of the kube controller manager include the route controller, the service controller, the node controller, and the node lifecycle controller.  See the [cloud controller manager KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2392-cloud-controller-manager) for more details.
 
+##### Container Images
+AWS Cloud Controller Managed container images are available in `registry.k8s.io/provider-aws/cloud-controller-manager`.
+
 ### AWS Credential Provider
 The AWS credential provider is a binary that is executed by kubelet to provide credentials for images in ECR.  Refer to the [credential provider extraction KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2133-out-of-tree-credential-provider) for more details.
 


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:
This PR adds a note about the AWS CCM container image. It also switches the new `registry.k8s.io` to be used as suggested by https://groups.google.com/a/kubernetes.io/g/dev/c/DYZYNQ_A6_c/m/oD9_Q8Q9AAAJ (ref https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)).

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
