### PR TITLE
Fargate rbn fix

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -5089,6 +5089,14 @@ func IsFargateNode(nodeName string) bool {
 	return strings.HasPrefix(nodeName, fargateNodeNamePrefix)
 }
 
+// extract private ip address from node name
+func nodeNameToIpAddress(nodeName string) string {
+	nodeName = strings.TrimPrefix(nodeName, privateDNSNamePrefix)
+	nodeName = strings.Split(nodeName, ".")[0]
+	ip := strings.ReplaceAll(nodeName, "-", ".")
+	return ip
+}
+
 func (c *Cloud) nodeNameToInstanceID(nodeName types.NodeName) (InstanceID, error) {
 	if strings.HasPrefix(string(nodeName), rbnNamePrefix) {
 		return InstanceID(nodeName), nil
@@ -5190,11 +5198,13 @@ func (c *Cloud) describeNetworkInterfaces(nodeName string) (*ec2.NetworkInterfac
 	}
 
 	// when enableDnsSupport is set to false in a VPC, interface will not have private DNS names.
+	// convert node name to ip address because ip-name based and resource-named EC2 resources
+	// may have different privateDNSName formats but same privateIpAddress format
 	if strings.HasPrefix(eniEndpoint, privateDNSNamePrefix) {
-		filters = append(filters, newEc2Filter("private-dns-name", eniEndpoint))
-	} else {
-		filters = append(filters, newEc2Filter("private-ip-address", eniEndpoint))
+		eniEndpoint = nodeNameToIpAddress(eniEndpoint)
 	}
+
+	filters = append(filters, newEc2Filter("private-ip-address", eniEndpoint))
 
 	request := &ec2.DescribeNetworkInterfacesInput{
 		Filters: filters,

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -3796,6 +3796,15 @@ func TestInstanceExistsByProviderIDForFargate(t *testing.T) {
 	assert.True(t, instanceExist)
 }
 
+func TestInstanceExistsByProviderIDWithNodeNameForFargate(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
+
+	instanceExist, err := c.InstanceExistsByProviderID(context.TODO(), "aws:///us-west-2c/1abc-2def/fargate-ip-192-168-164-88.us-west-2.compute.internal")
+	assert.Nil(t, err)
+	assert.True(t, instanceExist)
+}
+
 func TestInstanceNotExistsByProviderIDForFargate(t *testing.T) {
 	awsServices := newMockedFakeAWSServices(TestClusterID)
 	c, _ := newAWSCloud(CloudConfig{}, awsServices)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The function `InstanceExistsByProviderID` returns true if the instance with the given provider id. It tries to describeENI with either `privateDNSName` or `privateIpAddress` passed in the `providerID`. For fargate use cases, the instanceID got from providerID will be like either ip-name based privateDNSName or just ip address if enableDnsSupport is set to false in a VPC. However, with resource-name based EC2 resources, privateDNSName is a different format, which has instance id instead of ip address to generate privateDNSName. This causes that `InstanceExistsByProviderID` cannot find corresponding instance. The change here is to use privateIdAddress to describeENI since this format remains same for either ip-name based or resource-name based EC2 resources.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes [(issue)](https://github.com/aws/containers-roadmap/issues/1723)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Fix fargate nodes cannot join the cluster with resource-name enabled for EC2 hostnames
```
