### PR TITLE
Automated cherry pick of #308: Add tagging controller configuration
#334: Stop retrying failed workitem after a certain amount of
#387: Fix issues in tagging controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/book/_book/
 site/
 .vscode/
 e2e.test
+.idea/

--- a/cmd/aws-cloud-controller-manager/main.go
+++ b/cmd/aws-cloud-controller-manager/main.go
@@ -26,11 +26,11 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
-	"os"
-	"time"
-
 	"k8s.io/apimachinery/pkg/util/wait"
+	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider-aws/pkg/controllers/tagging"
+	awsv1 "k8s.io/cloud-provider-aws/pkg/providers/v1"
+	awsv2 "k8s.io/cloud-provider-aws/pkg/providers/v2"
 	"k8s.io/cloud-provider/app"
 	"k8s.io/cloud-provider/options"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -38,10 +38,9 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // for client metric registration
 	_ "k8s.io/component-base/metrics/prometheus/version"  // for version metric registration
 	"k8s.io/klog/v2"
-
-	cloudprovider "k8s.io/cloud-provider"
-	awsv1 "k8s.io/cloud-provider-aws/pkg/providers/v1"
-	awsv2 "k8s.io/cloud-provider-aws/pkg/providers/v2"
+	"math/rand"
+	"os"
+	"time"
 
 	cloudcontrollerconfig "k8s.io/cloud-provider/app/config"
 )
@@ -62,11 +61,23 @@ func main() {
 	}
 
 	controllerInitializers := app.DefaultInitFuncConstructors
+	taggingControllerWrapper := tagging.ControllerWrapper{}
 	fss := cliflag.NamedFlagSets{}
+	taggingControllerWrapper.Options.AddFlags(fss.FlagSet("tagging controller"))
+
+	taggingControllerConstructor := app.ControllerInitFuncConstructor{
+		InitContext: app.ControllerInitContext{
+			ClientName: tagging.TaggingControllerClientName,
+		},
+		Constructor: taggingControllerWrapper.StartTaggingControllerWrapper,
+	}
+
+	controllerInitializers[tagging.TaggingControllerKey] = taggingControllerConstructor
+	app.ControllersDisabledByDefault.Insert(tagging.TaggingControllerKey)
 	command := app.NewCloudControllerManagerCommand(opts, cloudInitializer, controllerInitializers, fss, wait.NeverStop)
 
 	if err := command.Execute(); err != nil {
-		os.Exit(1)
+		klog.Fatalf("unable to execute command: %v", err)
 	}
 }
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,3 +15,7 @@
 ### Kops
 
 * Add a full example (ideally with IAM roles)
+
+### Tagging Controller
+
+* Add e2e testing which enables the controller, and monitors if the resources are tagged properly

--- a/docs/tagging_controller.md
+++ b/docs/tagging_controller.md
@@ -1,0 +1,7 @@
+# The Tagging Controller
+
+The tagging controller is responsible for tagging and untagging node resources when they join and leave the cluster, respectively. It can add and remove tags based on user input. Additionally, if a tag is updated, it would leave the updated tag and reapply the user-provided tag. Unlike the existing controllers, the tagging controller works exclusively with AWS. The AWS APIs it uses are `ec2:CreateTags` and `ec2:DeleteTags`.
+
+| Flag | Valid Values | Default | Description |
+|------| --- | --- | --- |
+| tags          | Comma-separated list of key=value | -   | A comma-separated list of key-value pairs which will be recorded as nodes' additional tags. For example: "Key1=Val1,Key2=Val2,KeyNoVal1=,KeyNoVal2" |

--- a/pkg/controllers/options/resources.go
+++ b/pkg/controllers/options/resources.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+const (
+	// Instance presenting the string literal "instance"
+	Instance string = "instance"
+)
+
+// SupportedResources contains the resources that can be tagged by the controller at the moment
+var SupportedResources = []string{
+	Instance,
+}

