### PR TITLE
Use default GCS location to upload artifacts

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,7 +22,6 @@ steps:
     entrypoint: make
     env:
     - PULL_BASE_REF=$_PULL_BASE_REF
-    - GCS_LOCATION=$_GCS_LOCATION
     - LATEST_FILE=markers/${_PULL_BASE_REF}/latest-tag.txt
     args:
     - cloudbuild-artifacts


### PR DESCRIPTION
Ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/cloud-provider-aws-push-images/1633304842430582784
```
Step #2 - "cloudbuild-artifacts": == Uploading provider-aws ==
Step #2 - "cloudbuild-artifacts": gsutil -h "Cache-Control:private, max-age=0, no-transform" -m cp -n -r /workspace/_output/upload/provider-aws/*
Step #2 - "cloudbuild-artifacts": CommandException: Wrong number of arguments for "cp" command.
Step #2 - "cloudbuild-artifacts": make: *** [Makefile:201: gcs-upload] Error 1
```
/cc @dims @olemarkus @rifelpet 