### PR TITLE
Cherry pick of #675: Stricter dependency/security review & update go version #720: update the go version to 1.21.3 

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,0 +1,31 @@
+name: "Dependency Review"
+on: [push, pull_request, workflow_dispatch]
+permissions:
+  contents: read
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: "Dependency Review"
+        uses: actions/dependency-review-action@v3
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: 1.21.3
+          go-version-file: go.mod
+      - id: govulncheck-tests-e2e
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: 1.21.3
+          go-version-file: tests/e2e/go.mod

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.20.2-bullseye.0
+defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.21.3-bookworm.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.20.2
+ARG GOLANG_IMAGE=golang:1.21.3
 
 # The distroless image on which the CPI manager image is built.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG GOLANG_IMAGE=golang:1.21.3
 # deterministic builds. Follow what kubernetes uses to build
 # kube-controller-manager, for example for 1.23.x:
 # https://github.com/kubernetes/kubernetes/blob/release-1.24/build/common.sh#L94
-ARG DISTROLESS_IMAGE=k8s.gcr.io/build-image/go-runner:v2.3.1-go1.20.2-bullseye.0
+ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.3.1-go1.21.3-bookworm.0
 
 ################################################################################
 ##                              BUILD STAGE                                   ##

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,13 +7,22 @@ steps:
   - name: gcr.io/k8s-testimages/gcb-docker-gcloud
     entrypoint: /buildx-entrypoint
     args:
-    - build
-    - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:$_SHORT_TAG
-    - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:latest
-    - --build-arg=VERSION=$_SHORT_TAG
-    - --output=type=registry
-    - --platform=linux/amd64,linux/arm64
-    - .
+      - build
+      - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:$_SHORT_TAG
+      - --tag=gcr.io/$PROJECT_ID/cloud-controller-manager:latest
+      - --build-arg=VERSION=$_SHORT_TAG
+      - --output=type=registry
+      - --platform=linux/amd64,linux/arm64
+      - .
+  # Build cloudbuild artifacts (for attestation)
+  - name: 'docker.io/library/golang:1.21.3-bookworm'
+    id: cloudbuild-artifacts
+    entrypoint: make
+    env:
+      - PULL_BASE_REF=$_PULL_BASE_REF
+      - LATEST_FILE=markers/${_PULL_BASE_REF}/latest-tag.txt
+    args:
+      - cloudbuild-artifacts
 substitutions:
   _GIT_TAG: 'v99999999-v12345'
   # Remove date prefix (first 10 characters) to create valid semver version:


### PR DESCRIPTION
Cherry pick of https://github.com/kubernetes/cloud-provider-aws/pull/675 https://github.com/kubernetes/cloud-provider-aws/pull/720 on release-1.25.

https://github.com/kubernetes/cloud-provider-aws/pull/675: Stricter dependency/security review & update go version
https://github.com/kubernetes/cloud-provider-aws/pull/720: update the go version to 1.21.3