### PR TITLE
Automated cherry pick of #448: Handle InvalidInstanceID.NotFound when tagging resources

### DIFF
--- a/pkg/controllers/options/tagging_controller.go
+++ b/pkg/controllers/options/tagging_controller.go
@@ -37,6 +37,13 @@ func (o *TaggingControllerOptions) Validate() error {
 		return fmt.Errorf("--tags must not be empty and must be a form of key=value")
 	}
 
+	for key := range o.Tags {
+		// We label the nodes with the tag keys for a cache-hit check so restrict tag keys to 63 characters.
+		if len(key) > 63 {
+			return fmt.Errorf("Tag keys must not be more than 63 characters long")
+		}
+	}
+
 	if len(o.Resources) == 0 {
 		return fmt.Errorf("--resources must not be empty")
 	}

--- a/pkg/controllers/tagging/metrics.go
+++ b/pkg/controllers/tagging/metrics.go
@@ -27,6 +27,7 @@ var (
 			Name:           "cloudprovider_aws_tagging_controller_work_item_duration_seconds",
 			Help:           "workitem latency of workitem being in the queue and time it takes to process",
 			StabilityLevel: metrics.ALPHA,
+			Buckets:        metrics.ExponentialBuckets(0.5, 1.5, 20),
 		},
 		[]string{"latency_type"})
 

--- a/pkg/controllers/tagging/tagging_controller.go
+++ b/pkg/controllers/tagging/tagging_controller.go
@@ -25,7 +25,9 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	opt "k8s.io/cloud-provider-aws/pkg/controllers/options"
 	awsv1 "k8s.io/cloud-provider-aws/pkg/providers/v1"
+	nodehelpers "k8s.io/cloud-provider/node/helpers"
 	"k8s.io/klog/v2"
+	"strings"
 	"time"
 )
 
@@ -35,6 +37,10 @@ type workItem struct {
 	action         func(node *v1.Node) error
 	requeuingCount int
 	enqueueTime    time.Time
+}
+
+func (w workItem) String() string {
+	return fmt.Sprintf("[Node: %s, RequeuingCount: %d, EnqueueTime: %s]", w.node.GetName(), w.requeuingCount, w.enqueueTime)
 }
 
 const (
@@ -105,9 +111,29 @@ func NewTaggingController(
 	// Use shared informer to listen to add/update/delete of nodes. Note that any nodes
 	// that exist before tagging controller starts will show up in the update method
 	tc.nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { tc.enqueueNode(obj, tc.tagNodesResources) },
-		UpdateFunc: func(oldObj, newObj interface{}) { tc.enqueueNode(newObj, tc.tagNodesResources) },
-		DeleteFunc: func(obj interface{}) { tc.enqueueNode(obj, tc.untagNodeResources) },
+		AddFunc: func(obj interface{}) {
+			node := obj.(*v1.Node)
+			tc.enqueueNode(node, tc.tagNodesResources)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			node := newObj.(*v1.Node)
+			// We have a check for this when tagging instances too. The reason this check exists here is to make sure that
+			// we don't even put things in the work queue when we don't need to since a node goes through many updates when
+			// it joins the cluster.
+			// The check before tagging is to make sure that between when a node was put in the work queue and when it gets tagged,
+			// there might be another event which put the same item in the work queue (since the node won't have the labels yet)
+			// and hence this check before tagging prevents us from making an unnecessary EC2 call.
+			if !tc.isTaggingRequired(node) {
+				klog.Infof("Skip putting node %s in work queue since it was already tagged earlier.", node.GetName())
+				return
+			}
+
+			tc.enqueueNode(node, tc.tagNodesResources)
+		},
+		DeleteFunc: func(obj interface{}) {
+			node := obj.(*v1.Node)
+			tc.enqueueNode(node, tc.untagNodeResources)
+		},
 	})
 
 	return tc, nil
@@ -147,7 +173,7 @@ func (tc *Controller) process() bool {
 		return false
 	}
 
