### PR TITLE
Restrict subnets only to subnets from regular availability zones in ELB auto-discovery procedure

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -29,6 +29,7 @@ For the `aws-cloud-controller-manager` to be able to communicate to AWS APIs, yo
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
         "ec2:CreateVolume",

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -300,6 +300,12 @@ const (
 	volumeDetachedStatus = "detached"
 )
 
+const (
+	localZoneType               = "local-zone"
+	wavelengthZoneType          = "wavelength-zone"
+	regularAvailabilityZoneType = "availability-zone"
+)
+
 // awsTagNameMasterRoles is a set of well-known AWS tag names that indicate the instance is a master
 // The major consequence is that it is then not considered for AWS zone discovery for dynamic volume creation.
 var awsTagNameMasterRoles = sets.NewString("kubernetes.io/role/master", "k8s.io/role/master")
@@ -364,6 +370,8 @@ type EC2 interface {
 	RevokeSecurityGroupIngress(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error)
 
 	DescribeSubnets(*ec2.DescribeSubnetsInput) ([]*ec2.Subnet, error)
+
+	DescribeAvailabilityZones(request *ec2.DescribeAvailabilityZonesInput) ([]*ec2.AvailabilityZone, error)
 
 	CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
 	DeleteTags(input *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error)
@@ -1154,6 +1162,15 @@ func (s *awsSdkEC2) DescribeSubnets(request *ec2.DescribeSubnetsInput) ([]*ec2.S
 		return nil, fmt.Errorf("error listing AWS subnets: %q", err)
 	}
 	return response.Subnets, nil
+}
+
+func (s *awsSdkEC2) DescribeAvailabilityZones(request *ec2.DescribeAvailabilityZonesInput) ([]*ec2.AvailabilityZone, error) {
+	// AZs are not paged
+	response, err := s.ec2.DescribeAvailabilityZones(request)
+	if err != nil {
+		return nil, fmt.Errorf("error listing AWS availability zones: %q", err)
+	}
+	return response.AvailabilityZones, err
 }
 
 func (s *awsSdkEC2) CreateSecurityGroup(request *ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
@@ -3508,6 +3525,35 @@ func (c *Cloud) findSubnets() ([]*ec2.Subnet, error) {
 	return subnets, nil
 }
 
+// Returns a mapping between availability zone names and their types
+// Zone will not be included in the map in case it was not found in AWS by name
+func (c *Cloud) getZoneTypesByName(azNames []string) (map[string]string, error) {
+	if len(azNames) == 0 {
+		// if az names slice is empty, no need to make a request, return early with empty map
+		return map[string]string{}, nil
+	}
+	azFilter := newEc2Filter("zone-name", azNames...)
+	azRequest := &ec2.DescribeAvailabilityZonesInput{}
+	azRequest.Filters = []*ec2.Filter{azFilter}
+
+	azs, err := c.ec2.DescribeAvailabilityZones(azRequest)
+	if err != nil {
+		return nil, fmt.Errorf("error describe availability zones: %q", err)
+	}
+
+	azTypesMapping := make(map[string]string)
+	for _, az := range azs {
+		name := aws.StringValue(az.ZoneName)
+		zoneType := aws.StringValue(az.ZoneType)
+		if name == "" || zoneType == "" {
+			klog.Warningf("Ignoring zone with empty name/type: %v", az)
+			continue
+		}
+		azTypesMapping[name] = zoneType
+	}
+	return azTypesMapping, nil
+}
+
 // Finds the subnets to use for an ELB we are creating.
 // Normal (Internet-facing) ELBs must use public subnets, so we skip private subnets.
 // Internal ELBs can use public or private subnets, but if we have a private subnet we should prefer that.
@@ -3596,8 +3642,20 @@ func (c *Cloud) findELBSubnets(internalELB bool) ([]string, error) {
 
 	sort.Strings(azNames)
 
+	azTypesMapping, err := c.getZoneTypesByName(azNames)
+	if err != nil {
+		return nil, fmt.Errorf("error get availability zone types: %q", err)
+	}
+
 	var subnetIDs []string
 	for _, key := range azNames {
+		azType, found := azTypesMapping[key]
+		if found && azType != regularAvailabilityZoneType {
+			// take subnets only from zones with `availability-zone` type
+			// because another zone types (like local, wavelength and outpost zones)
+			// does not support NLB/CLB for the moment, only ALB.
+			continue
+		}
 		subnetIDs = append(subnetIDs, aws.StringValue(subnetsByAZ[key].SubnetId))
 	}
 

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -264,6 +264,28 @@ func (ec2i *FakeEC2Impl) RemoveSubnets() {
 	ec2i.Subnets = ec2i.Subnets[:0]
 }
 
+// DescribeAvailabilityZones returns fake availability zones
+// For every input returns a hardcoded list of fake availability zones for the moment
+func (ec2i *FakeEC2Impl) DescribeAvailabilityZones(request *ec2.DescribeAvailabilityZonesInput) ([]*ec2.AvailabilityZone, error) {
+	var azs []*ec2.AvailabilityZone
+
+	fakeZones := [5]string{"az-local", "az-wavelength", "us-west-2a", "us-west-2b", "us-west-2c"}
+	for _, name := range fakeZones {
+		var zoneType *string
+		switch name {
+		case "az-local":
+			zoneType = aws.String(localZoneType)
+		case "az-wavelength":
+			zoneType = aws.String(wavelengthZoneType)
+		default:
+			zoneType = aws.String(regularAvailabilityZoneType)
+		}
+		zone := &ec2.AvailabilityZone{ZoneName: aws.String(name), ZoneType: zoneType, ZoneId: aws.String(name)}
+		azs = append(azs, zone)
+	}
+	return azs, nil
+}
+
 // CreateTags is a mock for CreateTags from EC2
 func (ec2i *FakeEC2Impl) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
 	for _, id := range input.Resources {

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -999,6 +999,26 @@ func Test_findELBSubnets(t *testing.T) {
 		AvailabilityZone: aws.String("us-west-2c"),
 		SubnetId:         aws.String("subnet-notag"),
 	}
+	subnetLocalZone := &ec2.Subnet{
+		AvailabilityZone: aws.String("az-local"),
+		SubnetId:         aws.String("subnet-in-local-zone"),
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String(c.tagging.clusterTagKey()),
+				Value: aws.String("owned"),
+			},
+		},
+	}
+	subnetWavelengthZone := &ec2.Subnet{
+		AvailabilityZone: aws.String("az-wavelength"),
+		SubnetId:         aws.String("subnet-in-wavelength-zone"),
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String(c.tagging.clusterTagKey()),
+				Value: aws.String("owned"),
+			},
+		},
+	}
 
 	tests := []struct {
 		name        string
@@ -1119,6 +1139,17 @@ func Test_findELBSubnets(t *testing.T) {
 				"subnet-c0000001": true,
 				"subnet-notag":    true,
 				"subnet-other":    true,
+			},
+			want: []string{"subnet-a0000001", "subnet-b0000001", "subnet-c0000001"},
+		},
+		{
+			name: "exclude subnets from local and wavelenght zones",
+			subnets: []*ec2.Subnet{
+				subnetA0000001,
+				subnetB0000001,
+				subnetC0000001,
+				subnetLocalZone,
+				subnetWavelengthZone,
 			},
 			want: []string{"subnet-a0000001", "subnet-b0000001", "subnet-c0000001"},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Outpost, wavelength, and local zone don't support NLB or CLB at the moment. 
This pr adds check for availability zone type and includes only subnets from `availability-zone` typed zones for the auto-discovery.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #442 

**Special notes for your reviewer**:
I'm not sure about PR type, guess that `feature` is the most suitable one.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Added check  for availability zone type within subnets auto-discovery procedure for a load-balancers
Auto-discovery will include only subnets from `availability-zone` typed zones.

IMPORTANT: This change requires an IAM permissions update. IAM policy for control-plane nodes
should be extended with `ec2:DescribeAvailabilityZones` permission.
```
