### PR TITLE
Simplifies configuring provider region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ site/
 .vscode/
 e2e.test
 .idea/
+**/*.swp

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -5237,9 +5237,6 @@ func getRegionFromMetadata(cfg CloudConfig, metadata EC2Metadata) (string, error
 	if cfg.Global.Zone != "" {
 		zone := cfg.Global.Zone
 		klog.Infof("Zone %s configured in cloud config. Using that to get region.", zone)
-		if len(zone) <= 1 {
-			return "", fmt.Errorf("invalid AWS zone in config file: %s", zone)
-		}
 
 		return azToRegion(zone)
 	}

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -463,6 +463,7 @@ type KMS interface {
 type EC2Metadata interface {
 	// Query the EC2 metadata service (used to discover instance-id etc)
 	GetMetadata(path string) (string, error)
+	Region() (string, error)
 }
 
 // AWS volume types
@@ -611,6 +612,8 @@ type CloudConfig struct {
 		// Maybe if we're not running on AWS, e.g. bootstrap; for now it is not very useful
 		Zone string
 
+		Region string
+
 		// The AWS VPC flag enables the possibility to run the master components
 		// on a different aws account, on a different cloud provider or on-premises.
 		// If the flag is set also the KubernetesClusterTag must be provided
@@ -642,17 +645,6 @@ type CloudConfig struct {
 		//Security group for each ELB this security group will be used instead.
 		ElbSecurityGroup string
 
-		//During the instantiation of an new AWS cloud provider, the detected region
-		//is validated against a known set of regions.
-		//
-		//In a non-standard, AWS like environment (e.g. Eucalyptus), this check may
-		//be undesirable.  Setting this to true will disable the check and provide
-		//a warning that the check was skipped.  Please note that this is an
-		//experimental feature and work-in-progress for the moment.  If you find
-		//yourself in an non-AWS cloud and open an issue, please indicate that in the
-		//issue body.
-		DisableStrictZoneCheck bool
-
 		// NodeIPFamilies determines which IP addresses are added to node objects and their ordering.
 		NodeIPFamilies []string
 	}
@@ -677,6 +669,23 @@ type CloudConfig struct {
 		SigningMethod string
 		SigningName   string
 	}
+}
+
+// GetRegion returns the AWS region from the config, if set, or gets it from the metadata
+// service if unset and sets in config
+func (cfg *CloudConfig) GetRegion(metadata EC2Metadata) (string, error) {
+	if cfg.Global.Region != "" {
+		return cfg.Global.Region, nil
+	}
+
+	klog.Info("Loading region from metadata service")
+	region, err := metadata.Region()
+	if err != nil {
+		return "", err
+	}
+
+	cfg.Global.Region = region
+	return region, nil
 }
 
 func (cfg *CloudConfig) validateOverrides() error {
@@ -1262,7 +1271,7 @@ func init() {
 			return nil, fmt.Errorf("error creating AWS metadata client: %q", err)
 		}
 
-		regionName, _, err := getRegionFromMetadata(*cfg, metadata)
+		regionName, err := getRegionFromMetadata(*cfg, metadata)
 		if err != nil {
 			return nil, err
 		}
@@ -1308,28 +1317,6 @@ func readAWSCloudConfig(config io.Reader) (*CloudConfig, error) {
 	return &cfg, nil
 }
 
-func updateConfigZone(cfg *CloudConfig, metadata EC2Metadata) error {
-	if cfg.Global.Zone == "" {
-		if metadata != nil {
-			klog.Info("Zone not specified in configuration file; querying AWS metadata service")
-			var err error
-			cfg.Global.Zone, err = getAvailabilityZone(metadata)
-			if err != nil {
-				return err
-			}
-		}
-		if cfg.Global.Zone == "" {
-			return fmt.Errorf("no zone specified in configuration file")
-		}
-	}
-
-	return nil
-}
-
-func getAvailabilityZone(metadata EC2Metadata) (string, error) {
-	return metadata.GetMetadata("placement/availability-zone")
-}
-
 // Derives the region from a valid az name.
 // Returns an error if the az is known invalid (empty)
 func azToRegion(az string) (string, error) {
@@ -1358,17 +1345,9 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 		return nil, fmt.Errorf("error creating AWS metadata client: %q", err)
 	}
 
-	regionName, zone, err := getRegionFromMetadata(cfg, metadata)
+	regionName, err := getRegionFromMetadata(cfg, metadata)
 	if err != nil {
 		return nil, err
-	}
-
-	if !cfg.Global.DisableStrictZoneCheck {
-		if err := validateRegion(regionName, metadata); err != nil {
-			return nil, fmt.Errorf("not a valid AWS zone (unknown region): %s, %w", zone, err)
-		}
-	} else {
-		klog.Warningf("Strict AWS zone checking is disabled.  Proceeding with zone: %s", zone)
 	}
 
 	ec2, err := awsServices.Compute(regionName)
@@ -1457,48 +1436,6 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 // NewAWSCloud calls and return new aws cloud from newAWSCloud with the supplied configuration
 func NewAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 	return newAWSCloud(cfg, awsServices)
-}
-
-// validateRegion accepts an AWS region name and returns if the region is a
-// valid region known to the AWS SDK. Considers the region returned from the
-// EC2 metadata service to be a valid region as it's only available on a host
-// running in a valid AWS region.
-func validateRegion(region string, metadata EC2Metadata) error {
-	// Does the AWS SDK know about the region? Any region known by the SDK is a
-	// valid one.
-	for _, p := range endpoints.DefaultPartitions() {
-		for r := range p.Regions() {
-			if r == region {
-				return nil
-			}
-		}
-	}
-
-	// ap-northeast-3 is purposely excluded from the SDK because it
-	// requires an access request (for more details see):
-	// https://github.com/aws/aws-sdk-go/issues/1863
-	if region == "ap-northeast-3" {
-		return nil
-	}
-
-	// Fallback to checking if the region matches the instance metadata region
-	// (ignoring any user overrides). This just accounts for running an old
-	// build of Kubernetes in a new region that wasn't compiled into the SDK
-	// when Kubernetes was built.
-	az, err := getAvailabilityZone(metadata)
-	if err != nil {
-		return err
-	}
-	ec2Region, err := azToRegion(az)
-	if err != nil {
-		return err
-	}
-	if region != ec2Region {
-		return fmt.Errorf("region %s is not known, and does not match EC2 instance's region, %s",
-			region, ec2Region)
-	}
-
-	return nil
 }
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
@@ -5293,22 +5230,19 @@ func (c *Cloud) describeNetworkInterfaces(nodeName string) (*ec2.NetworkInterfac
 	return eni.NetworkInterfaces[0], nil
 }
 
-func getRegionFromMetadata(cfg CloudConfig, metadata EC2Metadata) (string, string, error) {
-	klog.Infof("Get AWS region from metadata client")
-	err := updateConfigZone(&cfg, metadata)
-	if err != nil {
-		return "", "", fmt.Errorf("unable to determine AWS zone from cloud provider config or EC2 instance metadata: %v", err)
+func getRegionFromMetadata(cfg CloudConfig, metadata EC2Metadata) (string, error) {
+	// For backwards compatibility reasons, keeping this check to avoid breaking possible
+	// cases where Zone was set to override the region configuration. Otherwise, fall back
+	// to getting region the standard way.
+	if cfg.Global.Zone != "" {
+		zone := cfg.Global.Zone
+		klog.Infof("Zone %s configured in cloud config. Using that to get region.", zone)
+		if len(zone) <= 1 {
+			return "", fmt.Errorf("invalid AWS zone in config file: %s", zone)
+		}
+
+		return azToRegion(zone)
 	}
 
-	zone := cfg.Global.Zone
-	if len(zone) <= 1 {
-		return "", "", fmt.Errorf("invalid AWS zone in config file: %s", zone)
-	}
-
-	regionName, err := azToRegion(zone)
-	if err != nil {
-		return "", "", err
-	}
-
-	return regionName, zone, nil
+	return cfg.GetRegion(metadata)
 }

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -91,6 +91,12 @@ func (s *FakeAWSServices) WithAz(az string) *FakeAWSServices {
 	return s
 }
 
+// WithRegion sets the AWS region
+func (s *FakeAWSServices) WithRegion(region string) *FakeAWSServices {
+	s.region = region
+	return s
+}
+
 // Compute returns a fake EC2 client
 func (s *FakeAWSServices) Compute(region string) (EC2, error) {
 	return s.ec2, nil
@@ -424,6 +430,11 @@ func (m *FakeMetadata) GetMetadata(key string) (string, error) {
 	}
 
 	return "", nil
+}
+
+// Region returns AWS region
+func (m *FakeMetadata) Region() (string, error) {
+	return m.aws.region, nil
 }
 
 // FakeELB is a fake ELB client used for testing

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -3767,6 +3767,26 @@ func TestGetZoneByProviderIDForFargate(t *testing.T) {
 	assert.Equal(t, "us-west-2c", zoneDetails.FailureDomain)
 }
 
+func TestGetRegionFromMetadata(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterID)
+	// Returns region from zone if set
+	cfg := CloudConfig{}
+	cfg.Global.Zone = "us-west-2a"
+	region, err := getRegionFromMetadata(cfg, awsServices.metadata)
+	assert.NoError(t, err)
+	assert.Equal(t, "us-west-2", region)
+	// Returns error if can map to region
+	cfg = CloudConfig{}
+	cfg.Global.Zone = "some-fake-zone"
+	_, err = getRegionFromMetadata(cfg, awsServices.metadata)
+	assert.Error(t, err)
+	// Returns region from metadata if zone unset
+	cfg = CloudConfig{}
+	region, err = getRegionFromMetadata(cfg, awsServices.metadata)
+	assert.NoError(t, err)
+	assert.Equal(t, "us-east-1", region)
+}
+
 type MockedEC2API struct {
 	ec2iface.EC2API
 	mock.Mock

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -145,79 +145,6 @@ func (m *MockedFakeELB) expectConfigureHealthCheck(loadBalancerName *string, exp
 	}
 }
 
-func TestReadAWSCloudConfig(t *testing.T) {
-	tests := []struct {
-		name string
-
-		reader io.Reader
-		aws    Services
-
-		expectError bool
-		zone        string
-	}{
-		{
-			"No config reader",
-			nil, nil,
-			true, "",
-		},
-		{
-			"Empty config, no metadata",
-			strings.NewReader(""), nil,
-			true, "",
-		},
-		{
-			"No zone in config, no metadata",
-			strings.NewReader("[global]\n"), nil,
-			true, "",
-		},
-		{
-			"Zone in config, no metadata",
-			strings.NewReader("[global]\nzone = eu-west-1a"), nil,
-			false, "eu-west-1a",
-		},
-		{
-			"No zone in config, metadata does not have zone",
-			strings.NewReader("[global]\n"), newMockedFakeAWSServices(TestClusterID).WithAz(""),
-			true, "",
-		},
-		{
-			"No zone in config, metadata has zone",
-			strings.NewReader("[global]\n"), newMockedFakeAWSServices(TestClusterID),
-			false, "us-east-1a",
-		},
-		{
-			"Zone in config should take precedence over metadata",
-			strings.NewReader("[global]\nzone = eu-west-1a"), newMockedFakeAWSServices(TestClusterID),
-			false, "eu-west-1a",
-		},
-	}
-
-	for _, test := range tests {
-		t.Logf("Running test case %s", test.name)
-		var metadata EC2Metadata
-		if test.aws != nil {
-			metadata, _ = test.aws.Metadata()
-		}
-		cfg, err := readAWSCloudConfig(test.reader)
-		if err == nil {
-			err = updateConfigZone(cfg, metadata)
-		}
-		if test.expectError {
-			if err == nil {
-				t.Errorf("Should error for case %s (cfg=%v)", test.name, cfg)
-			}
-		} else {
-			if err != nil {
-				t.Errorf("Should succeed for case: %s", test.name)
-			}
-			if cfg.Global.Zone != test.zone {
-				t.Errorf("Incorrect zone value (%s vs %s) for case: %s",
-					cfg.Global.Zone, test.zone, test.name)
-			}
-		}
-	}
-}
-
 func TestReadAWSCloudConfigNodeIPFamilies(t *testing.T) {
 	tests := []struct {
 		name string
@@ -554,11 +481,6 @@ func TestNewAWSCloud(t *testing.T) {
 		region      string
 	}{
 		{
-			"No config reader",
-			nil, newMockedFakeAWSServices(TestClusterID).WithAz(""),
-			true, "",
-		},
-		{
 			"Config specifies valid zone",
 			strings.NewReader("[global]\nzone = eu-west-1a"), newMockedFakeAWSServices(TestClusterID),
 			false, "eu-west-1",
@@ -568,12 +490,6 @@ func TestNewAWSCloud(t *testing.T) {
 			strings.NewReader("[global]\n"),
 			newMockedFakeAWSServices(TestClusterID),
 			false, "us-east-1",
-		},
-		{
-			"No zone in config or metadata",
-			strings.NewReader("[global]\n"),
-			newMockedFakeAWSServices(TestClusterID).WithAz(""),
-			true, "",
 		},
 	}
 
@@ -625,8 +541,8 @@ func mockInstancesResp(selfInstance *ec2.Instance, instances []*ec2.Instance) (*
 	return awsCloud, awsServices
 }
 
-func mockAvailabilityZone(availabilityZone string) *Cloud {
-	awsServices := newMockedFakeAWSServices(TestClusterID).WithAz(availabilityZone)
+func mockZone(region, availabilityZone string) *Cloud {
+	awsServices := newMockedFakeAWSServices(TestClusterID).WithAz(availabilityZone).WithRegion(region)
 	awsCloud, err := newAWSCloud(CloudConfig{}, awsServices)
 	if err != nil {
 		panic(err)
@@ -807,7 +723,7 @@ func TestNodeAddresses(t *testing.T) {
 }
 
 func TestGetRegion(t *testing.T) {
-	aws := mockAvailabilityZone("us-west-2e")
+	aws := mockZone("us-west-2", "us-west-2e")
 	zones, ok := aws.Zones()
 	if !ok {
 		t.Fatalf("Unexpected missing zones impl")
@@ -2585,47 +2501,6 @@ func TestCreateDiskFailDescribeVolume(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, volumeID, KubernetesVolumeID(""))
 	awsServices.ec2.(*MockedFakeEC2).AssertExpectations(t)
-}
-
-func TestRegionIsValid(t *testing.T) {
-	fake := newMockedFakeAWSServices("fakeCluster")
-	fake.selfInstance.Placement = &ec2.Placement{
-		AvailabilityZone: aws.String("pl-fake-999a"),
-	}
-
-	// This is the legacy list that was removed, using this to ensure we avoid
-	// region regressions if something goes wrong in the SDK
-	regions := []string{
-		"ap-northeast-1",
-		"ap-northeast-2",
-		"ap-northeast-3",
-		"ap-south-1",
-		"ap-southeast-1",
-		"ap-southeast-2",
-		"ca-central-1",
-		"eu-central-1",
-		"eu-west-1",
-		"eu-west-2",
-		"eu-west-3",
-		"sa-east-1",
-		"us-east-1",
-		"us-east-2",
-		"us-west-1",
-		"us-west-2",
-		"cn-north-1",
-		"cn-northwest-1",
-		"us-gov-west-1",
-		"ap-northeast-3",
-
-		// Ensures that we always trust what the metadata service returns
-		"pl-fake-999",
-	}
-
-	for _, region := range regions {
-		assert.NoError(t, validateRegion(region, fake.metadata), "expected region '%s' to be valid but it was not", region)
-	}
-
-	assert.Error(t, validateRegion("pl-fake-991a", fake.metadata), "expected region 'pl-fake-991' to be invalid but it was not")
 }
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:
The current logic derives region from the AZ with unnecessarily complex logic. As describe in #525, you can get the region directly from IMDS rather than getting it from the AZ. I've also removed the `DisableStrictZoneCheck` flag. I took an opinionated stance on this as it doesn't seem useful. It does a few things:

1. Verifies that the AWS SDK knows about the region - At first glance, this seems reasonable, but shortly after it's called, we instantiate clients in the SDK passing in the region, and if the region doesn't exist, I assume that will fail because the SDK will be unable to choose an endpoint and fail with an obvious error.
2. Gets the AZ from IMDS, again, converts it to a region and then makes sure that it's valid.
3. Compares the passed in region with IMDS region to ensure that it's running in the same region. This might be valuable IF there are cases where someone passes in config where `zone` is set, we derive the region from that and we want to reject a mismatch. I'm happy to put this bit back in if we think it's valuable. Otherwise, removing it simplifies things further.

IMO, this could use further refactoring because we also store `selfAWSInstance`, which includes all of that information as well, so I think there's an opportunity to unify some of this self-knowledge, but I'm going to keep this incremental.

**Which issue(s) this PR fixes**:

Fixes #525

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
No. There will be no behavior change. If we removed `zone` from the config you can pass in, which would be desirable if people aren't using that, then it would, but I left that to keep it backwards compatible.

```release-note
Simplifies configuring provider region
```