--- a/pkg/controllers/options/tagging_controller.go
+++ b/pkg/controllers/options/tagging_controller.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+	"github.com/spf13/pflag"
+)
+
+// TaggingControllerOptions contains the inputs that can
+// be used in the tagging controller
+type TaggingControllerOptions struct {
+	Tags      map[string]string
+	Resources []string
+}
+
+// AddFlags add the additional flags for the controller
+func (o *TaggingControllerOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringToStringVar(&o.Tags, "tags", o.Tags, "Tags to apply to AWS resources in the tagging controller, in a form of key=value.")
+	fs.StringArrayVar(&o.Resources, "resources", o.Resources, "AWS resources name to add/remove tags in the tagging controller.")
+}
+
+// Validate checks for errors from user input
+func (o *TaggingControllerOptions) Validate() error {
+	if len(o.Tags) == 0 {
+		return fmt.Errorf("--tags must not be empty and must be a form of key=value")
+	}
+
+	if len(o.Resources) == 0 {
+		return fmt.Errorf("--resources must not be empty")
+	}
+
+	for _, r := range o.Resources {
+		for _, resource := range SupportedResources {
+			if r != resource {
+				return fmt.Errorf("%s is not a supported resource. Current supported resources %v", r, SupportedResources)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/controllers/tagging/metrics.go
+++ b/pkg/controllers/tagging/metrics.go
@@ -27,6 +27,7 @@ var (
 			Name:           "cloudprovider_aws_tagging_controller_work_item_duration_seconds",
 			Help:           "workitem latency of workitem being in the queue and time it takes to process",
 			StabilityLevel: metrics.ALPHA,
+			Buckets:        metrics.ExponentialBuckets(0.5, 1.5, 20),
 		},
 		[]string{"latency_type"})
 

--- a/pkg/controllers/tagging/metrics.go
+++ b/pkg/controllers/tagging/metrics.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tagging
+
+import (
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"sync"
+)
+
+var register sync.Once
+
+var (
+	workItemDuration = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Name:           "cloudprovider_aws_tagging_controller_work_item_duration_seconds",
+			Help:           "workitem latency of workitem being in the queue and time it takes to process",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"latency_type"})
+
+	workItemError = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "cloudprovider_aws_tagging_controller_work_item_errors_total",
+			Help:           "any error in dequeueing the work queue and processing workItem",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"error_type", "instance_id"})
+)
+
+// registerMetrics registers tagging-controller metrics.
+func registerMetrics() {
+	register.Do(func() {
+		legacyregistry.MustRegister(workItemDuration)
+		legacyregistry.MustRegister(workItemError)
+	})
+}
+
+func recordWorkItemLatencyMetrics(latencyType string, timeTaken float64) {
+	workItemDuration.With(metrics.Labels{"latency_type": latencyType}).Observe(timeTaken)
+}
+
+func recordWorkItemErrorMetrics(errorType string, instanceID string) {
+	workItemError.With(metrics.Labels{"error_type": errorType, "instance_id": instanceID}).Inc()
+}

