### PR TITLE
Ci: Add support for generating SBOM on release

### DIFF
--- a/.github/workflows/helm_chart_release.yaml
+++ b/.github/workflows/helm_chart_release.yaml
@@ -20,23 +20,12 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install bom
+        uses: kubernetes-sigs/release-actions/setup-bom@dd08496c83441d6477114cc0555b96d404dacff7 # v0.1.2
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           config: .github/cr.yaml
-
-  generate-sbom:
-    runs-on: ubuntu-latest
-
-    permissions: {}
-
-    name: Install bom and test presence in path
-    steps:
-      - name: Install bom
-        uses: puerco/release-actions/setup-bom@main
-        with:
-          bom-release: '0.5.1'
-      - name: Check install!
-        run: bom version

--- a/.github/workflows/helm_chart_release.yaml
+++ b/.github/workflows/helm_chart_release.yaml
@@ -26,3 +26,17 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           config: .github/cr.yaml
+
+  generate-sbom:
+    runs-on: ubuntu-latest
+
+    permissions: {}
+
+    name: Install bom and test presence in path
+    steps:
+      - name: Install bom
+        uses: puerco/release-actions/setup-bom@main
+        with:
+          bom-release: '0.5.1'
+      - name: Check install!
+        run: bom version


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR adds Software Bill of Materials (SBOM) Generation to the release action. This change is part of the Kubernetes Security Slam Event, where we improve the security documentation of the project.   

This change has not been tested, and must be verified by the maintainers to ensure that the action is generating the right SBOM. The action is part of the [Kubernetes Release SIG's github actions](https://github.com/kubernetes-sigs/release-actions).

Tagging @puerco to take a look

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE
