### PR TITLE
[release-1.23] Pin kops version to 1.28

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -138,7 +138,7 @@ if [[ "${UP}" = "yes" ]]; then
       --admin-access="0.0.0.0/0" \
       --kubernetes-version="${KUBERNETES_VERSION}" \
       --ssh-public-key="${SSH_PUBLIC_KEY_PATH}" \
-      --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+      --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
 
       # Use the kops tester once we have a way of consuming an arbitrary e2e.test binary.
       #--test=kops \


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

kops 1.28 is the last version that supports Kubernetes 1.23; this will fix the CI on release-1.23 and we can merge the pending PR's.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE