### PR TITLE
Skip health rule creation when it is a subset of the client rule

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -173,7 +173,9 @@ const ServiceAnnotationLoadBalancerSSLNegotiationPolicy = "service.beta.kubernet
 // ServiceAnnotationLoadBalancerBEProtocol is the annotation used on the service
 // to specify the protocol spoken by the backend (pod) behind a listener.
 // If `http` (default) or `https`, an HTTPS listener that terminates the
-//  connection and parses headers is created.
+//
+//	connection and parses headers is created.
+//
 // If set to `ssl` or `tcp`, a "raw" SSL listener is used.
 // If set to `http` and `aws-load-balancer-ssl-cert` is not used then
 // a HTTP listener is used.
@@ -236,9 +238,9 @@ const ServiceAnnotationLoadBalancerTargetNodeLabels = "service.beta.kubernetes.i
 // subnetID or subnetName from different AZs
 // By default, the controller will auto-discover the subnets. If there are multiple subnets per AZ, auto-discovery
 // will break the tie in the following order -
-//   1. prefer the subnet with the correct role tag. kubernetes.io/role/elb for public and kubernetes.io/role/internal-elb for private access
-//   2. prefer the subnet with the cluster tag kubernetes.io/cluster/<Cluster Name>
-//   3. prefer the subnet that is first in lexicographic order
+//  1. prefer the subnet with the correct role tag. kubernetes.io/role/elb for public and kubernetes.io/role/internal-elb for private access
+//  2. prefer the subnet with the cluster tag kubernetes.io/cluster/<Cluster Name>
+//  3. prefer the subnet that is first in lexicographic order
 const ServiceAnnotationLoadBalancerSubnets = "service.beta.kubernetes.io/aws-load-balancer-subnets"
 
 // Event key when a volume is stuck on attaching state when being attached to a volume
