### PR TITLE
Add make targets for building with ko

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.18.3-bullseye.0

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-.EXPORT_ALL_VARIABLES:
 
 SHELL := /bin/bash
 GOOS ?= $(shell go env GOOS)
@@ -21,7 +20,8 @@ GOARCH ?= $(shell go env GOARCH)
 GOPROXY ?= $(shell go env GOPROXY)
 GIT_VERSION := $(shell git describe --dirty --tags --match='v*')
 VERSION ?= $(GIT_VERSION)
-IMAGE ?= amazon/cloud-controller-manager:$(VERSION)
+IMAGE_REPOSITORY ?= amazon/cloud-controller-manager
+IMAGE ?= $(IMAGE_REPOSITORY):$(VERSION)
 OUTPUT ?= $(shell pwd)/_output
 INSTALL_PATH ?= $(OUTPUT)/bin
 LDFLAGS ?= -w -s -X k8s.io/component-base/version.gitVersion=$(VERSION)
@@ -69,7 +69,7 @@ docker-build-arm64:
 .PHONY: docker-build
 docker-build:
 	docker buildx build --output=type=registry \
-		--build-arg LDFLAGS=$(LDFLAGS) \
+		--build-arg LDFLAGS="$(LDFLAGS)" \
 		--build-arg GOPROXY=$(GOPROXY) \
 		--platform linux/amd64,linux/arm64 \
 		--tag $(IMAGE) .

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,14 @@ docker-build:
 		--platform linux/amd64,linux/arm64 \
 		--tag $(IMAGE) .
 
+.PHONY: ko
+ko:
+	hack/install-ko.sh
+
+.PHONY: ko-build
+ko-build: ko
+	KO_DOCKER_REPO="$(IMAGE_REPOSITORY)" GOFLAGS="-ldflags=-X=k8s.io/component-base/version.gitVersion=$(VERSION)" ko build --tags ${VERSION}  --platform=linux/amd64,linux/arm64 --bare ./cmd/aws-cloud-controller-manager/
+
 .PHONY: e2e.test
 e2e.test:
 	pushd tests/e2e > /dev/null && \

--- a/hack/install-ko.sh
+++ b/hack/install-ko.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if ! command -v ko &> /dev/null; then
+  go install github.com/google/ko@v0.11.2
+fi
+


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The dockerx build is somewhat slow and downloads deps on every change. `ko` provides faster build and is somewhat simpler to set up and configure. We've been using ko for all image builds in kOps for some time now.

The PR also does some small fixes to the make file. Most notably, variables are not exported anymore as that broke `ko`. But we are passing in all the envs needed for the various targets anyway.

```release-note
NONE
```
