### PR TITLE
fix: handle subnets with resource based naming more flexibly

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -6,7 +6,7 @@ AWS supports two naming conventions: [IP-based or resource-based naming](https:/
 
 When _IP-based naming_ is used, the nodes must be named after the instance followed by the regional domain name (`ip-xxx-xxx-xxx-xxx.ec2.<region>.internal`). If you have custom domain name set in the DHCP options, you must set `--hostname-override` on kube-proxy and kubelet to match the above-mentioned naming convention.
 
-When _resource based naming_ is used, the node must be named after the instance without any domain name (`i-1234567890abcdefg`). Custom domain name may be used as long as the output of `hostname` does not include the domain name. `--hostname-override` should not be set on any components when using resource-based naming.
+When _resource based naming_ is used, the node must be named after the instance either with or without a domain name (`i-1234567890abcdefg` or `i-1234567890abcdefg.<region>.compute.internal`). A custom domain name, configured through DHCP options, may also be used. 
 
 ## IAM Policies
 For the `aws-cloud-controller-manager` to be able to communicate to AWS APIs, you will need to create a few IAM policies for your EC2 instances. The control plane (formerly master) policy is a bit open and can be scaled back depending on the use case. Adjust these based on your needs.

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -5124,6 +5124,12 @@ func nodeNameToIPAddress(nodeName string) string {
 
 func (c *Cloud) nodeNameToInstanceID(nodeName types.NodeName) (InstanceID, error) {
 	if strings.HasPrefix(string(nodeName), rbnNamePrefix) {
+		// depending on if you use a RHEL (e.g. AL2) or Debian (e.g. standard Ubuntu) based distribution, the
+		// hostname on the machine may be either i-00000000000000001 or i-00000000000000001.region.compute.internal.
+		// This handles both scenarios by returning anything before the first '.' in the node name if it has an RBN prefix.
+		if idx := strings.IndexByte(string(nodeName), '.'); idx != -1 {
+			return InstanceID(nodeName[0:idx]), nil
+		}
 		return InstanceID(nodeName), nil
 	}
 	if len(nodeName) == 0 {

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -560,14 +560,14 @@ func testHasNodeAddress(t *testing.T, addrs []v1.NodeAddress, addressType v1.Nod
 	t.Errorf("Did not find expected address: %s:%s in %v", addressType, address, addrs)
 }
 
-func makeInstance(num string, privateIP, publicIP, privateDNSName, publicDNSName string, ipv6s []string, setNetInterface bool) ec2.Instance {
+func makeInstance(instanceID string, privateIP, publicIP, privateDNSName, publicDNSName string, ipv6s []string, setNetInterface bool) ec2.Instance {
 	var tag ec2.Tag
 	tag.Key = aws.String(TagNameKubernetesClusterLegacy)
 	tag.Value = aws.String(TestClusterID)
 	tags := []*ec2.Tag{&tag}
 
 	instance := ec2.Instance{
-		InstanceId:       aws.String(fmt.Sprintf("i-%s", num)),
+		InstanceId:       &instanceID,
 		PrivateDnsName:   aws.String(privateDNSName),
 		PrivateIpAddress: aws.String(privateIP),
 		PublicDnsName:    aws.String(publicDNSName),
@@ -602,155 +602,202 @@ func makeInstance(num string, privateIP, publicIP, privateDNSName, publicDNSName
 }
 
 func TestNodeAddressesByProviderID(t *testing.T) {
-	// Note instance0 and instance1 have the same name
-	// (we test that this produces an error)
-	instance0 := makeInstance("00000000000000000", "192.168.0.1", "1.2.3.4", "instance-same.ec2.internal", "instance-same.ec2.external", nil, true)
-	instance1 := makeInstance("00000000000000001", "192.168.0.2", "", "instance-same.ec2.internal", "", nil, false)
-	instance2 := makeInstance("00000000000000002", "192.168.0.1", "1.2.3.4", "instance-other.ec2.internal", "", nil, false)
-	instance3 := makeInstance("00000000000000003", "192.168.0.3", "", "instance-ipv6.ec2.internal", "", []string{"2a05:d014:aa7:911:fc7e:1600:fc4d:ab2", "2a05:d014:aa7:911:9f44:e737:1aa0:6489"}, true)
-	instances := []*ec2.Instance{&instance0, &instance1, &instance2, &instance3}
+	for _, tc := range []struct {
+		Name            string
+		InstanceID      string
+		PrivateIP       string
+		PublicIP        string
+		PrivateDNSName  string
+		PublicDNSName   string
+		Ipv6s           []string
+		SetNetInterface bool
+		NodeName        string
+		Ipv6Only        bool
 
-	aws1, _ := mockInstancesResp(&instance0, []*ec2.Instance{&instance0})
-	_, err1 := aws1.NodeAddressesByProviderID(context.TODO(), "i-xxx")
-	if err1 == nil {
-		t.Errorf("Should error when no instance found")
-	}
+		ExpectedNumAddresses int
+	}{
+		{
+			Name:                 "ipv4 w/public IP",
+			InstanceID:           "i-00000000000000000",
+			PrivateIP:            "192.168.0.1",
+			PublicIP:             "1.2.3.4",
+			PrivateDNSName:       "instance-same.ec2.internal",
+			PublicDNSName:        "instance-same.ec2.external",
+			SetNetInterface:      true,
+			ExpectedNumAddresses: 5,
+		},
+		{
+			Name:                 "ipv4 w/private IP only",
+			InstanceID:           "i-00000000000000001",
+			PrivateIP:            "192.168.0.2",
+			PrivateDNSName:       "instance-same.ec2.internal",
+			ExpectedNumAddresses: 2,
+		},
+		{
+			Name:                 "ipv4 w/public IP and no public DNS",
+			InstanceID:           "i-00000000000000002",
+			PrivateIP:            "192.168.0.1",
+			PublicIP:             "1.2.3.4",
+			PrivateDNSName:       "instance-other.ec2.internal",
+			ExpectedNumAddresses: 3,
+		},
+		{
+			Name:                 "ipv6 only",
+			InstanceID:           "i-00000000000000003",
+			PrivateIP:            "192.168.0.3",
+			PrivateDNSName:       "instance-ipv6.ec2.internal",
+			Ipv6s:                []string{"2a05:d014:aa7:911:fc7e:1600:fc4d:ab2", "2a05:d014:aa7:911:9f44:e737:1aa0:6489"},
+			SetNetInterface:      true,
+			ExpectedNumAddresses: 1,
+			NodeName:             "foo",
+			Ipv6Only:             true,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			instance := makeInstance(tc.InstanceID, tc.PrivateIP, tc.PublicIP, tc.PrivateDNSName, tc.PublicDNSName, tc.Ipv6s, tc.SetNetInterface)
+			aws1, _ := mockInstancesResp(&instance, []*ec2.Instance{&instance})
+			_, err := aws1.NodeAddressesByProviderID(context.TODO(), "i-xxx")
+			if err == nil {
+				t.Errorf("Should error when no instance found")
+			}
+			if tc.Ipv6Only {
+				aws1.cfg.Global.NodeIPFamilies = []string{"ipv6"}
+			}
+			if tc.NodeName != "" {
+				aws1.selfAWSInstance.nodeName = types.NodeName(tc.NodeName)
+			}
+			addrs, err := aws1.NodeAddressesByProviderID(context.TODO(), tc.InstanceID)
+			if err != nil {
+				t.Errorf("Should not error when instance found, %s", err)
+			}
+			if len(addrs) != tc.ExpectedNumAddresses {
+				t.Errorf("Should return exactly %d NodeAddresses, got %d (%v)", tc.ExpectedNumAddresses, len(addrs), addrs)
+			}
 
-	aws2, _ := mockInstancesResp(&instance0, instances[0:1])
-	// change node name so it uses the instance instead of metadata
-	aws2.selfAWSInstance.nodeName = "foo"
-	addrs2, err2 := aws2.NodeAddressesByProviderID(context.TODO(), "i-00000000000000000")
-	if err2 != nil {
-		t.Errorf("Should not error when instance found, %s", err2)
+			if tc.SetNetInterface && !tc.Ipv6Only {
+				testHasNodeAddress(t, addrs, v1.NodeInternalIP, tc.PrivateIP)
+			}
+			if tc.PublicIP != "" {
+				testHasNodeAddress(t, addrs, v1.NodeExternalIP, tc.PublicIP)
+			}
+			if tc.PublicDNSName != "" {
+				testHasNodeAddress(t, addrs, v1.NodeExternalDNS, tc.PublicDNSName)
+			}
+			if tc.PrivateDNSName != "" && !tc.Ipv6Only {
+				testHasNodeAddress(t, addrs, v1.NodeInternalDNS, tc.PrivateDNSName)
+				testHasNodeAddress(t, addrs, v1.NodeHostName, tc.PrivateDNSName)
+			}
+			if tc.Ipv6Only {
+				testHasNodeAddress(t, addrs, v1.NodeInternalIP, tc.Ipv6s[0])
+			}
+		})
 	}
-	if len(addrs2) != 5 {
-		t.Errorf("Should return exactly 5 NodeAddresses")
-	}
-	testHasNodeAddress(t, addrs2, v1.NodeInternalIP, "192.168.0.1")
-	testHasNodeAddress(t, addrs2, v1.NodeExternalIP, "1.2.3.4")
-	testHasNodeAddress(t, addrs2, v1.NodeExternalDNS, "instance-same.ec2.external")
-	testHasNodeAddress(t, addrs2, v1.NodeInternalDNS, "instance-same.ec2.internal")
-	testHasNodeAddress(t, addrs2, v1.NodeHostName, "instance-same.ec2.internal")
-
-	aws3, _ := mockInstancesResp(&instance3, instances)
-	aws3.cfg.Global.NodeIPFamilies = []string{"ipv4", "ipv6"}
-	// change node name so it uses the instance instead of metadata
-	aws3.selfAWSInstance.nodeName = "foo"
-	addrs3, err3 := aws3.NodeAddressesByProviderID(context.TODO(), "i-00000000000000003")
-	if err3 != nil {
-		t.Errorf("Should not error when instance found, %s", err3)
-	}
-	if len(addrs3) != 4 {
-		t.Errorf("Should return exactly 4 NodeAddresses")
-	}
-	testHasNodeAddress(t, addrs3, v1.NodeInternalIP, "192.168.0.3")
-	testHasNodeAddress(t, addrs3, v1.NodeInternalIP, "2a05:d014:aa7:911:fc7e:1600:fc4d:ab2")
-	testHasNodeAddress(t, addrs3, v1.NodeInternalDNS, "instance-ipv6.ec2.internal")
-	testHasNodeAddress(t, addrs3, v1.NodeHostName, "instance-ipv6.ec2.internal")
-
-	aws4, _ := mockInstancesResp(&instance3, instances)
-	aws4.cfg.Global.NodeIPFamilies = []string{"ipv6"}
-	// change node name so it uses the instance instead of metadata
-	aws4.selfAWSInstance.nodeName = "foo"
-	addrs4, err4 := aws4.NodeAddressesByProviderID(context.TODO(), "i-00000000000000003")
-	if err4 != nil {
-		t.Errorf("Should not error when instance found, %s", err4)
-	}
-	if len(addrs4) != 1 {
-		t.Errorf("Should return exactly 1 NodeAddresses")
-	}
-	testHasNodeAddress(t, addrs4, v1.NodeInternalIP, "2a05:d014:aa7:911:fc7e:1600:fc4d:ab2")
 }
 
 func TestNodeAddresses(t *testing.T) {
-	instance0 := makeInstance("00000000000000000", "192.168.0.1", "1.2.3.4", "instance-same.ec2.internal", "instance-same.ec2.external", nil, true)
-	instance2 := makeInstance("00000000000000002", "192.168.0.1", "1.2.3.4", "instance-other.ec2.internal", "", nil, false)
-	instance3 := makeInstance("00000000000000003", "192.168.0.3", "", "instance-ipv6.ec2.internal", "", []string{"2a05:d014:aa7:911:fc7e:1600:fc4d:ab2", "2a05:d014:aa7:911:9f44:e737:1aa0:6489"}, true)
-	// configured for resource based naming using FQDN
-	instance4 := makeInstance("00000000000000004", "192.168.0.4", "1.2.3.4", "i-00000000000000004.ec2.internal", "", nil, true)
-	// configured for resource based naming using hostname only
-	instance5 := makeInstance("00000000000000005", "192.168.0.5", "1.2.3.4", "i-00000000000000005.ec2.internal", "", nil, true)
+	for _, tc := range []struct {
+		Name            string
+		InstanceID      string
+		PrivateIP       string
+		PublicIP        string
+		PrivateDNSName  string
+		PublicDNSName   string
+		Ipv6s           []string
+		SetNetInterface bool
+		NodeName        string
+		Ipv6Only        bool
 
-	instances := []*ec2.Instance{&instance0, &instance2, &instance3, &instance4, &instance5}
+		ExpectedNumAddresses int
+	}{
+		{
+			Name:                 "ipv4 w/public IP",
+			InstanceID:           "i-00000000000000000",
+			PrivateIP:            "192.168.0.1",
+			PublicIP:             "1.2.3.4",
+			PrivateDNSName:       "instance-same.ec2.internal",
+			PublicDNSName:        "instance-same.ec2.external",
+			SetNetInterface:      true,
+			NodeName:             "foo",
+			ExpectedNumAddresses: 5,
+		},
+		{
+			Name:                 "ipv4 w/private IP only",
+			InstanceID:           "i-00000000000000002",
+			PrivateIP:            "192.168.0.1",
+			PublicIP:             "1.2.3.4",
+			PrivateDNSName:       "instance-other.ec2.internal",
+			ExpectedNumAddresses: 3,
+		},
+		{
+			Name:                 "ipv6 only",
+			InstanceID:           "i-00000000000000003",
+			PrivateIP:            "192.168.0.3",
+			PrivateDNSName:       "instance-ipv6.ec2.internal",
+			PublicDNSName:        "instance-same.ec2.external",
+			Ipv6s:                []string{"2a05:d014:aa7:911:fc7e:1600:fc4d:ab2", "2a05:d014:aa7:911:9f44:e737:1aa0:6489"},
+			SetNetInterface:      true,
+			Ipv6Only:             true,
+			NodeName:             "foo",
+			ExpectedNumAddresses: 1,
+		},
+		{
+			Name:                 "resource based naming using FQDN",
+			InstanceID:           "i-00000000000000004",
+			PrivateIP:            "192.168.0.4",
+			PublicIP:             "1.2.3.4",
+			PrivateDNSName:       "i-00000000000000004.ec2.internal",
+			SetNetInterface:      true,
+			ExpectedNumAddresses: 4,
+		},
+		{
+			Name:                 "resource based naming using hostname only",
+			InstanceID:           "i-00000000000000005",
+			PrivateIP:            "192.168.0.5",
+			PublicIP:             "1.2.3.4",
+			PrivateDNSName:       "i-00000000000000005",
+			SetNetInterface:      true,
+			ExpectedNumAddresses: 4,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			instance := makeInstance(tc.InstanceID, tc.PrivateIP, tc.PublicIP, tc.PrivateDNSName, tc.PublicDNSName, tc.Ipv6s, tc.SetNetInterface)
+			aws1, _ := mockInstancesResp(&instance, []*ec2.Instance{&instance})
+			_, err := aws1.NodeAddresses(context.TODO(), "instance-mismatch.ec2.internal")
+			if err == nil {
+				t.Errorf("Should error when no instance found")
+			}
+			if tc.Ipv6Only {
+				aws1.cfg.Global.NodeIPFamilies = []string{"ipv6"}
+			}
+			if tc.NodeName != "" {
+				aws1.selfAWSInstance.nodeName = types.NodeName(tc.NodeName)
+			}
+			addrs, err := aws1.NodeAddresses(context.TODO(), types.NodeName(tc.PrivateDNSName))
+			if err != nil {
+				t.Errorf("Should not error when instance found, %s", err)
+			}
+			if len(addrs) != tc.ExpectedNumAddresses {
+				t.Errorf("Should return exactly %d NodeAddresses, got %d (%v)", tc.ExpectedNumAddresses, len(addrs), addrs)
+			}
 
-	aws1, _ := mockInstancesResp(&instance0, []*ec2.Instance{&instance0})
-	_, err1 := aws1.NodeAddresses(context.TODO(), "instance-mismatch.ec2.internal")
-	if err1 == nil {
-		t.Errorf("Should error when no instance found")
+			if tc.SetNetInterface && !tc.Ipv6Only {
+				testHasNodeAddress(t, addrs, v1.NodeInternalIP, tc.PrivateIP)
+			}
+			if tc.PublicIP != "" && !tc.Ipv6Only {
+				testHasNodeAddress(t, addrs, v1.NodeExternalIP, tc.PublicIP)
+			}
+			if tc.PublicDNSName != "" && !tc.Ipv6Only {
+				testHasNodeAddress(t, addrs, v1.NodeExternalDNS, tc.PublicDNSName)
+			}
+			if tc.PrivateDNSName != "" && !tc.Ipv6Only {
+				testHasNodeAddress(t, addrs, v1.NodeInternalDNS, tc.PrivateDNSName)
+				testHasNodeAddress(t, addrs, v1.NodeHostName, tc.PrivateDNSName)
+			}
+			if tc.Ipv6Only {
+				testHasNodeAddress(t, addrs, v1.NodeInternalIP, tc.Ipv6s[0])
+			}
+		})
 	}
-
-	aws3, _ := mockInstancesResp(&instance0, instances[0:1])
-	// change node name so it uses the instance instead of metadata
-	aws3.selfAWSInstance.nodeName = "foo"
-	addrs3, err3 := aws3.NodeAddresses(context.TODO(), "instance-same.ec2.internal")
-	if err3 != nil {
-		t.Errorf("Should not error when instance found")
-	}
-	if len(addrs3) != 5 {
-		t.Errorf("Should return exactly 5 NodeAddresses")
-	}
-	testHasNodeAddress(t, addrs3, v1.NodeInternalIP, "192.168.0.1")
-	testHasNodeAddress(t, addrs3, v1.NodeExternalIP, "1.2.3.4")
-	testHasNodeAddress(t, addrs3, v1.NodeExternalDNS, "instance-same.ec2.external")
-	testHasNodeAddress(t, addrs3, v1.NodeInternalDNS, "instance-same.ec2.internal")
-	testHasNodeAddress(t, addrs3, v1.NodeHostName, "instance-same.ec2.internal")
-
-	aws4, _ := mockInstancesResp(&instance3, instances)
-	aws4.cfg.Global.NodeIPFamilies = []string{"ipv4", "ipv6"}
-	// change node name so it uses the instance instead of metadata
-	aws4.selfAWSInstance.nodeName = "foo"
-	addrs4, err4 := aws4.NodeAddresses(context.TODO(), "instance-ipv6.ec2.internal")
-	if err4 != nil {
-		t.Errorf("Should not error when instance found")
-	}
-	if len(addrs4) != 4 {
-		t.Errorf("Should return exactly 4 NodeAddresses")
-	}
-	testHasNodeAddress(t, addrs4, v1.NodeInternalIP, "192.168.0.3")
-	testHasNodeAddress(t, addrs4, v1.NodeInternalIP, "2a05:d014:aa7:911:fc7e:1600:fc4d:ab2")
-	testHasNodeAddress(t, addrs4, v1.NodeInternalDNS, "instance-ipv6.ec2.internal")
-	testHasNodeAddress(t, addrs4, v1.NodeHostName, "instance-ipv6.ec2.internal")
-
-	aws5, _ := mockInstancesResp(&instance3, instances)
-	aws5.cfg.Global.NodeIPFamilies = []string{"ipv6"}
-	// change node name so it uses the instance instead of metadata
-	aws5.selfAWSInstance.nodeName = "foo"
-	addrs5, err5 := aws5.NodeAddresses(context.TODO(), "instance-ipv6.ec2.internal")
-	if err5 != nil {
-		t.Errorf("Should not error when instance found")
-	}
-	if len(addrs5) != 1 {
-		t.Errorf("Should return exactly 1 NodeAddresses")
-	}
-	testHasNodeAddress(t, addrs5, v1.NodeInternalIP, "2a05:d014:aa7:911:fc7e:1600:fc4d:ab2")
-
-	aws6, _ := mockInstancesResp(&instance4, instances)
-	addrs6, err6 := aws6.NodeAddresses(context.TODO(), "i-00000000000000004.ec2.internal")
-	if err6 != nil {
-		t.Errorf("Should not error when instance found, %s", err6)
-	}
-	if len(addrs6) != 4 {
-		t.Errorf("Should return exactly 4 NodeAddresses, got %v", addrs5)
-	}
-	testHasNodeAddress(t, addrs6, v1.NodeInternalIP, "192.168.0.4")
-	testHasNodeAddress(t, addrs6, v1.NodeExternalIP, "1.2.3.4")
-	testHasNodeAddress(t, addrs6, v1.NodeInternalDNS, "i-00000000000000004.ec2.internal")
-	testHasNodeAddress(t, addrs6, v1.NodeHostName, "i-00000000000000004.ec2.internal")
-
-	aws7, _ := mockInstancesResp(&instance5, instances)
-	aws7.selfAWSInstance.nodeName = "i-00000000000000005"
-	addrs7, err6 := aws7.NodeAddresses(context.TODO(), "i-00000000000000005")
-	if err6 != nil {
-		t.Errorf("Should not error when instance found, %s", err6)
-	}
-	if len(addrs6) != 4 {
-		t.Errorf("Should return exactly 4 NodeAddresses, got %v", addrs6)
-	}
-	testHasNodeAddress(t, addrs7, v1.NodeInternalIP, "192.168.0.5")
-	testHasNodeAddress(t, addrs7, v1.NodeExternalIP, "1.2.3.4")
-	testHasNodeAddress(t, addrs7, v1.NodeInternalDNS, "i-00000000000000005.ec2.internal")
-	testHasNodeAddress(t, addrs7, v1.NodeHostName, "i-00000000000000005.ec2.internal")
-
 }
 
 func TestGetRegion(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This adds support for RHEL based distributions that typically use a FQDN.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

See cloud-init for RHEL at https://github.com/canonical/cloud-init/blob/main/cloudinit/distros/rhel.py#L46
and https://github.com/canonical/cloud-init/blob/f146fe71733e72b94fad525b8cc9988b1405e760/cloudinit/distros/__init__.py#L343
**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
