### PR TITLE
Enable booting up kubelet with aws provider when it restarts

### DIFF
--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -141,6 +142,10 @@ type FakeEC2Impl struct {
 
 // DescribeInstances returns fake instance descriptions
 func (ec2i *FakeEC2Impl) DescribeInstances(request *ec2.DescribeInstancesInput) ([]*ec2.Instance, error) {
+	return ec2i.DescribeInstancesWithContext(context.Background(), request)
+}
+
+func (ec2i *FakeEC2Impl) DescribeInstancesWithContext(ctx context.Context, request *ec2.DescribeInstancesInput) ([]*ec2.Instance, error) {
 	matches := []*ec2.Instance{}
 	for _, instance := range ec2i.aws.instances {
 		if request.InstanceIds != nil {

--- a/pkg/providers/v1/instances.go
+++ b/pkg/providers/v1/instances.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -121,16 +122,21 @@ func mapToAWSInstanceIDsTolerant(nodes []*v1.Node) []InstanceID {
 	return instanceIDs
 }
 
-// Gets the full information about this instance from the EC2 API
 func describeInstance(ec2Client EC2, instanceID InstanceID) (*ec2.Instance, error) {
+	return describeInstanceWithContext(context.Background(), ec2Client, instanceID)
+}
+
+// Gets the full information about this instance from the EC2 API
+func describeInstanceWithContext(ctx context.Context, ec2Client EC2, instanceID InstanceID) (*ec2.Instance, error) {
 	request := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{instanceID.awsString()},
 	}
 
-	instances, err := ec2Client.DescribeInstances(request)
+	instances, err := ec2Client.DescribeInstancesWithContext(ctx, request)
 	if err != nil {
 		return nil, err
 	}
+
 	if len(instances) == 0 {
 		return nil, fmt.Errorf("no instances found for instance: %s", instanceID)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enables the cloud provider to boot up whenever the CPI is disconnected from the region.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Optional configuration introduced to cache the self-describe call. It introduces 
new parameter in cloud config to specify the location of the cache.
```
