### PR TITLE
[release-1.23] Pin kubetest2-kops to last-working commit

### DIFF
--- a/hack/install-e2e-tools.sh
+++ b/hack/install-e2e-tools.sh
@@ -41,6 +41,11 @@ fi
 
 cd "${KOPS_ROOT}/tests/e2e" > /dev/null
 
+# kops deployer began passing a flag that does not exist (--interval) in the older version that supports k8s 1.23
+# see: https://github.com/kubernetes/kops/commit/3f171475717fcf67fc98c652bd4eea10f8664d88
+# so, we'll pin the kops deployer/tester to the previous commit
+git checkout 40ec87b0f7f0aac0c4a2344e984623dcd2ea1c20
+
 echo " + Installing kubetest2-tester-kops"
 go install ./kubetest2-tester-kops
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

CI is broken for release-1.23 branch because of a change in the kubetest2-kops deployer. This pins it to the last-working commit.

Example failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/cloud-provider-aws/798/pull-cloud-provider-aws-e2e/1739308772402139136

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
