### PR TITLE
fix(controllers/tagging): fix log format string

### DIFF
--- a/pkg/controllers/tagging/tagging_controller.go
+++ b/pkg/controllers/tagging/tagging_controller.go
@@ -16,6 +16,10 @@ package tagging
 import (
 	"crypto/md5"
 	"fmt"
+	"sort"
+	"strings"
+	"time"
+
 	"golang.org/x/time/rate"
 	v1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -29,9 +33,6 @@ import (
 	awsv1 "k8s.io/cloud-provider-aws/pkg/providers/v1"
 	nodehelpers "k8s.io/cloud-provider/node/helpers"
 	"k8s.io/klog/v2"
-	"sort"
-	"strings"
-	"time"
 )
 
 // workItem contains the node and an action for that node
@@ -213,7 +214,7 @@ func (tc *Controller) process() bool {
 
 		timeTaken := time.Since(workItem.enqueueTime).Seconds()
 		recordWorkItemLatencyMetrics(workItemDequeuingTimeWorkItemMetric, timeTaken)
-		klog.Infof("Dequeuing latency %s", timeTaken)
+		klog.Infof("Dequeuing latency %f seconds", timeTaken)
 
 		instanceID, err := awsv1.KubernetesInstanceID(workItem.node.Spec.ProviderID).MapToAWSInstanceID()
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

 /kind cleanup

**What this PR does / why we need it**:

Fix cloud controler manager logs:

> I1101 15:10:22.564856 11 tagging_controller.go:216] Dequeuing latency %!s(float64=0.000102683)

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
