### PR TITLE
Automated cherry pick of #451: Test e2e

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -153,5 +153,6 @@ ginkgo . -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINK
 popd
 
 if [[ "${DOWN}" = "yes" ]]; then
+    echo "cleaning up kops"
     ${test_run}/kops delete cluster --name "${CLUSTER_NAME}" --yes
 fi

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -153,6 +153,6 @@ ginkgo . -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINK
 popd
 
 if [[ "${DOWN}" = "yes" ]]; then
-    echo "cleaning up kops"
-    ${test_run}/kops delete cluster --name "${CLUSTER_NAME}" --yes
+    # This should be changed to ${test_run}/kops once https://github.com/kubernetes/kops/pull/13217 is merged.
+    ${test_run}/${test_run_id}/kops delete cluster --name "${CLUSTER_NAME}" --yes
 fi


### PR DESCRIPTION
Cherry pick of #451 on release-1.21.

#451: Test e2e

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```