### PR TITLE
Cherrypick 1.28: use subnets of ensured NLBs when update worker node SG rules

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -4124,13 +4124,13 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 
 	if isNLB(annotations) {
 		// Find the subnets that the ELB will live in
-		subnetIDs, err := c.getLoadBalancerSubnets(apiService, internalELB)
+		discoveredSubnetIDs, err := c.getLoadBalancerSubnets(apiService, internalELB)
 		if err != nil {
 			klog.Errorf("Error listing subnets in VPC: %q", err)
 			return nil, err
 		}
 		// Bail out early if there are no subnets
-		if len(subnetIDs) == 0 {
+		if len(discoveredSubnetIDs) == 0 {
 			return nil, fmt.Errorf("could not find any suitable subnets for creating the ELB")
 		}
 
@@ -4147,7 +4147,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 			loadBalancerName,
 			v2Mappings,
 			instanceIDs,
-			subnetIDs,
+			discoveredSubnetIDs,
 			internalELB,
 			annotations,
 		)
@@ -4155,7 +4155,21 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 			return nil, err
 		}
 
-		subnetCidrs, err := c.getSubnetCidrs(subnetIDs)
+		// try to get the existing subnets of existing LBs from AZs
+		var ensuredSubnetIDs []string
+		var subnetCidrs []string
+		for _, az := range v2LoadBalancer.AvailabilityZones {
+			ensuredSubnetIDs = append(ensuredSubnetIDs, *az.SubnetId)
+		}
+		// for newly created LBs, the ensured subnets are nil since the loadbalancer.AvailabilityZones are none
+		// we use discovered subnets in this case
+		if len(ensuredSubnetIDs) == 0 {
+			klog.Infof("did not find existing subnets on LB %s, use discovered subnets %d", loadBalancerName, discoveredSubnetIDs)
+			subnetCidrs, err = c.getSubnetCidrs(discoveredSubnetIDs)
+		} else {
+			klog.Infof("use exising subnets on LB %s, subnet IDs: %d", loadBalancerName, ensuredSubnetIDs)
+			subnetCidrs, err = c.getSubnetCidrs(ensuredSubnetIDs)
+		}
 		if err != nil {
 			klog.Errorf("Error getting subnet cidrs: %q", err)
 			return nil, err

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -4155,21 +4155,16 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 			return nil, err
 		}
 
-		// try to get the existing subnets of existing LBs from AZs
+		// try to get the ensured subnets of the LBs from AZs
 		var ensuredSubnetIDs []string
 		var subnetCidrs []string
 		for _, az := range v2LoadBalancer.AvailabilityZones {
 			ensuredSubnetIDs = append(ensuredSubnetIDs, *az.SubnetId)
 		}
-		// for newly created LBs, the ensured subnets are nil since the loadbalancer.AvailabilityZones are none
-		// we use discovered subnets in this case
 		if len(ensuredSubnetIDs) == 0 {
-			klog.Infof("did not find existing subnets on LB %s, use discovered subnets %d", loadBalancerName, discoveredSubnetIDs)
-			subnetCidrs, err = c.getSubnetCidrs(discoveredSubnetIDs)
-		} else {
-			klog.Infof("use exising subnets on LB %s, subnet IDs: %d", loadBalancerName, ensuredSubnetIDs)
-			subnetCidrs, err = c.getSubnetCidrs(ensuredSubnetIDs)
+			return nil, fmt.Errorf("did not find ensured subnets on LB %s", loadBalancerName)
 		}
+		subnetCidrs, err = c.getSubnetCidrs(ensuredSubnetIDs)
 		if err != nil {
 			klog.Errorf("Error getting subnet cidrs: %q", err)
 			return nil, err

--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -138,7 +138,7 @@ func getKeyValuePropertiesFromAnnotation(annotations map[string]string, annotati
 }
 
 // ensureLoadBalancerv2 ensures a v2 load balancer is created
-func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBalancerName string, mappings []nlbPortMapping, instanceIDs, subnetIDs []string, internalELB bool, annotations map[string]string) (*elbv2.LoadBalancer, error) {
+func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBalancerName string, mappings []nlbPortMapping, instanceIDs, discoveredSubnetIDs []string, internalELB bool, annotations map[string]string) (*elbv2.LoadBalancer, error) {
 	loadBalancer, err := c.describeLoadBalancerv2(loadBalancerName)
 	if err != nil {
 		return nil, err
@@ -165,14 +165,14 @@ func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBa
 		var allocationIDs []string
 		if eipList, present := annotations[ServiceAnnotationLoadBalancerEIPAllocations]; present {
 			allocationIDs = strings.Split(eipList, ",")
-			if len(allocationIDs) != len(subnetIDs) {
-				return nil, fmt.Errorf("error creating load balancer: Must have same number of EIP AllocationIDs (%d) and SubnetIDs (%d)", len(allocationIDs), len(subnetIDs))
+			if len(allocationIDs) != len(discoveredSubnetIDs) {
+				return nil, fmt.Errorf("error creating load balancer: Must have same number of EIP AllocationIDs (%d) and SubnetIDs (%d)", len(allocationIDs), len(discoveredSubnetIDs))
 			}
 		}
 
 		// We are supposed to specify one subnet per AZ.
 		// TODO: What happens if we have more than one subnet per AZ?
-		createRequest.SubnetMappings = createSubnetMappings(subnetIDs, allocationIDs)
+		createRequest.SubnetMappings = createSubnetMappings(discoveredSubnetIDs, allocationIDs)
 
 		for k, v := range tags {
 			createRequest.Tags = append(createRequest.Tags, &elbv2.Tag{

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -2759,6 +2759,12 @@ func (m *MockedFakeELBV2) CreateLoadBalancer(request *elbv2.CreateLoadBalancerIn
 		LoadBalancerName: request.Name,
 		Type:             aws.String(elbv2.LoadBalancerTypeEnumNetwork),
 		VpcId:            aws.String("vpc-abc123def456abc78"),
+		AvailabilityZones: []*elbv2.AvailabilityZone{
+			{
+				ZoneName: aws.String("us-west-2a"),
+				SubnetId: aws.String("subnet-abc123de"),
+			},
+		},
 	}
 	m.LoadBalancers = append(m.LoadBalancers, newLB)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
see #763 
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
