### PR TITLE
Automated cherry pick of #302: Fix target group instances registration when TG created

### DIFF
--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -618,8 +618,7 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
 			return nil, fmt.Errorf("expected only one target group on CreateTargetGroup, got %d groups", len(result.TargetGroups))
 		}
 
-		tg := result.TargetGroups[0]
-		return tg, nil
+		targetGroup = result.TargetGroups[0]
 	}
 
 	// handle instances in service


### PR DESCRIPTION
Cherry pick of #302 on release-1.23.

#302: Fix target group instances registration when TG created

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```