### PR TITLE
Add zone-id topology label to nodes

### DIFF
--- a/pkg/providers/v1/instances_v2_test.go
+++ b/pkg/providers/v1/instances_v2_test.go
@@ -186,6 +186,9 @@ func TestInstanceMetadata(t *testing.T) {
 		}, result.NodeAddresses)
 		assert.Equal(t, "us-west-2a", result.Zone)
 		assert.Equal(t, "us-west-2", result.Region)
+		assert.Equal(t, map[string]string{
+			LabelZoneID: "az1",
+		}, result.AdditionalLabels)
 	})
 }
 

--- a/pkg/providers/v1/well_known_labels.go
+++ b/pkg/providers/v1/well_known_labels.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+const (
+	// LabelZoneID is a topology label that can be applied to any resource
+	// but will be initially applied to nodes.
+	LabelZoneID = "topology.k8s.aws/zone-id"
+)

--- a/pkg/providers/v1/zones.go
+++ b/pkg/providers/v1/zones.go
@@ -48,7 +48,7 @@ func (z *zoneCache) getZoneIDByZoneName(zoneName string) (string, error) {
 		return "", fmt.Errorf("Could not get zone ID from zone name %s", zoneName)
 	}
 
-	return zoneDetail.id, err
+	return zoneDetail.id, nil
 }
 
 // Get the zone details by zone names and load from the cache if available as

--- a/pkg/providers/v1/zones.go
+++ b/pkg/providers/v1/zones.go
@@ -37,6 +37,20 @@ type zoneCache struct {
 	zoneNameToDetails map[string]zoneDetails
 }
 
+func (z *zoneCache) getZoneIDByZoneName(zoneName string) (string, error) {
+	zoneNameToDetails, err := z.getZoneDetailsByNames([]string{zoneName})
+	if err != nil {
+		return "", err
+	}
+
+	zoneDetail, ok := zoneNameToDetails[zoneName]
+	if !ok {
+		return "", fmt.Errorf("Could not get zone ID from zone name %s", zoneName)
+	}
+
+	return zoneDetail.id, err
+}
+
 // Get the zone details by zone names and load from the cache if available as
 // zone information should never change.
 func (z *zoneCache) getZoneDetailsByNames(zoneNames []string) (map[string]zoneDetails, error) {

--- a/pkg/providers/v1/zones_test.go
+++ b/pkg/providers/v1/zones_test.go
@@ -24,6 +24,43 @@ import (
 	"testing"
 )
 
+func TestGetZoneIDByZoneName(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		zoneName       string
+		expectedResult string
+		expectError    bool
+	}{
+		{
+			name:           "Should return requested zone ID",
+			zoneName:       "az1",
+			expectedResult: "az1-id",
+			expectError:    false,
+		},
+		{
+			name:           "Should return error if AZ doesn't exist",
+			zoneName:       "az4",
+			expectedResult: "",
+			expectError:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := getCloudWithMockedDescribeAvailabilityZones()
+
+			result, err := c.zoneCache.getZoneIDByZoneName(tc.zoneName)
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected to see an error")
+				}
+			} else if err != nil {
+				t.Errorf("Should not error getting zone ID: %s", err)
+			}
+
+			assert.Equal(t, tc.expectedResult, result, "Should return the expected zone ID")
+		})
+	}
+}
+
 func TestGetZoneDetailsByNames(t *testing.T) {
 	for _, tc := range []struct {
 		name             string

--- a/tests/e2e/nodes.go
+++ b/tests/e2e/nodes.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+)
+
+var _ = Describe("[cloud-provider-aws-e2e] nodes", func() {
+	f := framework.NewDefaultFramework("cloud-provider-aws")
+
+	It("should set zone-id topology label", func(ctx context.Context) {
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(f.ClientSet, 10*time.Minute))
+
+		nodeList, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+
+		framework.ExpectNoError(err)
+
+		if len(nodeList.Items) < 2 {
+			framework.Failf("Conformance requires at least two nodes")
+		}
+
+		for _, node := range nodeList.Items {
+			gomega.Expect(node.Labels).To(gomega.HaveKey("topology.k8s.aws/zone-id"))
+		}
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As part of 1.30, [we added the ability to add custom labels from the cloud provider to nodes](https://github.com/kubernetes/kubernetes/pull/123223), and AWS customers are looking for a way to label nodes with a zone ID, which will be consistent across account. That label is added here.\

**Which issue(s) this PR fixes**:

Fixes #300

**Special notes for your reviewer**:
Added a new e2e case for this change.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Label nodes with zone-id topology label. AWS customers can use the `topology.k8s.aws/zone-id`
label on their nodes to associate observations across AWS accounts in a consistent way.
```
