### PR TITLE
Automated cherry pick of #313: add sts regional endpoint logic

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1208,12 +1208,18 @@ func init() {
 			return nil, fmt.Errorf("unable to validate custom endpoint overrides: %v", err)
 		}
 
-		regionName, err := getRegionFromMetadata(cfg)
+		metadata, err := newAWSSDKProvider(nil, cfg).Metadata()
+		if err != nil {
+			return nil, fmt.Errorf("error creating AWS metadata client: %q", err)
+		}
+
+		regiondetails, err := getRegionFromMetadata(*cfg, metadata)
 		if err != nil {
 			return nil, err
 		}
+
 		sess, err := session.NewSessionWithOptions(session.Options{
-			Config:            *aws.NewConfig().WithRegion(regionName).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint),
+			Config:            *aws.NewConfig().WithRegion(regiondetails.regionName).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint),
 			SharedConfigState: session.SharedConfigEnable,
 		})
 		if err != nil {
@@ -1305,19 +1311,9 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 		return nil, fmt.Errorf("error creating AWS metadata client: %q", err)
 	}
 
-	err = updateConfigZone(&cfg, metadata)
-	if err != nil {
-		return nil, fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
-	}
-
-	zone := cfg.Global.Zone
-	if len(zone) <= 1 {
-		return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
-	}
-	regionName, err := azToRegion(zone)
-	if err != nil {
-		return nil, err
-	}
+	regiondetails, err := getRegionFromMetadata(cfg, metadata)
+	regionName := regiondetails.regionName
+	zone := regiondetails.zone
 
 	if !cfg.Global.DisableStrictZoneCheck {
 		if !isRegionValid(regionName, metadata) {
@@ -5209,27 +5205,33 @@ func (c *Cloud) describeNetworkInterfaces(nodeName string) (*ec2.NetworkInterfac
 	return eni.NetworkInterfaces[0], nil
 }
 
-func getRegionFromMetadata(cfg *CloudConfig) (string, error) {
-	klog.Infof("Get AWS region from metadata client")
-	metadata, err := newAWSSDKProvider(nil, cfg).Metadata()
-	if err != nil {
-		return "", fmt.Errorf("error creating AWS metadata client: %q", err)
-	}
+type regionDetails struct {
+	regionName string
+	zone       string
+}
 
-	err = updateConfigZone(cfg, metadata)
+func getRegionFromMetadata(cfg CloudConfig, metadata EC2Metadata) (*regionDetails, error) {
+	klog.Infof("Get AWS region from metadata client")
+	err := updateConfigZone(&cfg, metadata)
 	if err != nil {
-		return "", fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
+		return nil, fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
 	}
 
 	zone := cfg.Global.Zone
 	if len(zone) <= 1 {
-		return "", fmt.Errorf("invalid AWS zone in config file: %s", zone)
+		return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
 	}
 
 	regionName, err := azToRegion(zone)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return regionName, nil
+	regiondetails := &regionDetails{
+		regionName: regionName,
+		zone:       zone,
+	}
+
+	return regiondetails, nil
 }
+

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1208,8 +1208,12 @@ func init() {
 			return nil, fmt.Errorf("unable to validate custom endpoint overrides: %v", err)
 		}
 
+		regionName, err := getRegionFromMetadata(cfg)
+		if err != nil {
+			return nil, err
+		}
 		sess, err := session.NewSessionWithOptions(session.Options{
-			Config:            aws.Config{},
+			Config:            *aws.NewConfig().WithRegion(regionName).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint),
 			SharedConfigState: session.SharedConfigEnable,
 		})
 		if err != nil {
@@ -5203,4 +5207,29 @@ func (c *Cloud) describeNetworkInterfaces(nodeName string) (*ec2.NetworkInterfac
 		return nil, fmt.Errorf("multiple interfaces found with same id %q", eni.NetworkInterfaces)
 	}
 	return eni.NetworkInterfaces[0], nil
+}
+
+func getRegionFromMetadata(cfg *CloudConfig) (string, error) {
+	klog.Infof("Get AWS region from metadata client")
+	metadata, err := newAWSSDKProvider(nil, cfg).Metadata()
+	if err != nil {
+		return "", fmt.Errorf("error creating AWS metadata client: %q", err)
+	}
+
+	err = updateConfigZone(cfg, metadata)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
+	}
+
+	zone := cfg.Global.Zone
+	if len(zone) <= 1 {
+		return "", fmt.Errorf("invalid AWS zone in config file: %s", zone)
+	}
+
+	regionName, err := azToRegion(zone)
+	if err != nil {
+		return "", err
+	}
+
+	return regionName, nil
 }

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1213,13 +1213,13 @@ func init() {
 			return nil, fmt.Errorf("error creating AWS metadata client: %q", err)
 		}
 
-		regiondetails, err := getRegionFromMetadata(*cfg, metadata)
+		regionName, _, err := getRegionFromMetadata(*cfg, metadata)
 		if err != nil {
 			return nil, err
 		}
 
 		sess, err := session.NewSessionWithOptions(session.Options{
-			Config:            *aws.NewConfig().WithRegion(regiondetails.regionName).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint),
+			Config:            *aws.NewConfig().WithRegion(regionName).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint),
 			SharedConfigState: session.SharedConfigEnable,
 		})
 		if err != nil {
@@ -1311,9 +1311,7 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 		return nil, fmt.Errorf("error creating AWS metadata client: %q", err)
 	}
 
-	regiondetails, err := getRegionFromMetadata(cfg, metadata)
-	regionName := regiondetails.regionName
-	zone := regiondetails.zone
+	regionName, zone, err := getRegionFromMetadata(cfg, metadata)
 
 	if !cfg.Global.DisableStrictZoneCheck {
 		if !isRegionValid(regionName, metadata) {
@@ -5205,33 +5203,22 @@ func (c *Cloud) describeNetworkInterfaces(nodeName string) (*ec2.NetworkInterfac
 	return eni.NetworkInterfaces[0], nil
 }
 
-type regionDetails struct {
-	regionName string
-	zone       string
-}
-
-func getRegionFromMetadata(cfg CloudConfig, metadata EC2Metadata) (*regionDetails, error) {
+func getRegionFromMetadata(cfg CloudConfig, metadata EC2Metadata) (string, string, error) {
 	klog.Infof("Get AWS region from metadata client")
 	err := updateConfigZone(&cfg, metadata)
 	if err != nil {
-		return nil, fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
+		return "", "", fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
 	}
 
 	zone := cfg.Global.Zone
 	if len(zone) <= 1 {
-		return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
+		return "", "", fmt.Errorf("invalid AWS zone in config file: %s", zone)
 	}
 
 	regionName, err := azToRegion(zone)
 	if err != nil {
-		return nil, err
+		return "", "", err
 	}
 
-	regiondetails := &regionDetails{
-		regionName: regionName,
-		zone:       zone,
-	}
-
-	return regiondetails, nil
+	return regionName, zone, nil
 }
-

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1312,6 +1312,9 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 	}
 
 	regionName, zone, err := getRegionFromMetadata(cfg, metadata)
+	if err != nil {
+		return nil, err
+	}
 
 	if !cfg.Global.DisableStrictZoneCheck {
 		if !isRegionValid(regionName, metadata) {


### PR DESCRIPTION
Cherry pick of #313 on release-1.21.

#313: add sts regional endpoint logic

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```