### PR TITLE
Automated cherry pick of #667: Handle private ECR image references containing public.ecr.aws

### DIFF
--- a/cmd/ecr-credential-provider/main.go
+++ b/cmd/ecr-credential-provider/main.go
@@ -36,7 +36,10 @@ import (
 	"k8s.io/kubelet/pkg/apis/credentialprovider/v1alpha1"
 )
 
-var ecrPattern = regexp.MustCompile(`^(\d{12})\.dkr\.ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(\.cn)?|sc2s\.sgov\.gov|c2s\.ic\.gov)$`)
+const ecrPublicRegion string = "us-east-1"
+const ecrPublicHost string = "public.ecr.aws"
+
+var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr\.ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(\.cn)?|sc2s\.sgov\.gov|c2s\.ic\.gov)$`)
 
 // ECR abstracts the calls we make to aws-sdk for testing purposes
 type ECR interface {
@@ -59,22 +62,37 @@ func defaultECRProvider(region string, registryID string) (*ecr.ECR, error) {
 	return ecr.New(sess), nil
 }
 
-func (e *ecrPlugin) GetCredentials(ctx context.Context, image string, args []string) (*v1alpha1.CredentialProviderResponse, error) {
-	registryID, region, registry, err := parseRepoURL(image)
+func publicECRProvider() (*ecrpublic.ECRPublic, error) {
+	// ECR public registries are only in one region and only accessible from regions
+	// in the "aws" partition.
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config:            aws.Config{Region: aws.String(ecrPublicRegion)},
+		SharedConfigState: session.SharedConfigEnable,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	if e.ecr == nil {
-		e.ecr, err = defaultECRProvider(region, registryID)
-		if err != nil {
-			return nil, err
-		}
+	return ecrpublic.New(sess), nil
+}
+
+type credsData struct {
+	authToken *string
+	expiresAt *time.Time
+}
+
+func (e *ecrPlugin) getPublicCredsData() (*credsData, error) {
+	klog.Infof("Getting creds for public registry")
+	var err error
+
+	if e.ecrPublic == nil {
+		e.ecrPublic, err = publicECRProvider()
+	}
+	if err != nil {
+		return nil, err
 	}
 
-	output, err := e.ecr.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{
-		RegistryIds: []*string{aws.String(registryID)},
-	})
+	output, err := e.ecrPublic.GetAuthorizationToken(&ecrpublic.GetAuthorizationTokenInput{})
 	if err != nil {
 		return nil, err
 	}
@@ -83,12 +101,64 @@ func (e *ecrPlugin) GetCredentials(ctx context.Context, image string, args []str
 		return nil, errors.New("response output from ECR was nil")
 	}
 
-	if len(output.AuthorizationData) == 0 {
+	if output.AuthorizationData == nil {
 		return nil, errors.New("authorization data was empty")
 	}
 
-	data := output.AuthorizationData[0]
-	if data.AuthorizationToken == nil {
+	return &credsData{
+		authToken: output.AuthorizationData.AuthorizationToken,
+		expiresAt: output.AuthorizationData.ExpiresAt,
+	}, nil
+}
+
+func (e *ecrPlugin) getPrivateCredsData(imageHost string, image string) (*credsData, error) {
+	klog.Infof("Getting creds for private image %s", image)
+	region, err := parseRegionFromECRPrivateHost(imageHost)
+	if err != nil {
+		return nil, err
+	}
+	if e.ecr == nil {
+		e.ecr, err = defaultECRProvider(region, registryID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	output, err := e.ecr.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{})
+	if err != nil {
+		return nil, err
+	}
+	if output == nil {
+		return nil, errors.New("response output from ECR was nil")
+	}
+	if len(output.AuthorizationData) == 0 {
+		return nil, errors.New("authorization data was empty")
+	}
+	return &credsData{
+		authToken: output.AuthorizationData[0].AuthorizationToken,
+		expiresAt: output.AuthorizationData[0].ExpiresAt,
+	}, nil
+}
+
+func (e *ecrPlugin) GetCredentials(ctx context.Context, image string, args []string) (*v1alpha1.CredentialProviderResponse, error) {
+	var creds *credsData
+	var err error
+
+	imageHost, err := parseHostFromImageReference(image)
+	if err != nil {
+		return nil, err
+	}
+
+	if imageHost == ecrPublicHost {
+		creds, err = e.getPublicCredsData()
+	} else {
+		creds, err = e.getPrivateCredsData(imageHost, image)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if creds.authToken == nil {
 		return nil, errors.New("authorization token in response was nil")
 	}
 
@@ -108,7 +178,7 @@ func (e *ecrPlugin) GetCredentials(ctx context.Context, image string, args []str
 		CacheKeyType:  v1alpha1.RegistryPluginCacheKeyType,
 		CacheDuration: cacheDuration,
 		Auth: map[string]v1alpha1.AuthConfig{
-			registry: {
+			imageHost: {
 				Username: parts[0],
 				Password: parts[1],
 			},
@@ -135,24 +205,25 @@ func getCacheDuration(expiresAt *time.Time) *metav1.Duration {
 	return cacheDuration
 }
 
-// parseRepoURL parses and splits the registry URL
-// returns (registryID, region, registry).
-// <registryID>.dkr.ecr(-fips).<region>.amazonaws.com(.cn)
-func parseRepoURL(image string) (string, string, string, error) {
-	if !strings.Contains(image, "https://") {
+// parseHostFromImageReference parses the hostname from an image reference
+func parseHostFromImageReference(image string) (string, error) {
+	// a URL needs a scheme to be parsed correctly
+	if !strings.Contains(image, "://") {
 		image = "https://" + image
 	}
 	parsed, err := url.Parse(image)
 	if err != nil {
-		return "", "", "", fmt.Errorf("error parsing image %s: %v", image, err)
+		return "", fmt.Errorf("error parsing image reference %s: %v", image, err)
 	}
+	return parsed.Hostname(), nil
+}
 
-	splitURL := ecrPattern.FindStringSubmatch(parsed.Hostname())
-	if len(splitURL) < 4 {
-		return "", "", "", fmt.Errorf("%s is not a valid ECR repository URL", parsed.Hostname())
+func parseRegionFromECRPrivateHost(host string) (string, error) {
+	splitHost := ecrPrivateHostPattern.FindStringSubmatch(host)
+	if len(splitHost) != 6 {
+		return "", fmt.Errorf("invalid private ECR host: %s", host)
 	}
-
-	return splitURL[1], splitURL[3], parsed.Hostname(), nil
+	return splitHost[3], nil
 }
 
 func main() {

--- a/cmd/ecr-credential-provider/main_test.go
+++ b/cmd/ecr-credential-provider/main_test.go
@@ -80,6 +80,12 @@ func Test_GetCredentials(t *testing.T) {
 			response:                    generateResponse("123456789123.dkr.ecr.us-west-2.amazonaws.com", "user", "pass"),
 		},
 		{
+			name:                        "image reference containing public ECR host",
+			image:                       "123456789123.dkr.ecr.us-west-2.amazonaws.com/public.ecr.aws/foo:latest",
+			getAuthorizationTokenOutput: generatePrivateGetAuthorizationTokenOutput("user", "pass", "", nil),
+			response:                    generateResponse("123456789123.dkr.ecr.us-west-2.amazonaws.com", "user", "pass"),
+		},
+		{
 			name:                        "empty authorization data",
 			image:                       "123456789123.dkr.ecr.us-west-2.amazonaws.com",
 			getAuthorizationTokenOutput: &ecr.GetAuthorizationTokenOutput{},
@@ -148,59 +154,187 @@ func Test_GetCredentials(t *testing.T) {
 	}
 }
 
-func Test_ParseURL(t *testing.T) {
+func generatePublicGetAuthorizationTokenOutput(user string, password string, proxy string, expiration *time.Time) *ecrpublic.GetAuthorizationTokenOutput {
+	creds := []byte(fmt.Sprintf("%s:%s", user, password))
+	data := &ecrpublic.AuthorizationData{
+		AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString(creds)),
+		ExpiresAt:          expiration,
+	}
+	output := &ecrpublic.GetAuthorizationTokenOutput{
+		AuthorizationData: data,
+	}
+	return output
+}
+
+func Test_GetCredentials_Public(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockECRPublic := mocks.NewMockECRPublic(ctrl)
+
 	testcases := []struct {
-		name       string
-		image      string
-		registryID string
-		region     string
-		registry   string
-		err        error
+		name                        string
+		image                       string
+		args                        []string
+		getAuthorizationTokenOutput *ecrpublic.GetAuthorizationTokenOutput
+		getAuthorizationTokenError  error
+		response                    *v1alpha1.CredentialProviderResponse
+		expectedError               error
 	}{
 		{
-			name:       "success",
-			image:      "123456789123.dkr.ecr.us-west-2.amazonaws.com",
-			registryID: "123456789123",
-			region:     "us-west-2",
-			registry:   "123456789123.dkr.ecr.us-west-2.amazonaws.com",
-			err:        nil,
+			name:                        "success",
+			image:                       "public.ecr.aws",
+			getAuthorizationTokenOutput: generatePublicGetAuthorizationTokenOutput("user", "pass", "", nil),
+			response:                    generateResponse("public.ecr.aws", "user", "pass"),
 		},
 		{
-			name:       "invalid registry",
-			image:      "foobar",
-			registryID: "",
-			region:     "",
-			registry:   "",
-			err:        errors.New("foobar is not a valid ECR repository URL"),
+			name:                        "empty authorization data",
+			image:                       "public.ecr.aws",
+			getAuthorizationTokenOutput: &ecrpublic.GetAuthorizationTokenOutput{},
+			getAuthorizationTokenError:  nil,
+			expectedError:               errors.New("authorization data was empty"),
 		},
 		{
-			name:       "invalid URL",
-			image:      "foobar  ",
-			registryID: "",
-			region:     "",
-			registry:   "",
-			err:        errors.New("error parsing image https://foobar  : parse \"https://foobar  \": invalid character \" \" in host name"),
+			name:                        "nil response",
+			image:                       "public.ecr.aws",
+			getAuthorizationTokenOutput: nil,
+			getAuthorizationTokenError:  nil,
+			expectedError:               errors.New("response output from ECR was nil"),
+		},
+		{
+			name:                        "empty authorization token",
+			image:                       "public.ecr.aws",
+			getAuthorizationTokenOutput: &ecrpublic.GetAuthorizationTokenOutput{AuthorizationData: &ecrpublic.AuthorizationData{}},
+			getAuthorizationTokenError:  nil,
+			expectedError:               errors.New("authorization token in response was nil"),
+		},
+		{
+			name:                        "invalid authorization token",
+			image:                       "public.ecr.aws",
+			getAuthorizationTokenOutput: nil,
+			getAuthorizationTokenError:  errors.New("getAuthorizationToken failed"),
+			expectedError:               errors.New("getAuthorizationToken failed"),
+		},
+		{
+			name:  "invalid authorization token",
+			image: "public.ecr.aws",
+			getAuthorizationTokenOutput: &ecrpublic.GetAuthorizationTokenOutput{
+				AuthorizationData: &ecrpublic.AuthorizationData{
+					AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte(fmt.Sprint("foo")))),
+				},
+			},
+			getAuthorizationTokenError: nil,
+			expectedError:              errors.New("error parsing username and password from authorization token"),
 		},
 	}
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			registryID, region, registry, err := parseRepoURL(testcase.image)
+			p := &ecrPlugin{ecrPublic: mockECRPublic}
+			mockECRPublic.EXPECT().GetAuthorizationToken(gomock.Any()).Return(testcase.getAuthorizationTokenOutput, testcase.getAuthorizationTokenError)
+
+			creds, err := p.GetCredentials(context.TODO(), testcase.image, testcase.args)
+
+			if testcase.expectedError != nil && (testcase.expectedError.Error() != err.Error()) {
+				t.Fatalf("expected %s, got %s", testcase.expectedError.Error(), err.Error())
+			}
+
+			if testcase.expectedError == nil {
+				if creds.CacheKeyType != testcase.response.CacheKeyType {
+					t.Fatalf("Unexpected CacheKeyType. Expected: %s, got: %s", testcase.response.CacheKeyType, creds.CacheKeyType)
+				}
+
+				if creds.Auth[testcase.image] != testcase.response.Auth[testcase.image] {
+					t.Fatalf("Unexpected Auth. Expected: %s, got: %s", testcase.response.Auth[testcase.image], creds.Auth[testcase.image])
+				}
+
+				if creds.CacheDuration.Duration != testcase.response.CacheDuration.Duration {
+					t.Fatalf("Unexpected CacheDuration. Expected: %s, got: %s", testcase.response.CacheDuration.Duration, creds.CacheDuration.Duration)
+				}
+			}
+		})
+	}
+}
+
+func Test_parseHostFromImageReference(t *testing.T) {
+	testcases := []struct {
+		name  string
+		image string
+		host  string
+		err   error
+	}{
+		{
+			name:  "success",
+			image: "123456789123.dkr.ecr.us-west-2.amazonaws.com/foo/bar:1.0",
+			host:  "123456789123.dkr.ecr.us-west-2.amazonaws.com",
+			err:   nil,
+		},
+		{
+			name:  "existing scheme",
+			image: "http://foobar",
+			host:  "foobar",
+			err:   nil,
+		},
+		{
+			name:  "invalid URL",
+			image: "foobar  ",
+			host:  "",
+			err:   errors.New("error parsing image reference https://foobar  : parse \"https://foobar  \": invalid character \" \" in host name"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			host, err := parseHostFromImageReference(testcase.image)
 
 			if testcase.err != nil && (testcase.err.Error() != err.Error()) {
 				t.Fatalf("expected error %s, got %s", testcase.err, err)
 			}
 
-			if registryID != testcase.registryID {
-				t.Fatalf("registryID mismatch. Expected %s, got %s", testcase.registryID, registryID)
+			if host != testcase.host {
+				t.Fatalf("registry mismatch. Expected %s, got %s", testcase.host, host)
+			}
+		})
+	}
+}
+
+func Test_parseRegionFromECRPrivateHost(t *testing.T) {
+	testcases := []struct {
+		name   string
+		host   string
+		region string
+		err    error
+	}{
+		{
+			name:   "success",
+			host:   "123456789123.dkr.ecr.us-west-2.amazonaws.com",
+			region: "us-west-2",
+			err:    nil,
+		},
+		{
+			name:   "invalid registry",
+			host:   "foobar",
+			region: "",
+			err:    errors.New("invalid private ECR host: foobar"),
+		},
+		{
+			name:   "invalid host",
+			host:   "foobar ",
+			region: "",
+			err:    errors.New("invalid private ECR host: foobar "),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			region, err := parseRegionFromECRPrivateHost(testcase.host)
+
+			if testcase.err != nil && (testcase.err.Error() != err.Error()) {
+				t.Fatalf("expected error %s, got %s", testcase.err, err)
 			}
 
 			if region != testcase.region {
 				t.Fatalf("region mismatch. Expected %s, got %s", testcase.region, region)
-			}
-
-			if registry != testcase.registry {
-				t.Fatalf("registry mismatch. Expected %s, got %s", testcase.registry, registry)
 			}
 		})
 	}
@@ -242,7 +376,7 @@ func TestRegistryPatternMatch(t *testing.T) {
 		{"123456789012.lala-land-1.amazonaws.com", false},
 	}
 	for _, g := range grid {
-		actual := ecrPattern.MatchString(g.Registry)
+		actual := ecrPrivateHostPattern.MatchString(g.Registry)
 		if actual != g.Expected {
 			t.Errorf("unexpected pattern match value, want %v for %s", g.Expected, g.Registry)
 		}


### PR DESCRIPTION
Cherry pick of #667 on release-1.26.

#667: Handle private ECR image references containing public.ecr.aws

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```