--- a/pkg/controllers/tagging/tagging_controller.go
+++ b/pkg/controllers/tagging/tagging_controller.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tagging
+
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	cloudprovider "k8s.io/cloud-provider"
+	opt "k8s.io/cloud-provider-aws/pkg/controllers/options"
+	awsv1 "k8s.io/cloud-provider-aws/pkg/providers/v1"
+	"k8s.io/klog/v2"
+	"time"
+)
+
+// workItem contains the node and an action for that node
+type workItem struct {
+	node           *v1.Node
+	action         func(node *v1.Node) error
+	requeuingCount int
+	enqueueTime    time.Time
+}
+
+const (
+	maxRequeuingCount = 9
+
+	// The label for depicting total number of errors a work item encounter and succeed
+	totalErrorsWorkItemErrorMetric = "total_errors"
+
+	// The label for depicting total time when work item gets queued to processed
+	workItemProcessingTimeWorkItemMetric = "work_item_processing_time"
+
+	// The label for depicting total time when work item gets queued to dequeued
+	workItemDequeuingTimeWorkItemMetric = "work_item_dequeuing_time"
+
+	// The label for depicting total number of errors a work item encounter and fail
+	errorsAfterRetriesExhaustedWorkItemErrorMetric = "errors_after_retries_exhausted"
+)
+
+// Controller is the controller implementation for tagging cluster resources.
+// It periodically checks for Node events (creating/deleting) to apply/delete appropriate
+// tags to resources.
+type Controller struct {
+	nodeInformer coreinformers.NodeInformer
+	kubeClient   clientset.Interface
+	cloud        *awsv1.Cloud
+	workqueue    workqueue.RateLimitingInterface
+	nodesSynced  cache.InformerSynced
+
+	// Value controlling Controller monitoring period, i.e. how often does Controller
+	// check node list. This value should be lower than nodeMonitorGracePeriod
+	// set in controller-manager
+	nodeMonitorPeriod time.Duration
+
+	// Representing the user input for tags
+	tags map[string]string
+
+	// Representing the resources to tag
+	resources []string
+}
+
+// NewTaggingController creates a NewTaggingController object
+func NewTaggingController(
+	nodeInformer coreinformers.NodeInformer,
+	kubeClient clientset.Interface,
+	cloud cloudprovider.Interface,
+	nodeMonitorPeriod time.Duration,
+	tags map[string]string,
+	resources []string) (*Controller, error) {
+
+	awsCloud, ok := cloud.(*awsv1.Cloud)
+	if !ok {
+		err := fmt.Errorf("tagging controller does not support %v provider", cloud.ProviderName())
+		return nil, err
+	}
+
+	registerMetrics()
+	tc := &Controller{
+		nodeInformer:      nodeInformer,
+		kubeClient:        kubeClient,
+		cloud:             awsCloud,
+		tags:              tags,
+		resources:         resources,
+		workqueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Tagging"),
+		nodesSynced:       nodeInformer.Informer().HasSynced,
+		nodeMonitorPeriod: nodeMonitorPeriod,
+	}
+
+	// Use shared informer to listen to add/update/delete of nodes. Note that any nodes
+	// that exist before tagging controller starts will show up in the update method
+	tc.nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { tc.enqueueNode(obj, tc.tagNodesResources) },
+		UpdateFunc: func(oldObj, newObj interface{}) { tc.enqueueNode(newObj, tc.tagNodesResources) },
+		DeleteFunc: func(obj interface{}) { tc.enqueueNode(obj, tc.untagNodeResources) },
+	})
+
+	return tc, nil
+}
+
+// Run will start the controller to tag resources attached to the cluster
+// and untag resources detached from the cluster.
+func (tc *Controller) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer tc.workqueue.ShutDown()
+
+	// Wait for the caches to be synced before starting workers
+	klog.Info("Waiting for informer caches to sync")
+	if ok := cache.WaitForCacheSync(stopCh, tc.nodesSynced); !ok {
+		klog.Errorf("failed to wait for caches to sync")
+		return
+	}
+
+	klog.Infof("Starting the tagging controller")
+	go wait.Until(tc.work, tc.nodeMonitorPeriod, stopCh)
+
+	<-stopCh
+}
+
+// work is a long-running function that continuously
+// call process() for each message on the workqueue
+func (tc *Controller) work() {
+	for tc.process() {
+	}
+}
+
+// process reads each message in the queue and performs either
+// tag or untag function on the Node object
+func (tc *Controller) process() bool {
+	obj, shutdown := tc.workqueue.Get()
+	if shutdown {
+		return false
+	}
+
+	klog.Infof("Starting to process %v", obj)
+
+	err := func(obj interface{}) error {
+		defer tc.workqueue.Done(obj)
+
+		workItem, ok := obj.(*workItem)
+		if !ok {
+			tc.workqueue.Forget(obj)
+			err := fmt.Errorf("expected workItem in workqueue but got %#v", obj)
+			utilruntime.HandleError(err)
+			return nil
+		}
+
+		timeTaken := time.Since(workItem.enqueueTime).Seconds()
+		recordWorkItemLatencyMetrics(workItemDequeuingTimeWorkItemMetric, timeTaken)
+
+		instanceID, err := awsv1.KubernetesInstanceID(workItem.node.Spec.ProviderID).MapToAWSInstanceID()
+		if err != nil {
+			err = fmt.Errorf("Error in getting instanceID for node %s, error: %v", workItem.node.GetName(), err)
+			utilruntime.HandleError(err)
+			return nil
+		}
+
+		err = workItem.action(workItem.node)
+
+		if err != nil {
+			if workItem.requeuingCount < maxRequeuingCount {
+				// Put the item back on the workqueue to handle any transient errors.
+				workItem.requeuingCount++
+				tc.workqueue.AddRateLimited(workItem)
+
+				recordWorkItemErrorMetrics(totalErrorsWorkItemErrorMetric, string(instanceID))
+				return fmt.Errorf("error processing work item '%v': %s, requeuing count %d", workItem, err.Error(), workItem.requeuingCount)
+			}
+
+			klog.Errorf("error processing work item '%v': %s, requeuing count exceeded", workItem, err.Error())
+			recordWorkItemErrorMetrics(errorsAfterRetriesExhaustedWorkItemErrorMetric, string(instanceID))
+		} else {
+			klog.Infof("Finished processing %v", workItem)
+			timeTaken = time.Since(workItem.enqueueTime).Seconds()
+			recordWorkItemLatencyMetrics(workItemProcessingTimeWorkItemMetric, timeTaken)
+		}
+
+		tc.workqueue.Forget(obj)
+		return nil
+	}(obj)
+
+	if err != nil {
+		klog.Errorf("Error occurred while processing %v", obj)
+		utilruntime.HandleError(err)
+	}
+
+	return true
+}
+
+// tagNodesResources tag node resources
+// If we want to tag more resources, modify this function appropriately
+func (tc *Controller) tagNodesResources(node *v1.Node) error {
+	for _, resource := range tc.resources {
+		switch resource {
+		case opt.Instance:
+			err := tc.tagEc2Instance(node)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// tagEc2Instances applies the provided tags to each EC2 instance in
+// the cluster.
+func (tc *Controller) tagEc2Instance(node *v1.Node) error {
+	instanceID, _ := awsv1.KubernetesInstanceID(node.Spec.ProviderID).MapToAWSInstanceID()
+
+	err := tc.cloud.TagResource(string(instanceID), tc.tags)
+
+	if err != nil {
+		klog.Errorf("Error in tagging EC2 instance for node %s, error: %v", node.GetName(), err)
+		return err
+	}
+
+	klog.Infof("Successfully tagged %s with %v", instanceID, tc.tags)
+
+	return nil
+}
+
+// untagNodeResources untag node resources
+// If we want to untag more resources, modify this function appropriately
+func (tc *Controller) untagNodeResources(node *v1.Node) error {
+	for _, resource := range tc.resources {
+		switch resource {
+		case opt.Instance:
+			err := tc.untagEc2Instance(node)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// untagEc2Instances deletes the provided tags to each EC2 instances in
+// the cluster.
+func (tc *Controller) untagEc2Instance(node *v1.Node) error {
+	instanceID, _ := awsv1.KubernetesInstanceID(node.Spec.ProviderID).MapToAWSInstanceID()
+
+	err := tc.cloud.UntagResource(string(instanceID), tc.tags)
+
+	if err != nil {
+		klog.Errorf("Error in untagging EC2 instance for node %s, error: %v", node.GetName(), err)
+		return err
+	}
+
+	klog.Infof("Successfully untagged %s with %v", instanceID, tc.tags)
+
+	return nil
+}
+
+// enqueueNode takes in the object and an
+// action for the object for a workitem and enqueue to the workqueue
+func (tc *Controller) enqueueNode(obj interface{}, action func(node *v1.Node) error) {
+	node := obj.(*v1.Node)
+	item := &workItem{
+		node:           node,
+		action:         action,
+		requeuingCount: 0,
+		enqueueTime:    time.Now(),
+	}
+	tc.workqueue.Add(item)
+	klog.Infof("Added %s to the workqueue", item)
+}

--- a/pkg/controllers/tagging/tagging_controller_test.go
+++ b/pkg/controllers/tagging/tagging_controller_test.go
@@ -71,6 +71,54 @@ func Test_NodesJoiningAndLeaving(t *testing.T) {
 			expectedMessages: []string{"Successfully tagged i-0001"},
 		},
 		{
+			name: "node0 joins the cluster and was tagged earlier with different tags.",
+			currNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					Labels: map[string]string{
+						taggingControllerLabelKey: "9767c4972ba72e87ab553bad2afde741", // MD5 for key1=value1
+					},
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "i-0001",
+				},
+			},
+			toBeTagged:       true,
+			expectedMessages: []string{"Successfully tagged i-0001"},
+		},
+		{
+			name: "node0 joins the cluster but isn't tagged because it was already tagged earlier.",
+			currNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					Labels: map[string]string{
+						taggingControllerLabelKey: "c812faa65d1d5e5aefa6b069b3da39df", // MD5 for key1=value1,key2=value2
+					},
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "i-0001",
+				},
+			},
+			toBeTagged:       true,
+			expectedMessages: []string{"Skip tagging node node0 since it was already tagged earlier."},
+		},
+		{
+			name: "fargate node joins the cluster.",
+			currNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "fargatenode0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "aws:///us-west-2a/2ea696a557-9e55466d21eb4f83a99a9aa396bbd134/fargate-ip-10-0-55-27.us-west-2.compute.internal",
+				},
+			},
+			toBeTagged:       true,
+			expectedMessages: []string{"Skip processing the node fargate-ip-10-0-55-27.us-west-2.compute.internal since it is a Fargate node"},
+		},
+		{
 			name: "node0 leaves the cluster, failed to untag.",
 			currNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -82,7 +130,7 @@ func Test_NodesJoiningAndLeaving(t *testing.T) {
 				},
 			},
 			toBeTagged:       false,
