### PR TITLE
Add rate limiting support for Tagging Controller

### DIFF
--- a/pkg/controllers/tagging/tagging_controller_wrapper.go
+++ b/pkg/controllers/tagging/tagging_controller_wrapper.go
@@ -46,7 +46,9 @@ func (tc *ControllerWrapper) startTaggingController(ctx context.Context, initCon
 		cloud,
 		completedConfig.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
 		tc.Options.Tags,
-		tc.Options.Resources)
+		tc.Options.Resources,
+		tc.Options.RateLimit,
+		tc.Options.BurstLimit)
 
 	if err != nil {
 		klog.Warningf("failed to start tagging controller: %s", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:

/kind feature

**What this PR does / why we need it**: Adds rate limiting support for Tagging Controller. This helps in controlling the rate at which the controller processes items and hence control the rate at which it makes calls to services like EC2.

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: N/A

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Adds rate limiting support for Tagging Controller. This helps in controlling the rate at which the controller processes items and hence control the rate at which it makes calls to services like EC2.
```
