### PR TITLE
Remove spurious space character in helm chart

### DIFF
--- a/charts/aws-cloud-controller-manager/values.yaml
+++ b/charts/aws-cloud-controller-manager/values.yaml
@@ -128,7 +128,7 @@ tolerations:
 # dnsPolicy -- dnsPolicy of deamonset pods. Should be set to Default if deployed as a deamonset on control-plane nodes to resolve properly
 dnsPolicy: Default
 
-clusterRoleName : system:cloud-controller-manager
+clusterRoleName: system:cloud-controller-manager
 
 roleBindingName: cloud-controller-manager:apiserver-authentication-reader
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The spurious character was introduced in the initial version of the helm chart.

YAML linters fail with errors similar to:

```
131:16    error    too many spaces before colon  (colons)
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