-			expectedMessages: []string{"Error in untagging EC2 instance for node node0"},
+			expectedMessages: []string{"Error in untagging EC2 instance i-error for node node0"},
 		},
 		{
 			name: "node0 leaves the cluster.",
@@ -125,7 +173,7 @@ func Test_NodesJoiningAndLeaving(t *testing.T) {
 				kubeClient:        clientset,
 				cloud:             fakeAws,
 				nodeMonitorPeriod: 1 * time.Second,
-				tags:              map[string]string{"key": "value"},
+				tags:              map[string]string{"key2": "value2", "key1": "value1"},
 				resources:         []string{"instance"},
 				workqueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Tagging"),
 			}

--- a/pkg/controllers/tagging/tagging_controller_test.go
+++ b/pkg/controllers/tagging/tagging_controller_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tagging
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/workqueue"
+	awsv1 "k8s.io/cloud-provider-aws/pkg/providers/v1"
+	"k8s.io/klog/v2"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const TestClusterID = "clusterid.test"
+
+func Test_NodesJoiningAndLeaving(t *testing.T) {
+	klog.InitFlags(nil)
+	flag.CommandLine.Parse([]string{"--logtostderr=false"})
+	testcases := []struct {
+		name             string
+		currNode         *v1.Node
+		toBeTagged       bool
+		expectedMessages []string
+	}{
+		{
+			name: "node0 joins the cluster, but fail to tag.",
+			currNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "i-error",
+				},
+			},
+			toBeTagged:       true,
+			expectedMessages: []string{"Error occurred while processing"},
+		},
+		{
+			name: "node0 joins the cluster.",
+			currNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "i-0001",
+				},
+			},
+			toBeTagged:       true,
+			expectedMessages: []string{"Successfully tagged i-0001"},
+		},
+		{
+			name: "node0 leaves the cluster, failed to untag.",
+			currNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "i-error",
+				},
+			},
+			toBeTagged:       false,
+			expectedMessages: []string{"Error in untagging EC2 instance for node node0"},
+		},
+		{
+			name: "node0 leaves the cluster.",
+			currNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "i-0001",
+				},
+			},
+			toBeTagged:       false,
+			expectedMessages: []string{"Successfully untagged i-0001"},
+		},
+	}
+
+	awsServices := awsv1.NewFakeAWSServices(TestClusterID)
+	fakeAws, _ := awsv1.NewAWSCloud(awsv1.CloudConfig{}, awsServices)
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			klog.SetOutput(&logBuf)
+			defer func() {
+				klog.SetOutput(os.Stderr)
+			}()
+
+			clientset := fake.NewSimpleClientset(testcase.currNode)
+			informer := informers.NewSharedInformerFactory(clientset, time.Second)
+			nodeInformer := informer.Core().V1().Nodes()
+
+			if err := syncNodeStore(nodeInformer, clientset); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			//eventBroadcaster := record.NewBroadcaster()
+			tc := &Controller{
+				nodeInformer:      nodeInformer,
+				kubeClient:        clientset,
+				cloud:             fakeAws,
+				nodeMonitorPeriod: 1 * time.Second,
+				tags:              map[string]string{"key": "value"},
+				resources:         []string{"instance"},
+				workqueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Tagging"),
+			}
+
+			if testcase.toBeTagged {
+				tc.enqueueNode(testcase.currNode, tc.tagNodesResources)
+			} else {
+				tc.enqueueNode(testcase.currNode, tc.untagNodeResources)
+			}
+
+			for tc.workqueue.Len() > 0 {
+				tc.process()
+
+				// sleep briefly because of exponential backoff when requeueing failed workitem
+				// resulting in workqueue to be empty if checked immediately
+				time.Sleep(1500 * time.Millisecond)
+			}
+
+			for _, msg := range testcase.expectedMessages {
+				if !strings.Contains(logBuf.String(), msg) {
+					t.Errorf("\nMsg %q not found in log: \n%v\n", msg, logBuf.String())
+				}
+				if strings.Contains(logBuf.String(), "Unable to tag") || strings.Contains(logBuf.String(), "Unable to untag") {
+					if !strings.Contains(logBuf.String(), ", requeuing count ") {
+						t.Errorf("\nFailed to tag or untag but logs did not requeue: \n%v\n", logBuf.String())
+					}
+
+					if !strings.Contains(logBuf.String(), "requeuing count exceeded") {
+						t.Errorf("\nExceeded requeue count but did not stop: \n%v\n", logBuf.String())
+					}
+				}
+			}
+		})
+	}
+}
+
+func syncNodeStore(nodeinformer coreinformers.NodeInformer, f *fake.Clientset) error {
+	nodes, err := f.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	newElems := make([]interface{}, 0, len(nodes.Items))
+	for i := range nodes.Items {
+		newElems = append(newElems, &nodes.Items[i])
+	}
+	return nodeinformer.Informer().GetStore().Replace(newElems, "newRV")
+}

