### PR TITLE
Automated cherry pick of #471: Use ip address to describeENI for fargate nodes

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -5126,7 +5126,7 @@ func nodeNameToIPAddress(nodeName string) string {
 	nodeName = strings.Split(nodeName, ".")[0]
 	return strings.ReplaceAll(nodeName, "-", ".")
 }
-	
+
 func (c *Cloud) nodeNameToProviderID(nodeName types.NodeName) (InstanceID, error) {
 	if len(nodeName) == 0 {
 		return "", fmt.Errorf("no nodeName provided")

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -5120,6 +5120,13 @@ func IsFargateNode(nodeName string) bool {
 	return strings.HasPrefix(nodeName, fargateNodeNamePrefix)
 }
 
+// extract private ip address from node name
+func nodeNameToIpAddress(nodeName string) string {
+	nodeName = strings.TrimPrefix(nodeName, privateDNSNamePrefix)
+	nodeName = strings.Split(nodeName, ".")[0]
+	return strings.ReplaceAll(nodeName, "-", ".")
+}
+	
 func (c *Cloud) nodeNameToProviderID(nodeName types.NodeName) (InstanceID, error) {
 	if len(nodeName) == 0 {
 		return "", fmt.Errorf("no nodeName provided")
@@ -5184,11 +5191,13 @@ func (c *Cloud) describeNetworkInterfaces(nodeName string) (*ec2.NetworkInterfac
 	}
 
 	// when enableDnsSupport is set to false in a VPC, interface will not have private DNS names.
+	// convert node name to ip address because ip-name based and resource-named EC2 resources
+	// may have different privateDNSName formats but same privateIpAddress format
 	if strings.HasPrefix(eniEndpoint, privateDNSNamePrefix) {
-		filters = append(filters, newEc2Filter("private-dns-name", eniEndpoint))
-	} else {
-		filters = append(filters, newEc2Filter("private-ip-address", eniEndpoint))
+		eniEndpoint = nodeNameToIpAddress(eniEndpoint)
 	}
+
+	filters = append(filters, newEc2Filter("private-ip-address", eniEndpoint))
 
 	request := &ec2.DescribeNetworkInterfacesInput{
 		Filters: filters,

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -5121,7 +5121,7 @@ func IsFargateNode(nodeName string) bool {
 }
 
 // extract private ip address from node name
-func nodeNameToIpAddress(nodeName string) string {
+func nodeNameToIPAddress(nodeName string) string {
 	nodeName = strings.TrimPrefix(nodeName, privateDNSNamePrefix)
 	nodeName = strings.Split(nodeName, ".")[0]
 	return strings.ReplaceAll(nodeName, "-", ".")
@@ -5194,7 +5194,7 @@ func (c *Cloud) describeNetworkInterfaces(nodeName string) (*ec2.NetworkInterfac
 	// convert node name to ip address because ip-name based and resource-named EC2 resources
 	// may have different privateDNSName formats but same privateIpAddress format
 	if strings.HasPrefix(eniEndpoint, privateDNSNamePrefix) {
-		eniEndpoint = nodeNameToIpAddress(eniEndpoint)
+		eniEndpoint = nodeNameToIPAddress(eniEndpoint)
 	}
 
 	filters = append(filters, newEc2Filter("private-ip-address", eniEndpoint))

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -728,7 +728,7 @@ func (ec2i *FakeEC2Impl) DescribeNetworkInterfaces(input *ec2.DescribeNetworkInt
 			return &ec2.DescribeNetworkInterfacesOutput{}, nil
 		}
 
-		if *filter.Name == "private-dns-name" {
+		if *filter.Values[0] == "return.private.dns.name" {
 			networkInterface[0].PrivateDnsName = aws.String("ip-1-2-3-4.compute.amazon.com")
 		}
 	}

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -3545,7 +3545,7 @@ func TestNodeAddressesForFargate(t *testing.T) {
 	awsServices := newMockedFakeAWSServices(TestClusterID)
 	c, _ := newAWSCloud(CloudConfig{}, awsServices)
 
-	nodeAddresses, _ := c.NodeAddressesByProviderID(context.TODO(), "aws:///us-west-2c/1abc-2def/fargate-ip-192.168.164.88")
+	nodeAddresses, _ := c.NodeAddressesByProviderID(context.TODO(), "aws:///us-west-2c/1abc-2def/fargate-ip-return-private-dns-name.us-west-2.compute.internal")
 	verifyNodeAddressesForFargate(t, true, nodeAddresses)
 }
 

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -3578,6 +3578,15 @@ func TestInstanceExistsByProviderIDForFargate(t *testing.T) {
 	assert.True(t, instanceExist)
 }
 
+func TestInstanceExistsByProviderIDWithNodeNameForFargate(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
+
+	instanceExist, err := c.InstanceExistsByProviderID(context.TODO(), "aws:///us-west-2c/1abc-2def/fargate-ip-192-168-164-88.us-west-2.compute.internal")
+	assert.Nil(t, err)
+	assert.True(t, instanceExist)
+}
+
 func TestInstanceNotExistsByProviderIDForFargate(t *testing.T) {
 	awsServices := newMockedFakeAWSServices(TestClusterID)
 	c, _ := newAWSCloud(CloudConfig{}, awsServices)


### PR DESCRIPTION
Cherry pick of #471 on release-1.21.

#471: Use ip address to describeENI for fargate nodes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```