### PR TITLE
Restore chunked behaviour of target group creation in LBv2

### DIFF
--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -618,7 +618,12 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
 			return nil, fmt.Errorf("expected only one target group on CreateTargetGroup, got %d groups", len(result.TargetGroups))
 		}
 
-		targetGroup = result.TargetGroups[0]
+		tg := result.TargetGroups[0]
+		tgARN := aws.StringValue(tg.TargetGroupArn)
+		if err := c.ensureTargetGroupTargets(tgARN, expectedTargets, nil); err != nil {
+			return nil, err
+		}
+		return tg, nil
 	}
 
 	// handle instances in service


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

When kubernetes/kubernetes##101592 introduced the target group registration chunking, this is how the target groups were being registered. Then we would return. The rest of this function was intended to handle the case where the load balancer already exists.

#293, I believe, accidentally removed the target registration from the "create" part of this function, creating the bug #301. #302 resolved this by allowing the function to fall through to the "update" section of the code.

Since we don't need to run the checks for existing and dirty health checks on create, I think we should restore the original behaviour to prevent those unnecessary API calls.

I've manually tested this myself by building a cluster and checking that when I create an NLB backed service, the targets are registered correctly on the first instance.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
None
```
