### PR TITLE
Update the go version to 1.21.4

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -22,10 +22,10 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.21.3
+          go-version-input: 1.21.4
           go-version-file: go.mod
       - id: govulncheck-tests-e2e
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.21.3
+          go-version-input: 1.21.4
           go-version-file: tests/e2e/go.mod

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.21.3-bookworm.0
+defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.21.4-bookworm.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.21.3
+ARG GOLANG_IMAGE=golang:1.21.4
 
 # The distroless image on which the CPI manager image is built.
 #
@@ -22,7 +22,7 @@ ARG GOLANG_IMAGE=golang:1.21.3
 # deterministic builds. Follow what kubernetes uses to build
 # kube-controller-manager, for example for 1.23.x:
 # https://github.com/kubernetes/kubernetes/blob/release-1.24/build/common.sh#L94
-ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.3.1-go1.21.3-bookworm.0
+ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.3.1-go1.21.4-bookworm.0
 
 ################################################################################
 ##                              BUILD STAGE                                   ##

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
       - --platform=linux/amd64,linux/arm64
       - .
   # Build cloudbuild artifacts (for attestation)
-  - name: 'docker.io/library/golang:1.21.3-bookworm'
+  - name: 'docker.io/library/golang:1.21.4-bookworm'
     id: cloudbuild-artifacts
     entrypoint: make
     env:


### PR DESCRIPTION
**What type of PR is this?**

 /kind cleanup


**What this PR does / why we need it**:
Update the go version to 1.21.4 to fix the CVE https://www.cve.org/CVERecord?id=CVE-2023-45283
 https://pkg.go.dev/vuln/GO-2023-2185

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Updated GO version to  1.21.4 to fix CVE-2023-45283 
```