### PR TITLE
Backport to release 1.26 - fix: handle subnets with resource based naming more flexibly

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -6,7 +6,7 @@ AWS supports two naming conventions: [IP-based or resource-based naming](https:/
 
 When _IP-based naming_ is used, the nodes must be named after the instance followed by the regional domain name (`ip-xxx-xxx-xxx-xxx.ec2.<region>.internal`). If you have custom domain name set in the DHCP options, you must set `--hostname-override` on kube-proxy and kubelet to match the above-mentioned naming convention.
 
-When _resource based naming_ is used, the node must be named after the instance without any domain name (`i-1234567890abcdefg`). Custom domain name may be used as long as the output of `hostname` does not include the domain name. `--hostname-override` should not be set on any components when using resource-based naming.
+When _resource based naming_ is used, the node must be named after the instance either with or without a domain name (`i-1234567890abcdefg` or `i-1234567890abcdefg.<region>.compute.internal`). A custom domain name, configured through DHCP options, may also be used. 
 
 ## IAM Policies
 For the `aws-cloud-controller-manager` to be able to communicate to AWS APIs, you will need to create a few IAM policies for your EC2 instances. The control plane (formerly master) policy is a bit open and can be scaled back depending on the use case. Adjust these based on your needs.

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -5228,6 +5228,12 @@ func nodeNameToIPAddress(nodeName string) string {
 
 func (c *Cloud) nodeNameToInstanceID(nodeName types.NodeName) (InstanceID, error) {
 	if strings.HasPrefix(string(nodeName), rbnNamePrefix) {
+		// depending on if you use a RHEL (e.g. AL2) or Debian (e.g. standard Ubuntu) based distribution, the
+		// hostname on the machine may be either i-00000000000000001 or i-00000000000000001.region.compute.internal.
+		// This handles both scenarios by returning anything before the first '.' in the node name if it has an RBN prefix.
+		if idx := strings.IndexByte(string(nodeName), '.'); idx != -1 {
+			return InstanceID(nodeName[0:idx]), nil
+		}
 		return InstanceID(nodeName), nil
 	}
 	if len(nodeName) == 0 {

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -644,14 +644,14 @@ func testHasNodeAddress(t *testing.T, addrs []v1.NodeAddress, addressType v1.Nod
 	t.Errorf("Did not find expected address: %s:%s in %v", addressType, address, addrs)
 }
 
-func makeInstance(num int, privateIP, publicIP, privateDNSName, publicDNSName string, ipv6s []string, setNetInterface bool) ec2.Instance {
+func makeInstance(num string, privateIP, publicIP, privateDNSName, publicDNSName string, ipv6s []string, setNetInterface bool) ec2.Instance {
 	var tag ec2.Tag
 	tag.Key = aws.String(TagNameKubernetesClusterLegacy)
 	tag.Value = aws.String(TestClusterID)
 	tags := []*ec2.Tag{&tag}
 
 	instance := ec2.Instance{
-		InstanceId:       aws.String(fmt.Sprintf("i-%d", num)),
+		InstanceId:       aws.String(fmt.Sprintf("i-%s", num)),
 		PrivateDnsName:   aws.String(privateDNSName),
 		PrivateIpAddress: aws.String(privateIP),
 		PublicDnsName:    aws.String(publicDNSName),
@@ -688,10 +688,10 @@ func makeInstance(num int, privateIP, publicIP, privateDNSName, publicDNSName st
 func TestNodeAddressesByProviderID(t *testing.T) {
 	// Note instance0 and instance1 have the same name
 	// (we test that this produces an error)
-	instance0 := makeInstance(0, "192.168.0.1", "1.2.3.4", "instance-same.ec2.internal", "instance-same.ec2.external", nil, true)
-	instance1 := makeInstance(1, "192.168.0.2", "", "instance-same.ec2.internal", "", nil, false)
-	instance2 := makeInstance(2, "192.168.0.1", "1.2.3.4", "instance-other.ec2.internal", "", nil, false)
-	instance3 := makeInstance(3, "192.168.0.3", "", "instance-ipv6.ec2.internal", "", []string{"2a05:d014:aa7:911:fc7e:1600:fc4d:ab2", "2a05:d014:aa7:911:9f44:e737:1aa0:6489"}, true)
+	instance0 := makeInstance("00000000000000000", "192.168.0.1", "1.2.3.4", "instance-same.ec2.internal", "instance-same.ec2.external", nil, true)
+	instance1 := makeInstance("00000000000000001", "192.168.0.2", "", "instance-same.ec2.internal", "", nil, false)
+	instance2 := makeInstance("00000000000000002", "192.168.0.1", "1.2.3.4", "instance-other.ec2.internal", "", nil, false)
+	instance3 := makeInstance("00000000000000003", "192.168.0.3", "", "instance-ipv6.ec2.internal", "", []string{"2a05:d014:aa7:911:fc7e:1600:fc4d:ab2", "2a05:d014:aa7:911:9f44:e737:1aa0:6489"}, true)
 	instances := []*ec2.Instance{&instance0, &instance1, &instance2, &instance3}
 
 	aws1, _ := mockInstancesResp(&instance0, []*ec2.Instance{&instance0})
@@ -703,9 +703,9 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 	aws2, _ := mockInstancesResp(&instance0, instances[0:1])
 	// change node name so it uses the instance instead of metadata
 	aws2.selfAWSInstance.nodeName = "foo"
-	addrs2, err2 := aws2.NodeAddressesByProviderID(context.TODO(), "i-0")
+	addrs2, err2 := aws2.NodeAddressesByProviderID(context.TODO(), "i-00000000000000000")
 	if err2 != nil {
-		t.Errorf("Should not error when instance found")
+		t.Errorf("Should not error when instance found, %s", err2)
 	}
 	if len(addrs2) != 5 {
 		t.Errorf("Should return exactly 5 NodeAddresses")
@@ -720,9 +720,9 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 	aws3.cfg.Global.NodeIPFamilies = []string{"ipv4", "ipv6"}
 	// change node name so it uses the instance instead of metadata
 	aws3.selfAWSInstance.nodeName = "foo"
-	addrs3, err3 := aws3.NodeAddressesByProviderID(context.TODO(), "i-3")
+	addrs3, err3 := aws3.NodeAddressesByProviderID(context.TODO(), "i-00000000000000003")
 	if err3 != nil {
-		t.Errorf("Should not error when instance found")
+		t.Errorf("Should not error when instance found, %s", err3)
 	}
 	if len(addrs3) != 4 {
 		t.Errorf("Should return exactly 4 NodeAddresses")
@@ -736,22 +736,26 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 	aws4.cfg.Global.NodeIPFamilies = []string{"ipv6"}
 	// change node name so it uses the instance instead of metadata
 	aws4.selfAWSInstance.nodeName = "foo"
-	addrs4, err4 := aws4.NodeAddressesByProviderID(context.TODO(), "i-3")
+	addrs4, err4 := aws4.NodeAddressesByProviderID(context.TODO(), "i-00000000000000003")
 	if err4 != nil {
-		t.Errorf("Should not error when instance found")
+		t.Errorf("Should not error when instance found, %s", err4)
 	}
 	if len(addrs4) != 1 {
 		t.Errorf("Should return exactly 1 NodeAddresses")
 	}
 	testHasNodeAddress(t, addrs4, v1.NodeInternalIP, "2a05:d014:aa7:911:fc7e:1600:fc4d:ab2")
-
 }
 
 func TestNodeAddresses(t *testing.T) {
-	instance0 := makeInstance(0, "192.168.0.1", "1.2.3.4", "instance-same.ec2.internal", "instance-same.ec2.external", nil, true)
-	instance2 := makeInstance(2, "192.168.0.1", "1.2.3.4", "instance-other.ec2.internal", "", nil, false)
-	instance3 := makeInstance(3, "192.168.0.3", "", "instance-ipv6.ec2.internal", "", []string{"2a05:d014:aa7:911:fc7e:1600:fc4d:ab2", "2a05:d014:aa7:911:9f44:e737:1aa0:6489"}, true)
-	instances := []*ec2.Instance{&instance0, &instance2, &instance3}
+	instance0 := makeInstance("00000000000000000", "192.168.0.1", "1.2.3.4", "instance-same.ec2.internal", "instance-same.ec2.external", nil, true)
+	instance2 := makeInstance("00000000000000002", "192.168.0.1", "1.2.3.4", "instance-other.ec2.internal", "", nil, false)
+	instance3 := makeInstance("00000000000000003", "192.168.0.3", "", "instance-ipv6.ec2.internal", "", []string{"2a05:d014:aa7:911:fc7e:1600:fc4d:ab2", "2a05:d014:aa7:911:9f44:e737:1aa0:6489"}, true)
+	// configured for resource based naming using FQDN
+	instance4 := makeInstance("00000000000000004", "192.168.0.4", "1.2.3.4", "i-00000000000000004.ec2.internal", "", nil, true)
+	// configured for resource based naming using hostname only
+	instance5 := makeInstance("00000000000000005", "192.168.0.5", "1.2.3.4", "i-00000000000000005.ec2.internal", "", nil, true)
+
+	instances := []*ec2.Instance{&instance0, &instance2, &instance3, &instance4, &instance5}
 
 	aws1, _ := mockInstancesResp(&instance0, []*ec2.Instance{&instance0})
 	_, err1 := aws1.NodeAddresses(context.TODO(), "instance-mismatch.ec2.internal")
@@ -803,6 +807,33 @@ func TestNodeAddresses(t *testing.T) {
 		t.Errorf("Should return exactly 1 NodeAddresses")
 	}
 	testHasNodeAddress(t, addrs5, v1.NodeInternalIP, "2a05:d014:aa7:911:fc7e:1600:fc4d:ab2")
+
+	aws6, _ := mockInstancesResp(&instance4, instances)
+	addrs6, err6 := aws6.NodeAddresses(context.TODO(), "i-00000000000000004.ec2.internal")
+	if err6 != nil {
+		t.Errorf("Should not error when instance found, %s", err6)
+	}
+	if len(addrs6) != 4 {
+		t.Errorf("Should return exactly 4 NodeAddresses, got %v", addrs5)
+	}
+	testHasNodeAddress(t, addrs6, v1.NodeInternalIP, "192.168.0.4")
+	testHasNodeAddress(t, addrs6, v1.NodeExternalIP, "1.2.3.4")
+	testHasNodeAddress(t, addrs6, v1.NodeInternalDNS, "i-00000000000000004.ec2.internal")
+	testHasNodeAddress(t, addrs6, v1.NodeHostName, "i-00000000000000004.ec2.internal")
+
+	aws7, _ := mockInstancesResp(&instance5, instances)
+	aws7.selfAWSInstance.nodeName = "i-00000000000000005"
+	addrs7, err6 := aws7.NodeAddresses(context.TODO(), "i-00000000000000005")
+	if err6 != nil {
+		t.Errorf("Should not error when instance found, %s", err6)
+	}
+	if len(addrs6) != 4 {
+		t.Errorf("Should return exactly 4 NodeAddresses, got %v", addrs6)
+	}
+	testHasNodeAddress(t, addrs7, v1.NodeInternalIP, "192.168.0.5")
+	testHasNodeAddress(t, addrs7, v1.NodeExternalIP, "1.2.3.4")
+	testHasNodeAddress(t, addrs7, v1.NodeInternalDNS, "i-00000000000000005.ec2.internal")
+	testHasNodeAddress(t, addrs7, v1.NodeHostName, "i-00000000000000005.ec2.internal")
 
 }
 


### PR DESCRIPTION
This adds support for RHEL based distributions that typically use a FQDN.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Backport to fix resource based naming instances

**Which issue(s) this PR fixes**:

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #799

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Backport to release 1.26 for resource based named instances
```
