### PR TITLE
Automated cherry pick of #448: Handle InvalidInstanceID.NotFound when tagging resources

### DIFF
--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -272,6 +273,10 @@ func (ec2i *FakeEC2Impl) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTags
 		if *id == "i-error" {
 			return nil, errors.New("Unable to tag")
 		}
+
+		if *id == "i-not-found" {
+			return nil, awserr.New("InvalidInstanceID.NotFound", "Instance not found", nil)
+		}
 	}
 	return &ec2.CreateTagsOutput{}, nil
 }
@@ -281,6 +286,10 @@ func (ec2i *FakeEC2Impl) DeleteTags(input *ec2.DeleteTagsInput) (*ec2.DeleteTags
 	for _, id := range input.Resources {
 		if *id == "i-error" {
 			return nil, errors.New("Unable to remove tag")
+		}
+
+		if *id == "i-not-found" {
+			return nil, awserr.New("InvalidInstanceID.NotFound", "Instance not found", nil)
 		}
 	}
 	return &ec2.DeleteTagsOutput{}, nil

--- a/pkg/providers/v1/tags.go
+++ b/pkg/providers/v1/tags.go
@@ -316,6 +316,10 @@ func (c *Cloud) TagResource(resourceID string, tags map[string]string) error {
 	output, err := c.ec2.CreateTags(request)
 
 	if err != nil {
+		if isAWSErrorInstanceNotFound(err) {
+			klog.Infof("Couldn't find resource when trying to tag it hence skipping it, %v", err)
+			return nil
+		}
 		klog.Errorf("Error occurred trying to tag resources, %v", err)
 		return err
 	}
@@ -336,6 +340,10 @@ func (c *Cloud) UntagResource(resourceID string, tags map[string]string) error {
 	output, err := c.ec2.DeleteTags(request)
 
 	if err != nil {
+		if isAWSErrorInstanceNotFound(err) {
+			klog.Infof("Couldn't find resource when trying to untag it hence skipping it, %v", err)
+			return nil
+		}
 		klog.Errorf("Error occurred trying to untag resources, %v", err)
 		return err
 	}


### PR DESCRIPTION
Cherry pick of #448 on release-1.20.

#448: Handle InvalidInstanceID.NotFound when tagging resources

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```