@@ -3806,8 +3808,8 @@ func (c *Cloud) buildELBSecurityGroupList(serviceName types.NamespacedName, load
 
 // sortELBSecurityGroupList returns a list of sorted securityGroupIDs based on the original order
 // from buildELBSecurityGroupList. The logic is:
-//  * securityGroups specified by ServiceAnnotationLoadBalancerSecurityGroups appears first in order
-//  * securityGroups specified by ServiceAnnotationLoadBalancerExtraSecurityGroups appears last in order
+//   - securityGroups specified by ServiceAnnotationLoadBalancerSecurityGroups appears first in order
+//   - securityGroups specified by ServiceAnnotationLoadBalancerExtraSecurityGroups appears last in order
 func (c *Cloud) sortELBSecurityGroupList(securityGroupIDs []string, annotations map[string]string) {
 	annotatedSGList := getSGListFromAnnotation(annotations[ServiceAnnotationLoadBalancerSecurityGroups])
 	annotatedExtraSGList := getSGListFromAnnotation(annotations[ServiceAnnotationLoadBalancerExtraSecurityGroups])

--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -1238,7 +1238,8 @@ func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBala
 
 // syncElbListeners computes a plan to reconcile the desired vs actual state of the listeners on an ELB
 // NOTE: there exists an O(nlgn) implementation for this function. However, as the default limit of
-//       listeners per elb is 100, this implementation is reduced from O(m*n) => O(n).
+//
+//	listeners per elb is 100, this implementation is reduced from O(m*n) => O(n).
 func syncElbListeners(loadBalancerName string, listeners []*elb.Listener, listenerDescriptions []*elb.ListenerDescription) ([]*elb.Listener, []*int64) {
 	foundSet := make(map[int]bool)
 	removals := []*int64{}

--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -834,8 +834,12 @@ func (c *Cloud) updateInstanceSecurityGroupsForNLB(lbName string, instances map[
 		for sgID, sg := range clusterSGs {
 			sgPerms := NewIPPermissionSet(sg.IpPermissions...).Ungroup()
 			if desiredSGIDs.Has(sgID) {
-				if err := c.updateInstanceSecurityGroupForNLBTraffic(sgID, sgPerms, healthRuleAnnotation, "tcp", healthCheckPorts, subnetCIDRs); err != nil {
-					return err
+				// If the client rule is 1) all addresses 2) tcp and 3) has same ports as the healthcheck,
+				// then the health rules are a subset of the client rule and are not needed.
+				if len(clientCIDRs) != 1 || clientCIDRs[0] != "0.0.0.0/0" || clientProtocol != "tcp" || !healthCheckPorts.Equal(clientPorts) {
+					if err := c.updateInstanceSecurityGroupForNLBTraffic(sgID, sgPerms, healthRuleAnnotation, "tcp", healthCheckPorts, subnetCIDRs); err != nil {
+						return err
+					}
 				}
 				if err := c.updateInstanceSecurityGroupForNLBTraffic(sgID, sgPerms, clientRuleAnnotation, clientProtocol, clientPorts, clientCIDRs); err != nil {
 					return err

--- a/pkg/providers/v1/instances.go
+++ b/pkg/providers/v1/instances.go
@@ -46,10 +46,10 @@ func (i InstanceID) awsString() *string {
 
 // KubernetesInstanceID represents the id for an instance in the kubernetes API;
 // the following form
-//  * aws:///<zone>/<awsInstanceId>
-//  * aws:////<awsInstanceId>
-//  * aws:///<zone>/fargate-<eni-ip-address>
-//  * <awsInstanceId>
+//   - aws:///<zone>/<awsInstanceId>
+//   - aws:////<awsInstanceId>
+//   - aws:///<zone>/fargate-<eni-ip-address>
+//   - <awsInstanceId>
 type KubernetesInstanceID string
 
 // MapToAWSInstanceID extracts the InstanceID from the KubernetesInstanceID

--- a/pkg/providers/v1/volumes.go
+++ b/pkg/providers/v1/volumes.go
@@ -40,9 +40,9 @@ func (i EBSVolumeID) awsString() *string {
 
 // KubernetesVolumeID represents the id for a volume in the kubernetes API;
 // a few forms are recognized:
-//  * aws://<zone>/<awsVolumeId>
-//  * aws:///<awsVolumeId>
-//  * <awsVolumeId>
+//   - aws://<zone>/<awsVolumeId>
+//   - aws:///<awsVolumeId>
+//   - <awsVolumeId>
 type KubernetesVolumeID string
 
 // DiskInfo returns aws disk information in easy to use manner

--- a/pkg/providers/v2/instances.go
+++ b/pkg/providers/v2/instances.go
@@ -233,7 +233,7 @@ func nodeAddressesForInstance(instance *ec2.Instance) ([]v1.NodeAddress, error) 
 
 // getInstanceProviderID returns the provider ID of an instance which is ultimately set in the node.Spec.ProviderID field.
 // The well-known format for a node's providerID is:
-//    * aws:///<availability-zone>/<instance-id>
+//   - aws:///<availability-zone>/<instance-id>
 func getInstanceProviderID(instance *ec2.Instance) (string, error) {
 	if aws.StringValue(instance.Placement.AvailabilityZone) == "" {
 		return "", errors.New("instance availability zone was not set")
@@ -247,9 +247,10 @@ func getInstanceProviderID(instance *ec2.Instance) (string, error) {
 }
 
 // parseInstanceIDFromProviderID parses the node's instance ID based on the following formats:
-//   * aws://<availability-zone>/<instance-id>
-//   * aws:///<instance-id>
-//   * <instance-id>
+//   - aws://<availability-zone>/<instance-id>
+//   - aws:///<instance-id>
+//   - <instance-id>
+//
 // This function always assumes a valid providerID format was provided.
 func parseInstanceIDFromProviderID(providerID string) (string, error) {
 	// trim the provider name prefix 'aws://', renaming providerID should contain metadata in one of the following formats:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently, if a Service of type LoadBalancer is created, and `Spec.LoadBalancerSourceRanges` is not specified, the AWS cloud-provider creates one rule for the client with a source of all addresses (0.0.0.0/0).  It also create a rule per-zone for the health check.  In many cases, these health rules are subsets of the client rule with more specific CIDR blocks.

AWS Quota on `Inbound or outbound rules per security group` is defaulted to 60 with a hard max of 200 (security groups per network interface * inbound or outbound rules per security group <= 1000).

Thus, a Service of type LoadBalancer on a cluster with nodes in 3 zones will result in 4 rules being added to the security group.  This means that, for such a cluster with the default quota, a maximum of 15 LBs can be created.

https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html#network-load-balancer

> For each NLB that you create Amazon EKS adds one inbound rule to the node's security group for client traffic and one rule for each load balancer subnet in the VPC for health checks. Deployment of a service of type LoadBalancer can fail if Amazon EKS attempts to create rules that exceed the quota for the maximum number of rules allowed for a security group.

The over quota condition manifests as a `RulesPerSecurityGroupLimitExceeded` error on the CCM or KCM (legacy).

This PR skips the health rules if they are a subset of the client rule.  This quadruples the number of typical Services of type LoadBalancer (i.e. Services without `Spec.LoadBalancerSourceRanges` specified) that will fit in a 3-zone cluster for a given quota. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Second commit is just gofmt update since the job uses go1.19 now
https://go.dev/doc/go1.19#go-doc

**Does this PR introduce a user-facing change?**:
Reduced number of rules in node security groups

```release-note
Skip creation of health check rules when they are a subset of the client rule
```
