### PR TITLE
chore: add k8s 1.24+ taints

### DIFF
--- a/charts/aws-cloud-controller-manager/Chart.yaml
+++ b/charts/aws-cloud-controller-manager/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: aws-cloud-controller-manager
 description: Installs Cloud Controller Manager for AWS Cloud Provider
-version: 0.0.6
+version: 0.0.7
 appVersion: v1.23.0-alpha.0
 maintainers:
 - name: Nick Turner

--- a/charts/aws-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/aws-cloud-controller-manager/templates/daemonset.yaml
@@ -20,7 +20,16 @@ spec:
         k8s-app:  {{ template "cloud-controller-manager.name" . }}
     spec:
       tolerations: {{ toYaml ( .Values.tolerations | default .Values.tolerations ) | nindent 8 }}
-      nodeSelector: {{ toYaml ( .Values.nodeSelector | default .Values.nodeSelector ) | nindent 8 }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
+              - matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
       priorityClassName: system-node-critical
       serviceAccountName: {{.Values.serviceAccountName}}
       {{- if .Values.hostNetworking }}

--- a/charts/aws-cloud-controller-manager/values.yaml
+++ b/charts/aws-cloud-controller-manager/values.yaml
@@ -11,10 +11,6 @@ image:
 # nameOverride overrides `cloud-controller-manager.fullname`
 nameOverride: "aws-cloud-controller-manager"
 
-# nodeSelector -- Node labels for pod assignment. Ref: https://kubernetes.io/docs/user-guide/node-selection/.
-nodeSelector:
-  node-role.kubernetes.io/master: ""
-
 clusterRoleRules:
 - apiGroups:
   - ""
@@ -106,11 +102,13 @@ resources:
   #   memory: 300Mi
 
 # env -- Pod environment variables
-env: {}
+env: []
 # securityContext -- Container Security Context.
 securityContext: {}
 # podSecurityContext -- Pods Security Context.
 podSecurityContext: {}
+
+hostNetworking: true
 
 # tolerations -- List of node taints to tolerate (requires Kubernetes >= 1.6).
 tolerations:
@@ -118,6 +116,8 @@ tolerations:
   value: "true"
   effect: NoSchedule
 - key: node-role.kubernetes.io/master
+  effect: NoSchedule
+- key: node-role.kubernetes.io/control-plane
   effect: NoSchedule
 
 clusterRoleName : system:cloud-controller-manager

--- a/examples/existing-cluster/base/aws-cloud-controller-manager-daemonset.yaml
+++ b/examples/existing-cluster/base/aws-cloud-controller-manager-daemonset.yaml
@@ -17,13 +17,23 @@ spec:
       labels:
         k8s-app: aws-cloud-controller-manager
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
+              - matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
         effect: NoSchedule
       - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       serviceAccountName: cloud-controller-manager
       containers:


### PR DESCRIPTION
Add new `node-role.kubernetes.io/control-plane` taints so that the
cloud controller tolerates them.

Signed-off-by: Noel Georgi <git@frezbo.dev>

Fixes: #430 