### PR TITLE
update golang version to silence GO-2024-2824

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -42,10 +42,10 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.22.2
+          go-version-input: 1.22.3
           go-version-file: go.mod
       - id: govulncheck-tests-e2e
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.22.2
+          go-version-input: 1.22.3
           go-version-file: tests/e2e/go.mod

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: '1.22.2'
+          go-version: '1.22.3'
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Update Dependencies
         id: update_deps

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.2-bookworm.0
+defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.3-bookworm.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.22.2
+ARG GOLANG_IMAGE=golang:1.22.3
 
 # The distroless image on which the CPI manager image is built.
 #
@@ -22,7 +22,7 @@ ARG GOLANG_IMAGE=golang:1.22.2
 # deterministic builds. Follow what kubernetes uses to build
 # kube-controller-manager, for example for 1.23.x:
 # https://github.com/kubernetes/kubernetes/blob/release-1.24/build/common.sh#L94
-ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.2-bookworm.0
+ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.3-bookworm.0
 
 ################################################################################
 ##                              BUILD STAGE                                   ##

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
       - --platform=linux/amd64,linux/arm64
       - .
   # Build cloudbuild artifacts (for attestation)
-  - name: 'docker.io/library/golang:1.22.2-bookworm'
+  - name: 'docker.io/library/golang:1.22.3-bookworm'
     id: cloudbuild-artifacts
     entrypoint: make
     env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-aws
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/aws/aws-sdk-go v1.53.0


### PR DESCRIPTION
from: https://github.com/kubernetes/cloud-provider-aws/actions/runs/9127157592/job/25096868187?pr=917
```
=== Symbol Results ===

Vulnerability #1: GO-2024-2824
    Malformed DNS message can cause infinite loop in net
  More info: https://pkg.go.dev/vuln/GO-2024-2824
  Standard library
    Found in: net@go1.22.2
    Fixed in: net@go1.22.3
    Example traces found:
Error:       #1: pkg/providers/v1/aws_sdk.go:220:44: providers.awsSDKProvider.KeyManagement calls session.NewSessionWithOptions, which eventually calls net.Dial
Error:       #2: pkg/providers/v1/aws_ec2.go:134:41: providers.awsSdkEC2.RevokeSecurityGroupIngress calls ec2.EC2.RevokeSecurityGroupIngress, which eventually calls net.Dialer.DialContext
Error:       #3: cmd/ecr-credential-provider/main.go:246:50: ecr.main calls cobra.Command.Execute, which eventually calls net.ListenConfig.Listen
Error:       #4: pkg/providers/v1/aws_sdk.go:220:44: providers.awsSDKProvider.KeyManagement calls session.NewSessionWithOptions, which eventually calls net.LookupHost

Your code is affected by 1 vulnerability from the Go standard library.
This scan also found 0 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call these
vulnerabilities.
Use '-show verbose' for more details.
Error: Process completed with exit code 3.

```