-	klog.Infof("Starting to process %v", obj)
+	klog.Infof("Starting to process %s", obj)
 
 	err := func(obj interface{}) error {
 		defer tc.workqueue.Done(obj)
@@ -155,18 +181,26 @@ func (tc *Controller) process() bool {
 		workItem, ok := obj.(*workItem)
 		if !ok {
 			tc.workqueue.Forget(obj)
-			err := fmt.Errorf("expected workItem in workqueue but got %#v", obj)
+			err := fmt.Errorf("expected workItem in workqueue but got %s", obj)
 			utilruntime.HandleError(err)
 			return nil
 		}
 
 		timeTaken := time.Since(workItem.enqueueTime).Seconds()
 		recordWorkItemLatencyMetrics(workItemDequeuingTimeWorkItemMetric, timeTaken)
+		klog.Infof("Dequeuing latency %s", timeTaken)
 
 		instanceID, err := awsv1.KubernetesInstanceID(workItem.node.Spec.ProviderID).MapToAWSInstanceID()
 		if err != nil {
 			err = fmt.Errorf("Error in getting instanceID for node %s, error: %v", workItem.node.GetName(), err)
 			utilruntime.HandleError(err)
+			return nil
+		}
+		klog.Infof("Instance ID of work item %s is %s", workItem, instanceID)
+
+		if awsv1.IsFargateNode(string(instanceID)) {
+			klog.Infof("Skip processing the node %s since it is a Fargate node", instanceID)
+			tc.workqueue.Forget(obj)
 			return nil
 		}
 
@@ -182,12 +216,13 @@ func (tc *Controller) process() bool {
 				return fmt.Errorf("error processing work item '%v': %s, requeuing count %d", workItem, err.Error(), workItem.requeuingCount)
 			}
 
-			klog.Errorf("error processing work item '%v': %s, requeuing count exceeded", workItem, err.Error())
+			klog.Errorf("error processing work item %s: %s, requeuing count exceeded", workItem, err.Error())
 			recordWorkItemErrorMetrics(errorsAfterRetriesExhaustedWorkItemErrorMetric, string(instanceID))
 		} else {
-			klog.Infof("Finished processing %v", workItem)
+			klog.Infof("Finished processing %s", workItem)
 			timeTaken = time.Since(workItem.enqueueTime).Seconds()
 			recordWorkItemLatencyMetrics(workItemProcessingTimeWorkItemMetric, timeTaken)
+			klog.Infof("Processing latency %s", timeTaken)
 		}
 
 		tc.workqueue.Forget(obj)
@@ -195,7 +230,7 @@ func (tc *Controller) process() bool {
 	}(obj)
 
 	if err != nil {
-		klog.Errorf("Error occurred while processing %v", obj)
+		klog.Errorf("Error occurred while processing %s", obj)
 		utilruntime.HandleError(err)
 	}
 
@@ -221,16 +256,28 @@ func (tc *Controller) tagNodesResources(node *v1.Node) error {
 // tagEc2Instances applies the provided tags to each EC2 instance in
 // the cluster.
 func (tc *Controller) tagEc2Instance(node *v1.Node) error {
+	if !tc.isTaggingRequired(node) {
+		klog.Infof("Skip tagging node %s since it was already tagged earlier.", node.GetName())
+		return nil
+	}
+
 	instanceID, _ := awsv1.KubernetesInstanceID(node.Spec.ProviderID).MapToAWSInstanceID()
 
 	err := tc.cloud.TagResource(string(instanceID), tc.tags)
 
 	if err != nil {
-		klog.Errorf("Error in tagging EC2 instance for node %s, error: %v", node.GetName(), err)
+		klog.Errorf("Error in tagging EC2 instance %s for node %s, error: %v", instanceID, node.GetName(), err)
 		return err
 	}
 
-	klog.Infof("Successfully tagged %s with %v", instanceID, tc.tags)
+	labels := convertTagsToLabels(tc.tags)
+	klog.Infof("Successfully tagged %s with %v. Labeling the nodes with equivalent labels now.", instanceID, tc.tags)
+	if !nodehelpers.AddOrUpdateLabelsOnNode(tc.kubeClient, labels, node) {
+		klog.Errorf("Couldn't apply labels %s to node %s.", labels, node.GetName())
+		return fmt.Errorf("couldn't apply labels %s to node %s", labels, node.GetName())
+	}
+
+	klog.Infof("Successfully labeled node %s with %v.", node.GetName(), labels)
 
 	return nil
 }
@@ -259,7 +306,7 @@ func (tc *Controller) untagEc2Instance(node *v1.Node) error {
 	err := tc.cloud.UntagResource(string(instanceID), tc.tags)
 
 	if err != nil {
-		klog.Errorf("Error in untagging EC2 instance for node %s, error: %v", node.GetName(), err)
+		klog.Errorf("Error in untagging EC2 instance %s for node %s, error: %v", instanceID, node.GetName(), err)
 		return err
 	}
 
@@ -270,8 +317,7 @@ func (tc *Controller) untagEc2Instance(node *v1.Node) error {
 
 // enqueueNode takes in the object and an
 // action for the object for a workitem and enqueue to the workqueue
-func (tc *Controller) enqueueNode(obj interface{}, action func(node *v1.Node) error) {
-	node := obj.(*v1.Node)
+func (tc *Controller) enqueueNode(node *v1.Node, action func(node *v1.Node) error) {
 	item := &workItem{
 		node:           node,
 		action:         action,
@@ -280,4 +326,32 @@ func (tc *Controller) enqueueNode(obj interface{}, action func(node *v1.Node) er
 	}
 	tc.workqueue.Add(item)
 	klog.Infof("Added %s to the workqueue", item)
+}
+
+func (tc *Controller) isTaggingRequired(node *v1.Node) bool {
+	labels := convertTagsToLabels(tc.tags)
+
+	if node.Labels != nil {
+		for key := range labels {
+			if _, ok := node.Labels[key]; !ok {
+				// If label key is missing in node, we tag and label the node.
+				return true
+			}
+		}
+	} else {
+		return true
+	}
+
+	return false
+}
+
+func convertTagsToLabels(tags map[string]string) map[string]string {
+	// Kubernetes label names can't contain ':' whereas it is very common in tags so convert that to '.' instead.
+	// Also, Kubernetes label keys and values shouldn't be more than 63 characters long so we ignore the values
+	// while labeling so that we can allow tag values to be longer than that.
+	labels := map[string]string{}
+	for key := range tags {
+		labels[strings.ReplaceAll(key, ":", ".")] = ""
+	}
+	return labels
 }

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1836,7 +1836,7 @@ func (c *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string
 		return nil, err
 	}
 
-	if isFargateNode(string(instanceID)) {
+	if IsFargateNode(string(instanceID)) {
 		eni, err := c.describeNetworkInterfaces(string(instanceID))
 		if eni == nil || err != nil {
 			return nil, err
@@ -1879,7 +1879,7 @@ func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID strin
 		return false, err
 	}
 
-	if isFargateNode(string(instanceID)) {
+	if IsFargateNode(string(instanceID)) {
 		eni, err := c.describeNetworkInterfaces(string(instanceID))
 		return eni != nil, err
 	}
@@ -1919,7 +1919,7 @@ func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID str
 		return false, err
 	}
 
-	if isFargateNode(string(instanceID)) {
+	if IsFargateNode(string(instanceID)) {
 		eni, err := c.describeNetworkInterfaces(string(instanceID))
 		return eni != nil, err
 	}
@@ -1980,7 +1980,7 @@ func (c *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string)
 		return "", err
 	}
 
-	if isFargateNode(string(instanceID)) {
+	if IsFargateNode(string(instanceID)) {
 		return "", nil
 	}
 
@@ -2089,7 +2089,7 @@ func (c *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (clo
 		return cloudprovider.Zone{}, err
 	}
 
-	if isFargateNode(string(instanceID)) {
+	if IsFargateNode(string(instanceID)) {
 		eni, err := c.describeNetworkInterfaces(string(instanceID))
 		if eni == nil || err != nil {
 			return cloudprovider.Zone{}, err
@@ -5248,8 +5248,8 @@ func (c *Cloud) getFullInstance(nodeName types.NodeName) (*awsInstance, *ec2.Ins
 	return awsInstance, instance, err
 }
 
-// isFargateNode returns true if given node runs on Fargate compute
-func isFargateNode(nodeName string) bool {
+// IsFargateNode returns true if given node runs on Fargate compute
+func IsFargateNode(nodeName string) bool {
 	return strings.HasPrefix(nodeName, fargateNodeNamePrefix)
 }
 

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -269,6 +270,10 @@ func (ec2i *FakeEC2Impl) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTags
 		if *id == "i-error" {
 			return nil, errors.New("Unable to tag")
 		}
+
+		if *id == "i-not-found" {
+			return nil, awserr.New("InvalidInstanceID.NotFound", "Instance not found", nil)
+		}
 	}
 	return &ec2.CreateTagsOutput{}, nil
 }
@@ -278,6 +283,10 @@ func (ec2i *FakeEC2Impl) DeleteTags(input *ec2.DeleteTagsInput) (*ec2.DeleteTags
 	for _, id := range input.Resources {
 		if *id == "i-error" {
 			return nil, errors.New("Unable to remove tag")
+		}
+
+		if *id == "i-not-found" {
+			return nil, awserr.New("InvalidInstanceID.NotFound", "Instance not found", nil)
 		}
 	}
 	return &ec2.DeleteTagsOutput{}, nil

--- a/pkg/providers/v1/instances.go
+++ b/pkg/providers/v1/instances.go
@@ -78,7 +78,7 @@ func (name KubernetesInstanceID) MapToAWSInstanceID() (InstanceID, error) {
 
 	// We sanity check the resulting volume; the two known formats are
 	// i-12345678 and i-12345678abcdef01
-	if awsID == "" || !(awsInstanceRegMatch.MatchString(awsID) || isFargateNode(awsID)) {
+	if awsID == "" || !(awsInstanceRegMatch.MatchString(awsID) || IsFargateNode(awsID)) {
 		return "", fmt.Errorf("Invalid format for AWS instance (%s)", name)
 	}
 

--- a/pkg/providers/v1/tags.go
+++ b/pkg/providers/v1/tags.go
@@ -322,6 +322,10 @@ func (c *Cloud) TagResource(resourceID string, tags map[string]string) error {
 	output, err := c.ec2.CreateTags(request)
 
 	if err != nil {
+		if isAWSErrorInstanceNotFound(err) {
+			klog.Infof("Couldn't find resource when trying to tag it hence skipping it, %v", err)
+			return nil
+		}
 		klog.Errorf("Error occurred trying to tag resources, %v", err)
 		return err
 	}
@@ -342,6 +346,10 @@ func (c *Cloud) UntagResource(resourceID string, tags map[string]string) error {
 	output, err := c.ec2.DeleteTags(request)
 
 	if err != nil {
+		if isAWSErrorInstanceNotFound(err) {
+			klog.Infof("Couldn't find resource when trying to untag it hence skipping it, %v", err)
+			return nil
+		}
 		klog.Errorf("Error occurred trying to untag resources, %v", err)
 		return err
 	}

--- a/pkg/providers/v1/tags_test.go
+++ b/pkg/providers/v1/tags_test.go
@@ -17,11 +17,16 @@ limitations under the License.
 package aws
 
 import (
+	"bytes"
+	"errors"
+	"flag"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
 )
 
 func TestFilterTags(t *testing.T) {
@@ -227,6 +232,110 @@ func TestHasNoClusterPrefixTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, c.tagging.hasNoClusterPrefixTag(tt.tags))
+		})
+	}
+}
+
+func TestTagResource(t *testing.T) {
+	testFlags := flag.NewFlagSet("TestTagResource", flag.ExitOnError)
+	klog.InitFlags(testFlags)
+	testFlags.Parse([]string{"--logtostderr=false"})
+	awsServices := NewFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+
+	tests := []struct {
+		name            string
+		instanceID      string
+		err             error
+		expectedMessage string
+	}{
+		{
+			name:            "tagging successful",
+			instanceID:      "i-random",
+			err:             nil,
+			expectedMessage: "Done calling create-tags to EC2",
+		},
+		{
+			name:            "tagging failed due to unknown error",
+			instanceID:      "i-error",
+			err:             errors.New("Unable to tag"),
+			expectedMessage: "Error occurred trying to tag resources",
+		},
+		{
+			name:            "tagging failed due to resource not found error",
+			instanceID:      "i-not-found",
+			err:             nil,
+			expectedMessage: "Couldn't find resource when trying to tag it hence skipping it",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			klog.SetOutput(&logBuf)
+			defer func() {
+				klog.SetOutput(os.Stderr)
+			}()
+
+			err := c.TagResource(tt.instanceID, nil)
+			assert.Equal(t, tt.err, err)
+			assert.Contains(t, logBuf.String(), tt.expectedMessage)
+		})
+	}
+}
+
+func TestUntagResource(t *testing.T) {
+	testFlags := flag.NewFlagSet("TestUntagResource", flag.ExitOnError)
+	klog.InitFlags(testFlags)
+	testFlags.Parse([]string{"--logtostderr=false"})
+	awsServices := NewFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+
+	tests := []struct {
+		name            string
+		instanceID      string
+		err             error
+		expectedMessage string
+	}{
+		{
+			name:            "untagging successful",
+			instanceID:      "i-random",
+			err:             nil,
+			expectedMessage: "Done calling delete-tags to EC2",
+		},
+		{
+			name:            "untagging failed due to unknown error",
+			instanceID:      "i-error",
+			err:             errors.New("Unable to remove tag"),
+			expectedMessage: "Error occurred trying to untag resources",
+		},
+		{
+			name:            "untagging failed due to resource not found error",
+			instanceID:      "i-not-found",
+			err:             nil,
+			expectedMessage: "Couldn't find resource when trying to untag it hence skipping it",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			klog.SetOutput(&logBuf)
+			defer func() {
+				klog.SetOutput(os.Stderr)
+			}()
+
+			err := c.UntagResource(tt.instanceID, nil)
+			assert.Equal(t, tt.err, err)
+			assert.Contains(t, logBuf.String(), tt.expectedMessage)
 		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #448 on release-1.22.

#448: Handle InvalidInstanceID.NotFound when tagging resources

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```