### PR TITLE
Add version flag to ecr-credential-provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ IMAGE_REPOSITORY ?= amazon/cloud-controller-manager
 IMAGE ?= $(IMAGE_REPOSITORY):$(VERSION)
 OUTPUT ?= $(shell pwd)/_output
 INSTALL_PATH ?= $(OUTPUT)/bin
-LDFLAGS ?= -w -s -X k8s.io/component-base/version.gitVersion=$(VERSION)
+LDFLAGS ?= -w -s -X k8s.io/component-base/version.gitVersion=$(VERSION) -X main.gitVersion=$(VERSION)
 
 # flags for ecr-credential-provider artifact promotion
 UPLOAD ?= $(OUTPUT)/upload


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The `ecr-credential-provider` has recently changed the API version it supports (#597). Currently, there is no straightforward way to distinguish two `ecr-credential-provider` binaries, which makes changes like #597 difficult to handle. This PR adds a `--version` flag that returns the standard `gitVersion` as in `k8s.io/component-base/version`, to help in such situations.

**Special notes for your reviewer**:

~~I ran `go mod vendor`, which did...a lot of things. Should I back those changes out?~~ Removed.

**Does this PR introduce a user-facing change?**:

Yes.
```release-note
A `--version` flag has been added to the `ecr-credential-provider`.
```
