### PR TITLE
Fix dependency review workflow

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,5 +1,22 @@
 name: "Dependency Review"
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+      - 'release-*'
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      head_ref:
+        description: 'HEAD git reference (tag/branch/commit) to analyze'
+        required: true
+        default: 'master'
+        type: string
+      base_ref: 
+        description: 'Base git reference (tag/branch/commit) to compare against head_ref'
+        required: true
+        default: 'master'
+        type: string
 permissions:
   contents: read
 jobs:
@@ -12,6 +29,9 @@ jobs:
           show-progress: false
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v3
+        with:
+          base-ref: ${{ inputs.base_ref || github.event.pull_request.base.sha || 'master' }}
+          head-ref: ${{ inputs.head_ref || github.event.pull_request.head.sha || github.ref }}
   govulncheck:
     runs-on: ubuntu-latest
     steps:

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,14 +23,14 @@
     <img alt="GitHub release (latest SemVer including pre-releases)" src="https://img.shields.io/github/v/release/kubernetes/cloud-provider-aws?include_prereleases">
 </p>
 <p align="center">
-    <a href="https://github.com/kubernetes/cloud-provider-aws/issues">
-        <img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat" alt="contributions welcome"/>
-    </a>
     <a href="https://github.com/kubernetes/cloud-provider-aws/blob/master/LICENSE">
         <img alt="GitHub license" src="https://img.shields.io/github/license/kubernetes/cloud-provider-aws">
     </a>
-    <a href="https://goreportcard.com/badge/github.com/kubernetes/cloud-provider-aws">
+    <a href="https://goreportcard.com/report/github.com/kubernetes/cloud-provider-aws">
         <img src="https://goreportcard.com/badge/github.com/kubernetes/cloud-provider-aws" alt="go report card"/>
+    </a>
+    <a href="https://github.com/kubernetes/cloud-provider-aws/actions/workflows/deps.yml">
+        <img src="https://github.com/kubernetes/cloud-provider-aws/actions/workflows/deps.yml/badge.svg" alt="Dependency Review"/>
     </a>
 </p>
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

**What this PR does / why we need it**:

Trying to fix the dependency review workflow, which is misconfigured for `push` and `workflow_dispatch` events.

Also adds a status badge for this workflow to the README, and removes the "contributions welcome" bade, which I think is clutter. Also fixes the href for the go report card to link to the actual report, not the status badge.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
