### PR TITLE
Get zone information from cache

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -580,6 +580,7 @@ type Cloud struct {
 	selfAWSInstance *awsInstance
 
 	instanceCache instanceCache
+	zoneCache     zoneCache
 
 	clientBuilder cloudprovider.ControllerClientBuilder
 	kubeClient    clientset.Interface
@@ -1422,6 +1423,7 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 		deviceAllocators: make(map[types.NodeName]DeviceAllocator),
 	}
 	awsCloud.instanceCache.cloud = awsCloud
+	awsCloud.zoneCache.cloud = awsCloud
 
 	tagged := cfg.Global.KubernetesClusterTag != "" || cfg.Global.KubernetesClusterID != ""
 	if cfg.Global.VPC != "" && (cfg.Global.SubnetID != "" || cfg.Global.RoleARN != "") && tagged {
@@ -3522,35 +3524,6 @@ func (c *Cloud) findSubnets() ([]*ec2.Subnet, error) {
 	return subnets, nil
 }
 
-// Returns a mapping between availability zone names and their types
-// Zone will not be included in the map in case it was not found in AWS by name
-func (c *Cloud) getZoneTypesByName(azNames []string) (map[string]string, error) {
-	if len(azNames) == 0 {
-		// if az names slice is empty, no need to make a request, return early with empty map
-		return map[string]string{}, nil
-	}
-	azFilter := newEc2Filter("zone-name", azNames...)
-	azRequest := &ec2.DescribeAvailabilityZonesInput{}
-	azRequest.Filters = []*ec2.Filter{azFilter}
-
-	azs, err := c.ec2.DescribeAvailabilityZones(azRequest)
-	if err != nil {
-		return nil, fmt.Errorf("error describe availability zones: %q", err)
-	}
-
-	azTypesMapping := make(map[string]string)
-	for _, az := range azs {
-		name := aws.StringValue(az.ZoneName)
-		zoneType := aws.StringValue(az.ZoneType)
-		if name == "" || zoneType == "" {
-			klog.Warningf("Ignoring zone with empty name/type: %v", az)
-			continue
-		}
-		azTypesMapping[name] = zoneType
-	}
-	return azTypesMapping, nil
-}
-
 // Finds the subnets to use for an ELB we are creating.
 // Normal (Internet-facing) ELBs must use public subnets, so we skip private subnets.
 // Internal ELBs can use public or private subnets, but if we have a private subnet we should prefer that.
@@ -3639,21 +3612,21 @@ func (c *Cloud) findELBSubnets(internalELB bool) ([]string, error) {
 
 	sort.Strings(azNames)
 
-	azTypesMapping, err := c.getZoneTypesByName(azNames)
+	zoneNameToDetails, err := c.zoneCache.getZoneDetailsByNames(azNames)
 	if err != nil {
 		return nil, fmt.Errorf("error get availability zone types: %q", err)
 	}
 
 	var subnetIDs []string
-	for _, key := range azNames {
-		azType, found := azTypesMapping[key]
-		if found && azType != regularAvailabilityZoneType {
+	for _, zone := range azNames {
+		azType, found := zoneNameToDetails[zone]
+		if found && azType.zoneType != regularAvailabilityZoneType {
 			// take subnets only from zones with `availability-zone` type
 			// because another zone types (like local, wavelength and outpost zones)
 			// does not support NLB/CLB for the moment, only ALB.
 			continue
 		}
-		subnetIDs = append(subnetIDs, aws.StringValue(subnetsByAZ[key].SubnetId))
+		subnetIDs = append(subnetIDs, aws.StringValue(subnetsByAZ[zone].SubnetId))
 	}
 
 	return subnetIDs, nil

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -55,7 +55,7 @@ type FakeAWSServices struct {
 // NewFakeAWSServices creates a new FakeAWSServices
 func NewFakeAWSServices(clusterID string) *FakeAWSServices {
 	s := &FakeAWSServices{}
-	s.region = "us-east-1"
+	s.region = "us-west-2"
 	s.ec2 = &FakeEC2Impl{aws: s}
 	s.elb = &FakeELB{aws: s}
 	s.elbv2 = &FakeELBV2{aws: s}
@@ -69,7 +69,7 @@ func NewFakeAWSServices(clusterID string) *FakeAWSServices {
 	selfInstance := &ec2.Instance{}
 	selfInstance.InstanceId = aws.String("i-self")
 	selfInstance.Placement = &ec2.Placement{
-		AvailabilityZone: aws.String("us-east-1a"),
+		AvailabilityZone: aws.String("us-west-2a"),
 	}
 	selfInstance.PrivateDnsName = aws.String("ip-172-20-0-100.ec2.internal")
 	selfInstance.PrivateIpAddress = aws.String("192.168.0.1")
@@ -287,23 +287,33 @@ func (ec2i *FakeEC2Impl) RemoveSubnets() {
 // DescribeAvailabilityZones returns fake availability zones
 // For every input returns a hardcoded list of fake availability zones for the moment
 func (ec2i *FakeEC2Impl) DescribeAvailabilityZones(request *ec2.DescribeAvailabilityZonesInput) ([]*ec2.AvailabilityZone, error) {
-	var azs []*ec2.AvailabilityZone
-
-	fakeZones := [5]string{"az-local", "az-wavelength", "us-west-2a", "us-west-2b", "us-west-2c"}
-	for _, name := range fakeZones {
-		var zoneType *string
-		switch name {
-		case "az-local":
-			zoneType = aws.String(localZoneType)
-		case "az-wavelength":
-			zoneType = aws.String(wavelengthZoneType)
-		default:
-			zoneType = aws.String(regularAvailabilityZoneType)
-		}
-		zone := &ec2.AvailabilityZone{ZoneName: aws.String(name), ZoneType: zoneType, ZoneId: aws.String(name)}
-		azs = append(azs, zone)
-	}
-	return azs, nil
+	return []*ec2.AvailabilityZone{
+		{
+			ZoneName: aws.String("us-west-2a"),
+			ZoneType: aws.String("availability-zone"),
+			ZoneId:   aws.String("az1"),
+		},
+		{
+			ZoneName: aws.String("us-west-2b"),
+			ZoneType: aws.String("availability-zone"),
+			ZoneId:   aws.String("az2"),
+		},
+		{
+			ZoneName: aws.String("us-west-2c"),
+			ZoneType: aws.String("availability-zone"),
+			ZoneId:   aws.String("az3"),
+		},
+		{
+			ZoneName: aws.String("az-local"),
+			ZoneType: aws.String("local-zone"),
+			ZoneId:   aws.String("lz1"),
+		},
+		{
+			ZoneName: aws.String("az-wavelength"),
+			ZoneType: aws.String("wavelength"),
+			ZoneId:   aws.String("wl1"),
+		},
+	}, nil
 }
 
 // CreateTags is a mock for CreateTags from EC2

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -488,7 +488,7 @@ func TestNewAWSCloud(t *testing.T) {
 			"Gets zone from metadata when not in config",
 			strings.NewReader("[global]\n"),
 			newMockedFakeAWSServices(TestClusterID),
-			false, "us-east-1",
+			false, "us-west-2",
 		},
 	}
 
@@ -577,7 +577,7 @@ func makeInstance(instanceID string, privateIP, publicIP, privateDNSName, public
 		PublicIpAddress:  aws.String(publicIP),
 		InstanceType:     aws.String("c3.large"),
 		Tags:             tags,
-		Placement:        &ec2.Placement{AvailabilityZone: aws.String("us-east-1a")},
+		Placement:        &ec2.Placement{AvailabilityZone: aws.String("us-west-2a")},
 		State: &ec2.InstanceState{
 			Name: aws.String("running"),
 		},
@@ -1685,7 +1685,7 @@ func TestGetVolumeLabels(t *testing.T) {
 	awsServices.ec2.(*MockedFakeEC2).On("DescribeVolumes", expectedVolumeRequest).Return([]*ec2.Volume{
 		{
 			VolumeId:         volumeID.awsString(),
-			AvailabilityZone: aws.String("us-east-1a"),
+			AvailabilityZone: aws.String("us-west-2a"),
 		},
 	})
 
@@ -1693,8 +1693,8 @@ func TestGetVolumeLabels(t *testing.T) {
 
 	assert.Nil(t, err, "Error creating Volume %v", err)
 	assert.Equal(t, map[string]string{
-		v1.LabelTopologyZone:   "us-east-1a",
-		v1.LabelTopologyRegion: "us-east-1"}, labels)
+		v1.LabelTopologyZone:   "us-west-2a",
+		v1.LabelTopologyRegion: "us-west-2"}, labels)
 	awsServices.ec2.(*MockedFakeEC2).AssertExpectations(t)
 }
 
@@ -1764,11 +1764,11 @@ func TestGetLabelsForVolume(t *testing.T) {
 			defaultVolume,
 			[]*ec2.Volume{{
 				VolumeId:         defaultVolume,
-				AvailabilityZone: aws.String("us-east-1a"),
+				AvailabilityZone: aws.String("us-west-2a"),
 			}},
 			map[string]string{
-				v1.LabelTopologyZone:   "us-east-1a",
-				v1.LabelTopologyRegion: "us-east-1",
+				v1.LabelTopologyZone:   "us-west-2a",
+				v1.LabelTopologyRegion: "us-west-2",
 			},
 			nil,
 		},
@@ -2503,11 +2503,11 @@ func TestCreateDisk(t *testing.T) {
 	c, _ := newAWSCloud(CloudConfig{}, awsServices)
 
 	volumeOptions := &VolumeOptions{
-		AvailabilityZone: "us-east-1a",
+		AvailabilityZone: "us-west-2a",
 		CapacityGB:       10,
 	}
 	request := &ec2.CreateVolumeInput{
-		AvailabilityZone: aws.String("us-east-1a"),
+		AvailabilityZone: aws.String("us-west-2a"),
 		Encrypted:        aws.Bool(false),
 		VolumeType:       aws.String(DefaultVolumeType),
 		Size:             aws.Int64(10),
@@ -2522,7 +2522,7 @@ func TestCreateDisk(t *testing.T) {
 	}
 
 	volume := &ec2.Volume{
-		AvailabilityZone: aws.String("us-east-1a"),
+		AvailabilityZone: aws.String("us-west-2a"),
 		VolumeId:         aws.String("vol-volumeId0"),
 		State:            aws.String("available"),
 	}
@@ -2535,7 +2535,7 @@ func TestCreateDisk(t *testing.T) {
 
 	volumeID, err := c.CreateDisk(volumeOptions)
 	assert.Nil(t, err, "Error creating disk: %v", err)
-	assert.Equal(t, volumeID, KubernetesVolumeID("aws://us-east-1a/vol-volumeId0"))
+	assert.Equal(t, volumeID, KubernetesVolumeID("aws://us-west-2a/vol-volumeId0"))
 	awsServices.ec2.(*MockedFakeEC2).AssertExpectations(t)
 }
 
@@ -2544,11 +2544,11 @@ func TestCreateDiskFailDescribeVolume(t *testing.T) {
 	c, _ := newAWSCloud(CloudConfig{}, awsServices)
 
 	volumeOptions := &VolumeOptions{
-		AvailabilityZone: "us-east-1a",
+		AvailabilityZone: "us-west-2a",
 		CapacityGB:       10,
 	}
 	request := &ec2.CreateVolumeInput{
-		AvailabilityZone: aws.String("us-east-1a"),
+		AvailabilityZone: aws.String("us-west-2a"),
 		Encrypted:        aws.Bool(false),
 		VolumeType:       aws.String(DefaultVolumeType),
 		Size:             aws.Int64(10),
@@ -2563,7 +2563,7 @@ func TestCreateDiskFailDescribeVolume(t *testing.T) {
 	}
 
 	volume := &ec2.Volume{
-		AvailabilityZone: aws.String("us-east-1a"),
+		AvailabilityZone: aws.String("us-west-2a"),
 		VolumeId:         aws.String("vol-volumeId0"),
 		State:            aws.String("creating"),
 	}
@@ -2588,7 +2588,7 @@ const (
 	testNodeName           = types.NodeName("ip-10-0-0-1.ec2.internal")
 	testInstanceIDNodeName = types.NodeName("i-02bce90670bb0c7cd")
 	testOverriddenNodeName = types.NodeName("foo")
-	testProviderID         = "aws:///us-east-1c/i-02bce90670bb0c7cd"
+	testProviderID         = "aws:///us-west-2c/i-02bce90670bb0c7cd"
 	testInstanceID         = "i-02bce90670bb0c7cd"
 )
 
@@ -2687,7 +2687,7 @@ func TestInstanceIDToNodeName(t *testing.T) {
 					Name: string(testOverriddenNodeName),
 				},
 				Spec: v1.NodeSpec{
-					ProviderID: "aws:///us-east-1c/i-foo",
+					ProviderID: "aws:///us-west-2c/i-foo",
 				},
 			},
 			expectedNodeName: types.NodeName(""),
@@ -2753,7 +2753,7 @@ func (m *MockedFakeELBV2) AddTags(request *elbv2.AddTagsInput) (*elbv2.AddTagsOu
 
 func (m *MockedFakeELBV2) CreateLoadBalancer(request *elbv2.CreateLoadBalancerInput) (*elbv2.CreateLoadBalancerOutput, error) {
 	accountID := 123456789
-	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:us-east-1:%d:loadbalancer/net/%x/%x",
+	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:us-west-2:%d:loadbalancer/net/%x/%x",
 		accountID,
 		rand.Uint64(),
 		rand.Uint32())
@@ -2849,7 +2849,7 @@ func (m *MockedFakeELBV2) DescribeLoadBalancerAttributes(request *elbv2.Describe
 
 func (m *MockedFakeELBV2) CreateTargetGroup(request *elbv2.CreateTargetGroupInput) (*elbv2.CreateTargetGroupOutput, error) {
 	accountID := 123456789
-	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:us-east-1:%d:targetgroup/%x/%x",
+	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:us-west-2:%d:targetgroup/%x/%x",
 		accountID,
 		rand.Uint64(),
 		rand.Uint32())
@@ -3057,7 +3057,7 @@ func (m *MockedFakeELBV2) DeregisterTargets(request *elbv2.DeregisterTargetsInpu
 
 func (m *MockedFakeELBV2) CreateListener(request *elbv2.CreateListenerInput) (*elbv2.CreateListenerOutput, error) {
 	accountID := 123456789
-	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:us-east-1:%d:listener/net/%x/%x/%x",
+	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:us-west-2:%d:listener/net/%x/%x/%x",
 		accountID,
 		rand.Uint64(),
 		rand.Uint32(),
@@ -3302,7 +3302,7 @@ func makeNamedNode(s *FakeAWSServices, offset int, name string) *v1.Node {
 	instance := &ec2.Instance{}
 	instance.InstanceId = aws.String(instanceID)
 	instance.Placement = &ec2.Placement{
-		AvailabilityZone: aws.String("us-east-1c"),
+		AvailabilityZone: aws.String("us-west-2c"),
 	}
 	instance.PrivateDnsName = aws.String(fmt.Sprintf("ip-172-20-0-%d.ec2.internal", 101+offset))
 	instance.PrivateIpAddress = aws.String(fmt.Sprintf("192.168.0.%d", 1+offset))
@@ -3314,7 +3314,7 @@ func makeNamedNode(s *FakeAWSServices, offset int, name string) *v1.Node {
 
 	s.instances = append(s.instances, instance)
 
-	testProviderID := "aws:///us-east-1c/" + instanceID
+	testProviderID := "aws:///us-west-2c/" + instanceID
 	return &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -3885,7 +3885,7 @@ func TestGetRegionFromMetadata(t *testing.T) {
 	cfg = CloudConfig{}
 	region, err = getRegionFromMetadata(cfg, awsServices.metadata)
 	assert.NoError(t, err)
-	assert.Equal(t, "us-east-1", region)
+	assert.Equal(t, "us-west-2", region)
 }
 
 type MockedEC2API struct {
@@ -3896,6 +3896,11 @@ type MockedEC2API struct {
 func (m *MockedEC2API) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
 	args := m.Called(input)
 	return args.Get(0).(*ec2.DescribeInstancesOutput), args.Error(1)
+}
+
+func (m *MockedEC2API) DescribeAvailabilityZones(input *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*ec2.DescribeAvailabilityZonesOutput), args.Error(1)
 }
 
 func newMockedEC2API() *MockedEC2API {

--- a/pkg/providers/v1/instances_v2_test.go
+++ b/pkg/providers/v1/instances_v2_test.go
@@ -51,7 +51,7 @@ func TestGetProviderId(t *testing.T) {
 			node: v1.Node{
 				Spec: v1.NodeSpec{},
 			},
-			expectedProviderID: "aws:///us-east-1a/i-00000000000000001",
+			expectedProviderID: "aws:///us-west-2a/i-00000000000000001",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -184,8 +184,8 @@ func TestInstanceMetadata(t *testing.T) {
 			{Type: "Hostname", Address: "instance-same.ec2.internal"},
 			{Type: "ExternalDNS", Address: "instance-same.ec2.external"},
 		}, result.NodeAddresses)
-		assert.Equal(t, "us-east-1a", result.Zone)
-		assert.Equal(t, "us-east-1", result.Region)
+		assert.Equal(t, "us-west-2a", result.Zone)
+		assert.Equal(t, "us-west-2", result.Region)
 	})
 }
 

--- a/pkg/providers/v1/zones.go
+++ b/pkg/providers/v1/zones.go
@@ -96,8 +96,8 @@ func (z *zoneCache) populate() error {
 	}
 
 	// Initialize the map if it's unset
-	if len(z.zoneNameToDetails) == 0 {
-		z.zoneNameToDetails = map[string]zoneDetails{}
+	if z.zoneNameToDetails == nil {
+		z.zoneNameToDetails = make(map[string]zoneDetails)
 	}
 
 	for _, zone := range zones {

--- a/pkg/providers/v1/zones.go
+++ b/pkg/providers/v1/zones.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/klog/v2"
+)
+
+type zoneDetails struct {
+	name     string
+	id       string
+	zoneType string
+}
+
+type zoneCache struct {
+	cloud             *Cloud
+	mutex             sync.Mutex
+	zoneNameToDetails map[string]zoneDetails
+}
+
+// Get the zone details by zone names and load from the cache if available as
+// zone information should never change.
+func (z *zoneCache) getZoneDetailsByNames(zoneNames []string) (map[string]zoneDetails, error) {
+	if len(zoneNames) == 0 {
+		return map[string]zoneDetails{}, nil
+	}
+
+	z.mutex.Lock()
+	defer z.mutex.Unlock()
+
+	if z.shouldPopulateCache(zoneNames) {
+		// Populate the cache if it hasn't been populated yet
+		err := z.populate()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	requestedZoneDetails := map[string]zoneDetails{}
+	for _, zone := range zoneNames {
+		if zoneDetails, ok := z.zoneNameToDetails[zone]; ok {
+			requestedZoneDetails[zone] = zoneDetails
+		} else {
+			klog.Warningf("Could not find zone %s", zone)
+		}
+	}
+
+	return requestedZoneDetails, nil
+}
+
+// NOTE: This method is not thread safe and should not be called outside of getZoneDetailsByNames
+func (z *zoneCache) shouldPopulateCache(zoneNames []string) bool {
+	if len(z.zoneNameToDetails) == 0 {
+		// Populate the cache if it hasn't been populated yet
+		return true
+	}
+
+	// Make sure that we know about all of the AZs we're looking for.
+	for _, zone := range zoneNames {
+		if _, ok := z.zoneNameToDetails[zone]; !ok {
+			klog.Infof("AZ %s not found in zone cache.", zone)
+			return true
+		}
+	}
+
+	return false
+}
+
+// Populates the zone cache. If cache is already populated, it will overwrite entries,
+// which is useful when accounts get access to new zones.
+// NOTE: This method is not thread safe and should not be called outside of getZoneDetailsByNames
+func (z *zoneCache) populate() error {
+	azRequest := &ec2.DescribeAvailabilityZonesInput{}
+	zones, err := z.cloud.ec2.DescribeAvailabilityZones(azRequest)
+	if err != nil {
+		return fmt.Errorf("error describe availability zones: %q", err)
+	}
+
+	// Initialize the map if it's unset
+	if len(z.zoneNameToDetails) == 0 {
+		z.zoneNameToDetails = map[string]zoneDetails{}
+	}
+
+	for _, zone := range zones {
+		name := aws.StringValue(zone.ZoneName)
+		z.zoneNameToDetails[name] = zoneDetails{
+			name:     name,
+			id:       aws.StringValue(zone.ZoneId),
+			zoneType: aws.StringValue(zone.ZoneType),
+		}
+	}
+
+	return nil
+}

--- a/pkg/providers/v1/zones_test.go
+++ b/pkg/providers/v1/zones_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func TestGetZoneDetailsByNames(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		zones            []string
+		expectedResult   map[string]zoneDetails
+		expectedAPICalls int
+	}{
+		{
+			name:  "Should return all requested zones when available",
+			zones: []string{"az1", "az2"},
+			expectedResult: map[string]zoneDetails{
+				"az1": {
+					name:     "az1",
+					id:       "az1-id",
+					zoneType: "availability-zone",
+				},
+				"az2": {
+					name:     "az2",
+					id:       "az2-id",
+					zoneType: "availability-zone",
+				},
+			},
+			expectedAPICalls: 1,
+		},
+		{
+			name:  "Should refresh zones and handle zones not found",
+			zones: []string{"az1", "az4"},
+			expectedResult: map[string]zoneDetails{
+				"az1": {
+					name:     "az1",
+					id:       "az1-id",
+					zoneType: "availability-zone",
+				},
+			},
+			expectedAPICalls: 2,
+		},
+		{
+			name:             "Should handle empty AZs",
+			zones:            []string{},
+			expectedResult:   map[string]zoneDetails{},
+			expectedAPICalls: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, mockedEC2API := getCloudWithMockedDescribeAvailabilityZones()
+
+			result, err := c.zoneCache.getZoneDetailsByNames(tc.zones)
+			if err != nil {
+				t.Errorf("Should not error getting zone details: %s", err)
+			}
+
+			assert.Equal(t, tc.expectedResult, result, "Should return the expected zones")
+
+			// Call again to verify expected caching behavior
+			result, err = c.zoneCache.getZoneDetailsByNames(tc.zones)
+			if err != nil {
+				t.Errorf("Should not error getting zone details: %s", err)
+			}
+			mockedEC2API.AssertNumberOfCalls(t, "DescribeAvailabilityZones", tc.expectedAPICalls)
+		})
+	}
+}
+
+func getCloudWithMockedDescribeAvailabilityZones() (*Cloud, *MockedEC2API) {
+	mockedEC2API := newMockedEC2API()
+	c := &Cloud{ec2: &awsSdkEC2{ec2: mockedEC2API}}
+	c.zoneCache = zoneCache{cloud: c}
+
+	mockedEC2API.On("DescribeAvailabilityZones", mock.Anything).Return(&ec2.DescribeAvailabilityZonesOutput{
+		AvailabilityZones: []*ec2.AvailabilityZone{
+			{
+				ZoneName: aws.String("az1"),
+				ZoneId:   aws.String("az1-id"),
+				ZoneType: aws.String("availability-zone"),
+			},
+			{
+				ZoneName: aws.String("az2"),
+				ZoneId:   aws.String("az2-id"),
+				ZoneType: aws.String("availability-zone"),
+			},
+			{
+				ZoneName: aws.String("az3"),
+				ZoneId:   aws.String("az3-id"),
+				ZoneType: aws.String("availability-zone"),
+			},
+		},
+	}, nil)
+
+	return c, mockedEC2API
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
To support labeling nodes with zone IDs #300, we'll need to map zone names to zone IDs, which isn't readily available in existing calls to generate the instance metadata. When we call `DescribeAvailabilityZones` today to get that information, we don't actually cache that data and just call the API again despite the fact that the data we need (zone name, ID and type) will never change. The only scenario where we can't rely entirely on cached information is when new zones are made available to the account via getting access to a special zone (i.e. local-zone) or AWS adds a new AZ to a region, so we need to refresh values that we can't find.

This PR updates the code to pull zones from a cache before greatly increase the number of times that we'll need that information. This will be independently beneficial and avoid increasing EC2 API calls.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