--- a/pkg/controllers/tagging/tagging_controller_wrapper.go
+++ b/pkg/controllers/tagging/tagging_controller_wrapper.go
@@ -1,0 +1,59 @@
+package tagging
+
+import (
+	"context"
+
+	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider/app"
+	cloudcontrollerconfig "k8s.io/cloud-provider/app/config"
+	genericcontrollermanager "k8s.io/controller-manager/app"
+	"k8s.io/controller-manager/controller"
+	"k8s.io/klog/v2"
+
+	"k8s.io/cloud-provider-aws/pkg/controllers/options"
+)
+
+const (
+	// TaggingControllerClientName is the name of the tagging controller
+	TaggingControllerClientName = "tagging-controller"
+
+	// TaggingControllerKey is the key used to register this controller
+	TaggingControllerKey = "tagging"
+)
+
+// ControllerWrapper is the wrapper for the tagging controller
+type ControllerWrapper struct {
+	Options options.TaggingControllerOptions
+}
+
+// StartTaggingControllerWrapper is used to take cloud config as input and start the tagging controller
+func (tc *ControllerWrapper) StartTaggingControllerWrapper(initContext app.ControllerInitContext, completedConfig *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface) app.InitFunc {
+	return func(ctx context.Context, controllerContext genericcontrollermanager.ControllerContext) (controller.Interface, bool, error) {
+		return tc.startTaggingController(ctx, initContext, completedConfig, cloud)
+	}
+}
+
+func (tc *ControllerWrapper) startTaggingController(ctx context.Context, initContext app.ControllerInitContext, completedConfig *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface) (controller.Interface, bool, error) {
+	err := tc.Options.Validate()
+	if err != nil {
+		klog.Fatalf("Tagging controller inputs are not properly set: %v", err)
+	}
+
+	// Start the Controller
+	taggingcontroller, err := NewTaggingController(
+		completedConfig.SharedInformers.Core().V1().Nodes(),
+		completedConfig.ClientBuilder.ClientOrDie(initContext.ClientName),
+		cloud,
+		completedConfig.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
+		tc.Options.Tags,
+		tc.Options.Resources)
+
+	if err != nil {
+		klog.Warningf("failed to start tagging controller: %s", err)
+		return nil, false, nil
+	}
+
+	go taggingcontroller.Run(ctx.Done())
+
+	return nil, true, nil
+}

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1638,7 +1638,7 @@ func (c *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string
 		return nil, err
 	}
 
