### PR TITLE
fix(pkg/controllers/tagging): correct logging message for seconds

### DIFF
--- a/pkg/controllers/tagging/tagging_controller.go
+++ b/pkg/controllers/tagging/tagging_controller.go
@@ -248,7 +248,7 @@ func (tc *Controller) process() bool {
 			klog.Infof("Finished processing %s", workItem)
 			timeTaken = time.Since(workItem.enqueueTime).Seconds()
 			recordWorkItemLatencyMetrics(workItemProcessingTimeWorkItemMetric, timeTaken)
-			klog.Infof("Processing latency %s", timeTaken)
+			klog.Infof("Processing latency %f seconds", timeTaken)
 		}
 
 		tc.workqueue.Forget(obj)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**: Similar to https://github.com/kubernetes/cloud-provider-aws/pull/712, fix logging format.

> I1107 17:47:44.958671 11 tagging_controller.go:250] Processing latency %!s(float64=0.565427747)

should be "Processing latency 0.565427747 seconds".

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: Thanks.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
