### PR TITLE
Add rate limiting support for Tagging Controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	gopkg.in/gcfg.v1 v1.2.0
 	gopkg.in/warnings.v0 v0.1.1 // indirect
 	k8s.io/api v0.20.15

--- a/pkg/controllers/tagging/tagging_controller_test.go
+++ b/pkg/controllers/tagging/tagging_controller_test.go
@@ -40,6 +40,7 @@ func Test_NodesJoiningAndLeaving(t *testing.T) {
 		currNode         *v1.Node
 		toBeTagged       bool
 		expectedMessages []string
+		rateLimited      bool
 	}{
 		{
 			name: "node0 joins the cluster, but fail to tag.",
@@ -67,7 +68,22 @@ func Test_NodesJoiningAndLeaving(t *testing.T) {
 				},
 			},
 			toBeTagged:       true,
-			expectedMessages: []string{"Successfully tagged i-0001"},
+			expectedMessages: []string{"Successfully tagged i-0001", "to the workqueue (without any rate-limit)"},
+		},
+		{
+			name: "node0 joins the cluster (rate-limited).",
+			currNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "i-0001",
+				},
+			},
+			toBeTagged:       true,
+			expectedMessages: []string{"Successfully tagged i-0001", "to the workqueue (rate-limited)"},
+			rateLimited:      true,
 		},
 		{
 			name: "node0 joins the cluster and was tagged earlier with different tags.",
@@ -175,12 +191,18 @@ func Test_NodesJoiningAndLeaving(t *testing.T) {
 				tags:              map[string]string{"key2": "value2", "key1": "value1"},
 				resources:         []string{"instance"},
 				workqueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Tagging"),
+				rateLimitEnabled:  testcase.rateLimited,
 			}
 
 			if testcase.toBeTagged {
 				tc.enqueueNode(testcase.currNode, tc.tagNodesResources)
 			} else {
 				tc.enqueueNode(testcase.currNode, tc.untagNodeResources)
+			}
+
+			if tc.rateLimitEnabled {
+				// If rate limit is enabled, sleep for 10 ms to wait for the item to be added to the queue since the base delay is 5 ms.
+				time.Sleep(10 * time.Millisecond)
 			}
 
 			for tc.workqueue.Len() > 0 {

--- a/pkg/controllers/tagging/tagging_controller_wrapper.go
+++ b/pkg/controllers/tagging/tagging_controller_wrapper.go
@@ -45,7 +45,9 @@ func (tc *ControllerWrapper) startTaggingController(ctx genericcontrollermanager
 		cloud,
 		completedConfig.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
 		tc.Options.Tags,
-		tc.Options.Resources)
+		tc.Options.Resources,
+		tc.Options.RateLimit,
+		tc.Options.BurstLimit)
 
 	if err != nil {
 		klog.Warningf("failed to start tagging controller: %s", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:

/kind feature

**What this PR does / why we need it**: Adds rate limiting support for Tagging Controller. This helps in controlling the rate at which the controller processes items and hence control the rate at which it makes calls to services like EC2.

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: N/A

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Adds rate limiting support for Tagging Controller. This helps in controlling the rate at which the controller processes items and hence control the rate at which it makes calls to services like EC2.
```
