### PR TITLE
Automated cherry pick of #376: Stop tagging latest for release branches

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,6 @@ steps:
     args:
     - build
     - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:$_SHORT_TAG
-    - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:latest
     - --build-arg=VERSION=$_SHORT_TAG
     - --output=type=registry
     - --platform=linux/amd64,linux/arm64


### PR DESCRIPTION
Cherry pick of #376 on release-1.21.

#376: Stop tagging latest for release branches

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```