### PR TITLE
Automated cherry pick of #448: Handle InvalidInstanceID.NotFound when tagging resources

### DIFF
--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -269,6 +270,10 @@ func (ec2i *FakeEC2Impl) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTags
 		if *id == "i-error" {
 			return nil, errors.New("Unable to tag")
 		}
+
+		if *id == "i-not-found" {
+			return nil, awserr.New("InvalidInstanceID.NotFound", "Instance not found", nil)
+		}
 	}
 	return &ec2.CreateTagsOutput{}, nil
 }
@@ -278,6 +283,10 @@ func (ec2i *FakeEC2Impl) DeleteTags(input *ec2.DeleteTagsInput) (*ec2.DeleteTags
 	for _, id := range input.Resources {
 		if *id == "i-error" {
 			return nil, errors.New("Unable to remove tag")
+		}
+
+		if *id == "i-not-found" {
+			return nil, awserr.New("InvalidInstanceID.NotFound", "Instance not found", nil)
 		}
 	}
 	return &ec2.DeleteTagsOutput{}, nil

--- a/pkg/providers/v1/tags.go
+++ b/pkg/providers/v1/tags.go
@@ -322,6 +322,10 @@ func (c *Cloud) TagResource(resourceID string, tags map[string]string) error {
 	output, err := c.ec2.CreateTags(request)
 
 	if err != nil {
+		if isAWSErrorInstanceNotFound(err) {
+			klog.Infof("Couldn't find resource when trying to tag it hence skipping it, %v", err)
+			return nil
+		}
 		klog.Errorf("Error occurred trying to tag resources, %v", err)
 		return err
 	}
@@ -342,6 +346,10 @@ func (c *Cloud) UntagResource(resourceID string, tags map[string]string) error {
 	output, err := c.ec2.DeleteTags(request)
 
 	if err != nil {
+		if isAWSErrorInstanceNotFound(err) {
+			klog.Infof("Couldn't find resource when trying to untag it hence skipping it, %v", err)
+			return nil
+		}
 		klog.Errorf("Error occurred trying to untag resources, %v", err)
 		return err
 	}

--- a/pkg/providers/v1/tags_test.go
+++ b/pkg/providers/v1/tags_test.go
@@ -17,11 +17,16 @@ limitations under the License.
 package aws
 
 import (
+	"bytes"
+	"errors"
+	"flag"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
 )
 
 func TestFilterTags(t *testing.T) {
@@ -227,6 +232,110 @@ func TestHasNoClusterPrefixTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, c.tagging.hasNoClusterPrefixTag(tt.tags))
+		})
+	}
+}
+
+func TestTagResource(t *testing.T) {
+	testFlags := flag.NewFlagSet("TestTagResource", flag.ExitOnError)
+	klog.InitFlags(testFlags)
+	testFlags.Parse([]string{"--logtostderr=false"})
+	awsServices := NewFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+
+	tests := []struct {
+		name            string
+		instanceID      string
+		err             error
+		expectedMessage string
+	}{
+		{
+			name:            "tagging successful",
+			instanceID:      "i-random",
+			err:             nil,
+			expectedMessage: "Done calling create-tags to EC2",
+		},
+		{
+			name:            "tagging failed due to unknown error",
+			instanceID:      "i-error",
+			err:             errors.New("Unable to tag"),
+			expectedMessage: "Error occurred trying to tag resources",
+		},
+		{
+			name:            "tagging failed due to resource not found error",
+			instanceID:      "i-not-found",
+			err:             nil,
+			expectedMessage: "Couldn't find resource when trying to tag it hence skipping it",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			klog.SetOutput(&logBuf)
+			defer func() {
+				klog.SetOutput(os.Stderr)
+			}()
+
+			err := c.TagResource(tt.instanceID, nil)
+			assert.Equal(t, tt.err, err)
+			assert.Contains(t, logBuf.String(), tt.expectedMessage)
+		})
+	}
+}
+
+func TestUntagResource(t *testing.T) {
+	testFlags := flag.NewFlagSet("TestUntagResource", flag.ExitOnError)
+	klog.InitFlags(testFlags)
+	testFlags.Parse([]string{"--logtostderr=false"})
+	awsServices := NewFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+
+	tests := []struct {
+		name            string
+		instanceID      string
+		err             error
+		expectedMessage string
+	}{
+		{
+			name:            "untagging successful",
+			instanceID:      "i-random",
+			err:             nil,
+			expectedMessage: "Done calling delete-tags to EC2",
+		},
+		{
+			name:            "untagging failed due to unknown error",
+			instanceID:      "i-error",
+			err:             errors.New("Unable to remove tag"),
+			expectedMessage: "Error occurred trying to untag resources",
+		},
+		{
+			name:            "untagging failed due to resource not found error",
+			instanceID:      "i-not-found",
+			err:             nil,
+			expectedMessage: "Couldn't find resource when trying to untag it hence skipping it",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			klog.SetOutput(&logBuf)
+			defer func() {
+				klog.SetOutput(os.Stderr)
+			}()
+
+			err := c.UntagResource(tt.instanceID, nil)
+			assert.Equal(t, tt.err, err)
+			assert.Contains(t, logBuf.String(), tt.expectedMessage)
 		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #448 on release-1.22.

#448: Handle InvalidInstanceID.NotFound when tagging resources

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```