### PR TITLE
Do not allow EC2 instance ID NotFound to succeed tagging

### DIFF
--- a/pkg/providers/v1/tags.go
+++ b/pkg/providers/v1/tags.go
@@ -322,10 +322,6 @@ func (c *Cloud) TagResource(resourceID string, tags map[string]string) error {
 	output, err := c.ec2.CreateTags(request)
 
 	if err != nil {
-		if isAWSErrorInstanceNotFound(err) {
-			klog.Infof("Couldn't find resource when trying to tag it hence skipping it, %v", err)
-			return nil
-		}
 		klog.Errorf("Error occurred trying to tag resources, %v", err)
 		return err
 	}
@@ -346,6 +342,8 @@ func (c *Cloud) UntagResource(resourceID string, tags map[string]string) error {
 	output, err := c.ec2.DeleteTags(request)
 
 	if err != nil {
+		// An instance not found should not fail the untagging workflow as it
+		// would for tagging, since the target state is already reached.
 		if isAWSErrorInstanceNotFound(err) {
 			klog.Infof("Couldn't find resource when trying to untag it hence skipping it, %v", err)
 			return nil

--- a/pkg/providers/v1/tags_test.go
+++ b/pkg/providers/v1/tags_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/klog/v2"
@@ -268,8 +269,8 @@ func TestTagResource(t *testing.T) {
 		{
 			name:            "tagging failed due to resource not found error",
 			instanceID:      "i-not-found",
-			err:             nil,
-			expectedMessage: "Couldn't find resource when trying to tag it hence skipping it",
+			err:             awserr.New("InvalidInstanceID.NotFound", "Instance not found", nil),
+			expectedMessage: "Error occurred trying to tag resources",
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Removes the graceful handling of `InvalidInstanceID.NotFound` error when attempting to `tag` an ec2 instance that has not fully come up. This has caused an issue where we've seen the tagging controller misleadingly exit successfully, not actually tagging the instance, and does not re-queue the item to (ideally) execute again once the instance becomes visible.

example log feed:
```log
tags.go:326] Couldn't find resource when trying to tag it hence skipping it, InvalidInstanceID.NotFound: The instance ID 'i-***' does not exist status code: 400, request id: ***
tagging_controller.go:299] Successfully tagged i-*** with map[aws:eks:cluster-name:***]. Labeling the nodes with tagging controller labels now.
tagging_controller.go:305] Successfully labeled node ip-***.compute.internal with map[k8s.io/cloud-provider-aws:***].
```

This behavior *does* satisfy the `untag` action, since removing the tag from a non-existing instance is a no-op, so no changes need to be made there.

Its worth mentioning the initial PR to gracefully handle this (https://github.com/kubernetes/cloud-provider-aws/pull/448) aimed to fix all cases discussed in issue https://github.com/kubernetes/cloud-provider-aws/issues/444 where the untracked `InvalidInstanceID.NotFound` errors were valid failure modes in the context of instance termination. 

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: N/A

**Does this PR introduce a user-facing change?**: NONE
