### PR TITLE
Chart dns policy

### DIFF
--- a/charts/aws-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/aws-cloud-controller-manager/templates/daemonset.yaml
@@ -21,6 +21,7 @@ spec:
     spec:
       tolerations: {{ toYaml ( .Values.tolerations | default .Values.tolerations ) | nindent 8 }}
       nodeSelector: {{ toYaml ( .Values.nodeSelector | default .Values.nodeSelector ) | nindent 8 }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
       priorityClassName: system-node-critical
       serviceAccountName: {{.Values.serviceAccountName}}
       {{- if .Values.hostNetworking }}

--- a/charts/aws-cloud-controller-manager/values.yaml
+++ b/charts/aws-cloud-controller-manager/values.yaml
@@ -120,6 +120,9 @@ tolerations:
 - key: node-role.kubernetes.io/master
   effect: NoSchedule
 
+# dnsPolicy -- dnsPolicy of deamonset pods. Should be set to Default if deployed as a deamonset on control-plane nodes to resolve properly
+dnsPolicy: Default
+
 clusterRoleName : system:cloud-controller-manager
 
 roleBindingName: cloud-controller-manager:apiserver-authentication-reader


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
It enables setting dnsPolicy for daemonset in helm chart. In case of starting a fresh cluster all nodes have taint `node.cloudprovider.kubernetes.io/uninitialized` preventing coredns from starting (without toleration). Without coredns aws cloud provider can't resolve AWS api endpoint what leads to a locked cluster.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Added possibility to control dnsPolicy through helm chart values.
```
