### PR TITLE
Revert "Ensure kops cluster is always torn down after e2e run"

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -121,14 +121,7 @@ aws ecr get-login-password --region "${REGION}" | docker login --username AWS --
 docker tag "${BUILD_IMAGE}" "${IMAGE_NAME}:${IMAGE_TAG}"
 docker push "${IMAGE_NAME}:${IMAGE_TAG}"
 
-function kops-finish {
-    "${test_run}"/kops delete cluster --name "${CLUSTER_NAME}" --yes
-}
-
 if [[ "${UP}" = "yes" ]]; then
-
-    trap kops-finish EXIT
-
     kubetest2 kops \
       -v 2 \
       --up \
@@ -151,3 +144,7 @@ fi
 pushd ./tests/e2e
 ginkgo . -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINKGO_SKIP}" "" -- -kubeconfig="${KUBECONFIG}" -report-dir="${test_run}" -gce-zone="${ZONES%,*}" "${EXPANDED_TEST_EXTRA_FLAGS}"
 popd
+
+if [[ "${DOWN}" = "yes" ]]; then
+    ${test_run}/kops delete cluster --name "${CLUSTER_NAME}" --yes
+fi


### PR DESCRIPTION
This reverts commit 0b078ce702846fb1c9357496dfea2f4f46c54188.

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>

/kind failing-test


**What this PR does / why we need it**:

Temporarily revert the trap EXIT/kops cleanup function, which is failing in the prow environment.  We do need to figure out our cleanup story but this is blocking PRs.


**Which issue(s) this PR fixes**:
Fixes #445

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
