### PR TITLE
Update health checks to use Kube-Proxy when no other configuration is provided

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -2072,6 +2072,7 @@ func (c *Cloud) buildNLBHealthCheckConfiguration(svc *v1.Service) (healthCheckCo
 			UnhealthyThreshold: 2,
 		}
 	}
+
 	if parseStringAnnotation(svc.Annotations, ServiceAnnotationLoadBalancerHealthCheckProtocol, &hc.Protocol) {
 		hc.Protocol = strings.ToUpper(hc.Protocol)
 	}
@@ -2085,6 +2086,31 @@ func (c *Cloud) buildNLBHealthCheckConfiguration(svc *v1.Service) (healthCheckCo
 	}
 
 	parseStringAnnotation(svc.Annotations, ServiceAnnotationLoadBalancerHealthCheckPort, &hc.Port)
+
+	switch c.cfg.Global.ClusterServiceLoadBalancerHealthProbeMode {
+	case config.ClusterServiceLoadBalancerHealthProbeModeShared:
+		// For a non-local service, we override the health check to use the kube-proxy port when no other overrides are provided.
+		// The kube-proxy port should be open on all nodes and allows the health check to check the nodes ability to proxy traffic.
+		// When the node is shutting down, the health check should fail before the node loses the ability to route traffic to the backend pod.
+		// This allows the load balancer to gracefully drain connections from the node.
+		if svc.Spec.ExternalTrafficPolicy != v1.ServiceExternalTrafficPolicyTypeLocal {
+			hc.Path = defaultKubeProxyHealthCheckPath
+			if c.cfg.Global.ClusterServiceSharedLoadBalancerHealthProbePath != "" {
+				hc.Path = c.cfg.Global.ClusterServiceSharedLoadBalancerHealthProbePath
+			}
+
+			hc.Port = strconv.Itoa(int(defaultKubeProxyHealthCheckPort))
+			if c.cfg.Global.ClusterServiceSharedLoadBalancerHealthProbePort != 0 {
+				hc.Port = strconv.Itoa(int(c.cfg.Global.ClusterServiceSharedLoadBalancerHealthProbePort))
+			}
+
+			hc.Protocol = elbv2.ProtocolEnumHttp
+		}
+	case config.ClusterServiceLoadBalancerHealthProbeModeServiceNodePort, "":
+		// Configuration is already up to date as this is the default case.
+	default:
+		return healthCheckConfig{}, fmt.Errorf("Unsupported ClusterServiceLoadBalancerHealthProbeMode %v", c.cfg.Global.ClusterServiceLoadBalancerHealthProbeMode)
+	}
 
 	if _, err := parseInt64Annotation(svc.Annotations, ServiceAnnotationLoadBalancerHCInterval, &hc.Interval); err != nil {
 		return healthCheckConfig{}, err
@@ -2484,6 +2510,9 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 		}
 	} else {
 		klog.V(4).Infof("service %v does not need custom health checks", apiService.Name)
+		var hcPath string
+		hcPort := tcpHealthCheckPort
+
 		annotationProtocol := strings.ToLower(annotations[ServiceAnnotationLoadBalancerBEProtocol])
 		var hcProtocol string
 		if annotationProtocol == "https" || annotationProtocol == "ssl" {
@@ -2491,8 +2520,23 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 		} else {
 			hcProtocol = "TCP"
 		}
-		// there must be no path on TCP health check
-		err = c.ensureLoadBalancerHealthCheck(loadBalancer, hcProtocol, tcpHealthCheckPort, "", annotations)
+
+		if c.cfg.Global.ClusterServiceLoadBalancerHealthProbeMode == config.ClusterServiceLoadBalancerHealthProbeModeShared {
+			// Use the kube-proxy port as the health check port for non-local services.
+			hcProtocol = "HTTP"
+			hcPath = defaultKubeProxyHealthCheckPath
+			hcPort = int32(defaultKubeProxyHealthCheckPort)
+
+			if c.cfg.Global.ClusterServiceSharedLoadBalancerHealthProbePath != "" {
+				hcPath = c.cfg.Global.ClusterServiceSharedLoadBalancerHealthProbePath
+			}
+
+			if c.cfg.Global.ClusterServiceSharedLoadBalancerHealthProbePort != 0 {
+				hcPort = c.cfg.Global.ClusterServiceSharedLoadBalancerHealthProbePort
+			}
+		}
+
+		err = c.ensureLoadBalancerHealthCheck(loadBalancer, hcProtocol, hcPort, hcPath, annotations)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -68,6 +68,9 @@ var (
 	defaultHealthCheckPort         = "traffic-port"
 	defaultHealthCheckPath         = "/"
 
+	defaultKubeProxyHealthCheckPort = 10256
+	defaultKubeProxyHealthCheckPath = "/healthz"
+
 	// Defaults for ELB Target operations
 	defaultRegisterTargetsChunkSize   = 100
 	defaultDeregisterTargetsChunkSize = 100

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -3180,11 +3180,12 @@ func TestCloud_sortELBSecurityGroupList(t *testing.T) {
 
 func TestCloud_buildNLBHealthCheckConfiguration(t *testing.T) {
 	tests := []struct {
-		name        string
-		annotations map[string]string
-		service     *v1.Service
-		want        healthCheckConfig
-		wantError   bool
+		name         string
+		annotations  map[string]string
+		service      *v1.Service
+		modifyConfig func(*config.CloudConfig)
+		want         healthCheckConfig
+		wantError    bool
 	}{
 		{
 			name:        "default cluster",
@@ -3209,6 +3210,110 @@ func TestCloud_buildNLBHealthCheckConfiguration(t *testing.T) {
 			want: healthCheckConfig{
 				Port:               "traffic-port",
 				Protocol:           elbv2.ProtocolEnumTcp,
+				Interval:           30,
+				Timeout:            10,
+				HealthyThreshold:   3,
+				UnhealthyThreshold: 3,
+			},
+			wantError: false,
+		},
+		{
+			name:        "default cluster with shared health check",
+			annotations: map[string]string{},
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-svc",
+					UID:  "UID",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:       "http",
+							Protocol:   v1.ProtocolTCP,
+							Port:       8080,
+							TargetPort: intstr.FromInt(8880),
+							NodePort:   32205,
+						},
+					},
+				},
+			},
+			modifyConfig: func(cfg *config.CloudConfig) {
+				cfg.Global.ClusterServiceLoadBalancerHealthProbeMode = config.ClusterServiceLoadBalancerHealthProbeModeShared
+			},
+			want: healthCheckConfig{
+				Port:               "10256",
+				Protocol:           elbv2.ProtocolEnumHttp,
+				Path:               "/healthz",
+				Interval:           30,
+				Timeout:            10,
+				HealthyThreshold:   3,
+				UnhealthyThreshold: 3,
+			},
+			wantError: false,
+		},
+		{
+			name:        "default cluster with shared health check and custom port",
+			annotations: map[string]string{},
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-svc",
+					UID:  "UID",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:       "http",
+							Protocol:   v1.ProtocolTCP,
+							Port:       8080,
+							TargetPort: intstr.FromInt(8880),
+							NodePort:   32205,
+						},
+					},
+				},
+			},
+			modifyConfig: func(cfg *config.CloudConfig) {
+				cfg.Global.ClusterServiceLoadBalancerHealthProbeMode = config.ClusterServiceLoadBalancerHealthProbeModeShared
+				cfg.Global.ClusterServiceSharedLoadBalancerHealthProbePort = 8080
+			},
+			want: healthCheckConfig{
+				Port:               "8080",
+				Protocol:           elbv2.ProtocolEnumHttp,
+				Path:               "/healthz",
+				Interval:           30,
+				Timeout:            10,
+				HealthyThreshold:   3,
+				UnhealthyThreshold: 3,
+			},
+			wantError: false,
+		},
+		{
+			name:        "default cluster with shared health check and custom path",
+			annotations: map[string]string{},
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-svc",
+					UID:  "UID",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:       "http",
+							Protocol:   v1.ProtocolTCP,
+							Port:       8080,
+							TargetPort: intstr.FromInt(8880),
+							NodePort:   32205,
+						},
+					},
+				},
+			},
+			modifyConfig: func(cfg *config.CloudConfig) {
+				cfg.Global.ClusterServiceLoadBalancerHealthProbeMode = config.ClusterServiceLoadBalancerHealthProbeModeShared
+				cfg.Global.ClusterServiceSharedLoadBalancerHealthProbePath = "/custom-healthz"
+			},
+			want: healthCheckConfig{
+				Port:               "10256",
+				Protocol:           elbv2.ProtocolEnumHttp,
+				Path:               "/custom-healthz",
 				Interval:           30,
 				Timeout:            10,
 				HealthyThreshold:   3,
@@ -3457,7 +3562,14 @@ func TestCloud_buildNLBHealthCheckConfiguration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Cloud{}
+			c := &Cloud{
+				cfg: &config.CloudConfig{},
+			}
+
+			if tt.modifyConfig != nil {
+				tt.modifyConfig(c.cfg)
+			}
+
 			hc, err := c.buildNLBHealthCheckConfiguration(tt.service)
 			if !tt.wantError {
 				assert.Equal(t, tt.want, hc)

--- a/pkg/providers/v1/config/config.go
+++ b/pkg/providers/v1/config/config.go
@@ -2,12 +2,21 @@ package config
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/request"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 
 	"k8s.io/klog/v2"
+)
+
+const (
+	// ClusterServiceLoadBalancerHealthProbeModeShared is the shared health probe mode for cluster service load balancer.
+	ClusterServiceLoadBalancerHealthProbeModeShared = "Shared"
+
+	// ClusterServiceLoadBalancerHealthProbeModeServiceNodePort is the service node port health probe mode for cluster service load balancer.
+	ClusterServiceLoadBalancerHealthProbeModeServiceNodePort = "ServiceNodePort"
 )
 
 // CloudConfig wraps the settings for the AWS cloud provider.
@@ -62,6 +71,18 @@ type CloudConfig struct {
 
 		// NodeIPFamilies determines which IP addresses are added to node objects and their ordering.
 		NodeIPFamilies []string
+
+		// ClusterServiceLoadBalancerHealthProbeMode determines the health probe mode for cluster service load balancer.
+		// Supported values are `Shared` and `ServiceNodePort`.
+		// `ServiceeNodePort`: the health probe will be created against each port of each service by watching the backend application (default).
+		// `Shared`: all cluster services shares one HTTP probe targeting the kube-proxy on the node (<nodeIP>/healthz:10256).
+		ClusterServiceLoadBalancerHealthProbeMode string `json:"clusterServiceLoadBalancerHealthProbeMode,omitempty" yaml:"clusterServiceLoadBalancerHealthProbeMode,omitempty"`
+
+		// ClusterServiceSharedLoadBalancerHealthProbePort defines the target port of the shared health probe. Default to 10256.
+		ClusterServiceSharedLoadBalancerHealthProbePort int32 `json:"clusterServiceSharedLoadBalancerHealthProbePort,omitempty" yaml:"clusterServiceSharedLoadBalancerHealthProbePort,omitempty"`
+
+		// ClusterServiceSharedLoadBalancerHealthProbePath defines the target path of the shared health probe. Default to `/healthz`.
+		ClusterServiceSharedLoadBalancerHealthProbePath string `json:"clusterServiceSharedLoadBalancerHealthProbePath,omitempty" yaml:"clusterServiceSharedLoadBalancerHealthProbePath,omitempty"`
 	}
 	// [ServiceOverride "1"]
 	//  Service = s3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug


**What this PR does / why we need it**:

When a service is using the default configuration (ie they haven't changed any of port, path or protocol via annotations), this updates the health check to, rather then checking the traffic port, check the kube-proxy health endpoint.

This is deliberately done so that if a user has specified any change to the port/path/protocol, we do not change the behaviour of their health checks. But if they have no opinion at all, we give them an improved health check.

**Which issue(s) this PR fixes**:

[KEP 3458](https://github.com/kubernetes/enhancements/issues/3458) was added to the AWS provider in release 1.27. This means now that a nodes presence in the load balancer backends, is no longer determined by whether the instance is healthy or not.

We have observed long periods of disruption (15-20s) during upgrades with the AWS provider since this went in. The issue here is because the health check is checking the traffic port, and not the nodes ability to route traffic to the backend.

This is specifically for `exxternalTrafficPolicy: Cluster`. In this topology, all nodes in the cluster accept connections for the backend for the service, and then route that internally. So, unless all endpoints are down, the traffic port that is exposed will always return a healthy result. When a node is going away, it's ability to route the traffic from the traffic port to the backend, is based on whether kube-proxy is running or not. In fact, so much so, that actually, it makes more sense to health check kube-proxy.

When kube-proxy is being terminated, assuming you have configured graceful shutdown, it will return bad healthchecks for a period before shutting down. This allows the AWS health check to observe the node is going away, before it loses the ability to route traffic to the backend.
In the current guise, it only fails health checks after the node can no longer route traffic.

I did a lot of research into this earlier in the year and wrote up kubernetes-sigs/cloud-provider-azure#3499 which explains the problem in a little more depth, note as well, that GCP uses kube-proxy based health checks in this manner and we are working to move Azure over too.

There's also [KEP-3836](https://github.com/kubernetes/enhancements/issues/3836) which suggests this is the way to go forward as well.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Update health checks to use Kube-Proxy when no other configuration is provided
```