-	if isFargateNode(string(instanceID)) {
+	if IsFargateNode(string(instanceID)) {
 		eni, err := c.describeNetworkInterfaces(string(instanceID))
 		if eni == nil || err != nil {
 			return nil, err
@@ -1681,7 +1681,7 @@ func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID strin
 		return false, err
 	}
 
-	if isFargateNode(string(instanceID)) {
+	if IsFargateNode(string(instanceID)) {
 		eni, err := c.describeNetworkInterfaces(string(instanceID))
 		return eni != nil, err
 	}
@@ -1721,7 +1721,7 @@ func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID str
 		return false, err
 	}
 
-	if isFargateNode(string(instanceID)) {
+	if IsFargateNode(string(instanceID)) {
 		eni, err := c.describeNetworkInterfaces(string(instanceID))
 		return eni != nil, err
 	}
@@ -1782,7 +1782,7 @@ func (c *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string)
 		return "", err
 	}
 
-	if isFargateNode(string(instanceID)) {
+	if IsFargateNode(string(instanceID)) {
 		return "", nil
 	}
 
@@ -1891,7 +1891,7 @@ func (c *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (clo
 		return cloudprovider.Zone{}, err
 	}
 
-	if isFargateNode(string(instanceID)) {
+	if IsFargateNode(string(instanceID)) {
 		eni, err := c.describeNetworkInterfaces(string(instanceID))
 		if eni == nil || err != nil {
 			return cloudprovider.Zone{}, err
@@ -5084,8 +5084,8 @@ func (c *Cloud) getFullInstance(nodeName types.NodeName) (*awsInstance, *ec2.Ins
 	return awsInstance, instance, err
 }
 
-// isFargateNode returns true if given node runs on Fargate compute
-func isFargateNode(nodeName string) bool {
+// IsFargateNode returns true if given node runs on Fargate compute
+func IsFargateNode(nodeName string) bool {
 	return strings.HasPrefix(nodeName, fargateNodeNamePrefix)
 }
 

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -364,6 +364,7 @@ type EC2 interface {
 	DescribeSubnets(*ec2.DescribeSubnetsInput) ([]*ec2.Subnet, error)
 
 	CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
+	DeleteTags(input *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error)
 
 	DescribeRouteTables(request *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error)
 	CreateRoute(request *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error)
@@ -1177,6 +1178,14 @@ func (s *awsSdkEC2) CreateTags(request *ec2.CreateTagsInput) (*ec2.CreateTagsOut
 	return resp, err
 }
 
+func (s *awsSdkEC2) DeleteTags(request *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error) {
+	requestTime := time.Now()
+	resp, err := s.ec2.DeleteTags(request)
+	timeTaken := time.Since(requestTime).Seconds()
+	recordAWSMetric("delete_tags", timeTaken, err)
+	return resp, err
+}
+
 func (s *awsSdkEC2) DescribeRouteTables(request *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error) {
 	results := []*ec2.RouteTable{}
 	var nextToken *string
@@ -1426,6 +1435,11 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 	klog.Infof("The following IP families will be added to nodes: %v", cfg.Global.NodeIPFamilies)
 
 	return awsCloud, nil
+}
+
+// NewAWSCloud calls and return new aws cloud from newAWSCloud with the supplied configuration
+func NewAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
+	return newAWSCloud(cfg, awsServices)
 }
 
 // isRegionValid accepts an AWS region name and returns if the region is a

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -262,9 +263,24 @@ func (ec2i *FakeEC2Impl) RemoveSubnets() {
 	ec2i.Subnets = ec2i.Subnets[:0]
 }
 
-// CreateTags is not implemented but is required for interface conformance
-func (ec2i *FakeEC2Impl) CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
-	panic("Not implemented")
+// CreateTags is a mock for CreateTags from EC2
+func (ec2i *FakeEC2Impl) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
+	for _, id := range input.Resources {
+		if *id == "i-error" {
+			return nil, errors.New("Unable to tag")
+		}
+	}
+	return &ec2.CreateTagsOutput{}, nil
+}
+
+// DeleteTags is a mock for DeleteTags from EC2
+func (ec2i *FakeEC2Impl) DeleteTags(input *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error) {
+	for _, id := range input.Resources {
+		if *id == "i-error" {
+			return nil, errors.New("Unable to remove tag")
+		}
+	}
+	return &ec2.DeleteTagsOutput{}, nil
 }
 
 // DescribeRouteTables returns fake route table descriptions

--- a/pkg/providers/v1/instances.go
+++ b/pkg/providers/v1/instances.go
@@ -78,7 +78,7 @@ func (name KubernetesInstanceID) MapToAWSInstanceID() (InstanceID, error) {
 
 	// We sanity check the resulting volume; the two known formats are
 	// i-12345678 and i-12345678abcdef01
-	if awsID == "" || !(awsInstanceRegMatch.MatchString(awsID) || isFargateNode(awsID)) {
+	if awsID == "" || !(awsInstanceRegMatch.MatchString(awsID) || IsFargateNode(awsID)) {
 		return "", fmt.Errorf("Invalid format for AWS instance (%s)", name)
 	}
 

--- a/pkg/providers/v1/tags.go
+++ b/pkg/providers/v1/tags.go
@@ -310,3 +310,56 @@ func (t *awsTagging) buildTags(lifecycle ResourceLifecycle, additionalTags map[s
 func (t *awsTagging) clusterID() string {
 	return t.ClusterID
 }
+
+// TagResource calls EC2 and tag the resource associated to resourceID
+// with the supplied tags
+func (c *Cloud) TagResource(resourceID string, tags map[string]string) error {
+	request := &ec2.CreateTagsInput{
+		Resources: []*string{aws.String(resourceID)},
+		Tags:      buildAwsTags(tags),
+	}
+
+	output, err := c.ec2.CreateTags(request)
+
+	if err != nil {
+		klog.Errorf("Error occurred trying to tag resources, %v", err)
+		return err
+	}
+
+	klog.Infof("Done calling create-tags to EC2: %v", output)
+
+	return nil
+}
+
+// UntagResource calls EC2 and tag the resource associated to resourceID
+// with the supplied tags
+func (c *Cloud) UntagResource(resourceID string, tags map[string]string) error {
+	request := &ec2.DeleteTagsInput{
+		Resources: []*string{aws.String(resourceID)},
+		Tags:      buildAwsTags(tags),
+	}
+
+	output, err := c.ec2.DeleteTags(request)
+
+	if err != nil {
+		klog.Errorf("Error occurred trying to untag resources, %v", err)
+		return err
+	}
+
+	klog.Infof("Done calling delete-tags to EC2: %v", output)
+
+	return nil
+}
+
+func buildAwsTags(tags map[string]string) []*ec2.Tag {
+	var awsTags []*ec2.Tag
+	for k, v := range tags {
+		newTag := &ec2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+		awsTags = append(awsTags, newTag)
+	}
+
+	return awsTags
+}


### PR DESCRIPTION
Cherry pick of #308 #334 #387 on release-1.23.

#308: Add tagging controller configuration
#334: Stop retrying failed workitem after a certain amount of
#387: Fix issues in tagging controller

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```