### PR TITLE
Fetch all history when tagging releases

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - run: /usr/bin/git config --global user.email actions@github.com
       - run: /usr/bin/git config --global user.name 'GitHub Actions Release Tagger'
       - run: hack/tag-release.sh


### PR DESCRIPTION
To be able to check if a tag already exists, all history has to be pulled during checkout:
https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches

Without this, the job will fail when the tag already exists:
https://github.com/kubernetes/cloud-provider-aws/runs/6636986249?check_suite_focus=true

Ref: #388 

/cc @olemarkus @nckturner 