### PR TITLE
[release-1.27] update go to 1.20.10

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.20.3-bullseye.0
+defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.20.10-bullseye.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.20.3
+ARG GOLANG_IMAGE=golang:1.20.10
 
 # The distroless image on which the CPI manager image is built.
 #
@@ -22,7 +22,7 @@ ARG GOLANG_IMAGE=golang:1.20.3
 # deterministic builds. Follow what kubernetes uses to build
 # kube-controller-manager, for example for 1.23.x:
 # https://github.com/kubernetes/kubernetes/blob/release-1.24/build/common.sh#L94
-ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.3.1-go1.20.3-bullseye.0
+ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.3.1-go1.20.10-bullseye.0
 
 ################################################################################
 ##                              BUILD STAGE                                   ##

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
     - --platform=linux/amd64,linux/arm64
     - .
   # Build cloudbuild artifacts (for attestation)
-  - name: 'docker.io/library/golang:1.19.5-bullseye'
+  - name: 'docker.io/library/golang:1.20.10-bullseye'
     id: cloudbuild-artifacts
     entrypoint: make
     env:


### PR DESCRIPTION
Bump the go version which contains the security fixes for CVE-2023-39325.