### PR TITLE
Single goroutine access to the node cache

### DIFF
--- a/pkg/providers/v1/instances.go
+++ b/pkg/providers/v1/instances.go
@@ -149,7 +149,8 @@ type instanceCache struct {
 	snapshot *allInstancesSnapshot
 }
 
-// Gets the full information about these instance from the EC2 API
+// Gets the full information about these instance from the EC2 API. Caller must have acquired c.mutex before
+// calling describeAllInstancesUncached.
 func (c *instanceCache) describeAllInstancesUncached() (*allInstancesSnapshot, error) {
 	now := time.Now()
 
@@ -168,10 +169,6 @@ func (c *instanceCache) describeAllInstancesUncached() (*allInstancesSnapshot, e
 	}
 
 	snapshot := &allInstancesSnapshot{now, m}
-
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
 	if c.snapshot != nil && snapshot.olderThan(c.snapshot) {
 		// If this happens a lot, we could run this function in a mutex and only return one result
 		klog.Infof("Not caching concurrent AWS DescribeInstances results")
@@ -195,22 +192,14 @@ type cacheCriteria struct {
 
 // describeAllInstancesCached returns all instances, using cached results if applicable
 func (c *instanceCache) describeAllInstancesCached(criteria cacheCriteria) (*allInstancesSnapshot, error) {
-	var err error
-	snapshot := c.getSnapshot()
-	if snapshot != nil && !snapshot.MeetsCriteria(criteria) {
-		snapshot = nil
-	}
-
-	if snapshot == nil {
-		snapshot, err = c.describeAllInstancesUncached()
-		if err != nil {
-			return nil, err
-		}
-	} else {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if c.snapshot != nil && c.snapshot.MeetsCriteria(criteria) {
 		klog.V(6).Infof("EC2 DescribeInstances - using cached results")
+		return c.snapshot, nil
 	}
 
-	return snapshot, nil
+	return c.describeAllInstancesUncached()
 }
 
 // getSnapshot returns a snapshot if one exists

--- a/pkg/providers/v1/instances.go
+++ b/pkg/providers/v1/instances.go
@@ -202,14 +202,6 @@ func (c *instanceCache) describeAllInstancesCached(criteria cacheCriteria) (*all
 	return c.describeAllInstancesUncached()
 }
 
-// getSnapshot returns a snapshot if one exists
-func (c *instanceCache) getSnapshot() *allInstancesSnapshot {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	return c.snapshot
-}
-
 // olderThan is a simple helper to encapsulate timestamp comparison
 func (s *allInstancesSnapshot) olderThan(other *allInstancesSnapshot) bool {
 	// After() is technically broken by time changes until we have monotonic time


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
This PR restricts the access to the `describeAllInstancesUncached` to a single worker. For AWS accounts with thousand of EC2 instances the call to fetch the instances from the AWS API is costly in resources. On startup of the CCM with `concurrent-service-syncs` > 1 because the cache is empty all the workers will try to hit the AWS API which creates very large spikes in resources used.

With this PR only one worker will access describeAllInstancesUncached while the rest will wait for the mutex. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Fix a bug that leads to multiple workers making concurrent `DescribeInstance` requests to AWS.
```
