### PR TITLE
Calculate cache duration correctly

### DIFF
--- a/cmd/ecr-credential-provider/main_test.go
+++ b/cmd/ecr-credential-provider/main_test.go
@@ -248,3 +248,22 @@ func TestRegistryPatternMatch(t *testing.T) {
 		}
 	}
 }
+
+func Test_getCacheDuration(t *testing.T) {
+	testcases := []struct {
+		ExpiresAt *time.Time
+		Expected  time.Duration
+	}{
+		{nil, 0},
+		{aws.Time(time.Now().Add(12 * time.Hour)), 6 * time.Hour},
+	}
+
+	for _, tc := range testcases {
+		actual := getCacheDuration(tc.ExpiresAt)
+		if actual == nil {
+			t.Errorf("unexpected nil value returned for test value %v", tc.ExpiresAt)
+		} else if actual.Round(time.Second) != tc.Expected {
+			t.Errorf("unexpected duration value: want %v, got %v", tc.Expected, actual.Duration)
+		}
+	}
+}


### PR DESCRIPTION
Time.Unix() returns the time in seconds so need to multiply the duration by time.Second

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Cache duration was being calculated incorrectly (e.g. returning 21 microseconds instead of 6 hours).


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #348

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
