### PR TITLE
[release-1.26] Automated cherry pick of #674: do not allow ec2 instance ID not found in tagging path

### DIFF
--- a/pkg/providers/v1/tags.go
+++ b/pkg/providers/v1/tags.go
@@ -322,10 +322,6 @@ func (c *Cloud) TagResource(resourceID string, tags map[string]string) error {
 	output, err := c.ec2.CreateTags(request)
 
 	if err != nil {
-		if isAWSErrorInstanceNotFound(err) {
-			klog.Infof("Couldn't find resource when trying to tag it hence skipping it, %v", err)
-			return nil
-		}
 		klog.Errorf("Error occurred trying to tag resources, %v", err)
 		return err
 	}
@@ -346,6 +342,8 @@ func (c *Cloud) UntagResource(resourceID string, tags map[string]string) error {
 	output, err := c.ec2.DeleteTags(request)
 
 	if err != nil {
+		// An instance not found should not fail the untagging workflow as it
+		// would for tagging, since the target state is already reached.
 		if isAWSErrorInstanceNotFound(err) {
 			klog.Infof("Couldn't find resource when trying to untag it hence skipping it, %v", err)
 			return nil

--- a/pkg/providers/v1/tags_test.go
+++ b/pkg/providers/v1/tags_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/klog/v2"
@@ -268,8 +269,8 @@ func TestTagResource(t *testing.T) {
 		{
 			name:            "tagging failed due to resource not found error",
 			instanceID:      "i-not-found",
-			err:             nil,
-			expectedMessage: "Couldn't find resource when trying to tag it hence skipping it",
+			err:             awserr.New("InvalidInstanceID.NotFound", "Instance not found", nil),
+			expectedMessage: "Error occurred trying to tag resources",
 		},
 	}
 


### PR DESCRIPTION
Cherry pick of #674 on release-1.26.

#674: do not allow ec2 instance ID not found in tagging path

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes an issue where `InvalidInstanceID.NotFound` error did not re-queue the tagging work item  
```