### PR TITLE
refactor: allow variants to implement their own k8s providerID parsing logic

### DIFF
--- a/pkg/providers/v1/aws_instance.go
+++ b/pkg/providers/v1/aws_instance.go
@@ -20,7 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/apimachinery/pkg/types"
-
 	"k8s.io/cloud-provider-aws/pkg/providers/v1/iface"
 )
 
@@ -67,5 +66,5 @@ func newAWSInstance(ec2Service iface.EC2, instance *ec2.Instance) *awsInstance {
 
 // Gets the full information about this instance from the EC2 API
 func (i *awsInstance) describeInstance() (*ec2.Instance, error) {
-	return describeInstance(i.ec2, InstanceID(i.awsID))
+	return describeInstance(i.ec2, i.awsID)
 }

--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"k8s.io/cloud-provider-aws/pkg/providers/v1/awsnode"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -781,7 +782,7 @@ func (c *Cloud) chunkTargetDescriptions(targets []*elbv2.TargetDescription, chun
 
 // updateInstanceSecurityGroupsForNLB will adjust securityGroup's settings to allow inbound traffic into instances from clientCIDRs and portMappings.
 // TIP: if either instances or clientCIDRs or portMappings are nil, then the securityGroup rules for lbName are cleared.
-func (c *Cloud) updateInstanceSecurityGroupsForNLB(lbName string, instances map[InstanceID]*ec2.Instance, subnetCIDRs []string, clientCIDRs []string, portMappings []nlbPortMapping) error {
+func (c *Cloud) updateInstanceSecurityGroupsForNLB(lbName string, instances map[awsnode.NodeID]*ec2.Instance, subnetCIDRs []string, clientCIDRs []string, portMappings []nlbPortMapping) error {
 	if c.cfg.Global.DisableSecurityGroupIngress {
 		return nil
 	}
@@ -1430,7 +1431,7 @@ func (c *Cloud) ensureLoadBalancerHealthCheck(loadBalancer *elb.LoadBalancerDesc
 }
 
 // Makes sure that exactly the specified hosts are registered as instances with the load balancer
-func (c *Cloud) ensureLoadBalancerInstances(loadBalancerName string, lbInstances []*elb.Instance, instanceIDs map[InstanceID]*ec2.Instance) error {
+func (c *Cloud) ensureLoadBalancerInstances(loadBalancerName string, lbInstances []*elb.Instance, instanceIDs map[awsnode.NodeID]*ec2.Instance) error {
 	expected := sets.NewString()
 	for id := range instanceIDs {
 		expected.Insert(string(id))
@@ -1607,7 +1608,7 @@ func proxyProtocolEnabled(backend *elb.BackendServerDescription) bool {
 // findInstancesForELB gets the EC2 instances corresponding to the Nodes, for setting up an ELB
 // We ignore Nodes (with a log message) where the instanceid cannot be determined from the provider,
 // and we ignore instances which are not found
-func (c *Cloud) findInstancesForELB(nodes []*v1.Node, annotations map[string]string) (map[InstanceID]*ec2.Instance, error) {
+func (c *Cloud) findInstancesForELB(nodes []*v1.Node, annotations map[string]string) (map[awsnode.NodeID]*ec2.Instance, error) {
 
 	targetNodes := filterTargetNodes(nodes, annotations)
 

--- a/pkg/providers/v1/aws_loadbalancer_test.go
+++ b/pkg/providers/v1/aws_loadbalancer_test.go
@@ -18,6 +18,7 @@ package aws
 
 import (
 	"fmt"
+	"k8s.io/cloud-provider-aws/pkg/providers/v1/awsnode"
 	"reflect"
 	"testing"
 	"time"
@@ -592,7 +593,7 @@ func TestCloud_findInstancesForELB(t *testing.T) {
 		return
 	}
 
-	want := map[InstanceID]*ec2.Instance{
+	want := map[awsnode.NodeID]*ec2.Instance{
 		"i-self": awsServices.selfInstance,
 	}
 	got, err := c.findInstancesForELB([]*v1.Node{defaultNode}, nil)
@@ -601,9 +602,9 @@ func TestCloud_findInstancesForELB(t *testing.T) {
 
 	// Add a new EC2 instance
 	awsServices.instances = append(awsServices.instances, newInstance)
-	want = map[InstanceID]*ec2.Instance{
+	want = map[awsnode.NodeID]*ec2.Instance{
 		"i-self": awsServices.selfInstance,
-		InstanceID(aws.StringValue(newInstance.InstanceId)): newInstance,
+		awsnode.NodeID(aws.StringValue(newInstance.InstanceId)): newInstance,
 	}
 	got, err = c.findInstancesForELB([]*v1.Node{defaultNode, newNode}, nil)
 	assert.NoError(t, err)

--- a/pkg/providers/v1/aws_routes.go
+++ b/pkg/providers/v1/aws_routes.go
@@ -19,9 +19,9 @@ package aws
 import (
 	"context"
 	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/cloud-provider-aws/pkg/providers/v1/awsnode"
 	"k8s.io/klog/v2"
 
 	cloudprovider "k8s.io/cloud-provider"
@@ -114,7 +114,7 @@ func (c *Cloud) ListRoutes(ctx context.Context, clusterName string) ([]*cloudpro
 		if instanceID != "" {
 			_, found := instances[instanceID]
 			if found {
-				node, err := c.instanceIDToNodeName(InstanceID(instanceID))
+				node, err := c.instanceIDToNodeName(awsnode.NodeID(instanceID))
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"k8s.io/cloud-provider-aws/pkg/providers/v1/awsnode"
 	"math/rand"
 	"reflect"
 	"sort"
@@ -2399,7 +2400,7 @@ func TestNodeNameToInstanceID(t *testing.T) {
 func TestInstanceIDToNodeName(t *testing.T) {
 	testCases := []struct {
 		name             string
-		instanceID       InstanceID
+		instanceID       awsnode.NodeID
 		node             *v1.Node
 		expectedNodeName types.NodeName
 		expectedErr      error

--- a/pkg/providers/v1/awsnode/identifier.go
+++ b/pkg/providers/v1/awsnode/identifier.go
@@ -1,0 +1,11 @@
+package awsnode
+
+import "github.com/aws/aws-sdk-go/aws"
+
+// NodeID is the ID used to uniquely identify a node within an AWS service
+type NodeID string
+
+// AwsString returns a pointer to the string value of the NodeID. Useful for AWS APIs
+func (i NodeID) AwsString() *string {
+	return aws.String(string(i))
+}

--- a/pkg/providers/v1/instances.go
+++ b/pkg/providers/v1/instances.go
@@ -18,6 +18,7 @@ package aws
 
 import (
 	"fmt"
+	"k8s.io/cloud-provider-aws/pkg/providers/v1/awsnode"
 	"net/url"
 	"regexp"
 	"strings"
@@ -36,29 +37,14 @@ import (
 // awsInstanceRegMatch represents Regex Match for AWS instance.
 var awsInstanceRegMatch = regexp.MustCompile("^i-[^/]*$")
 
-// InstanceID represents the ID of the instance in the AWS API, e.g. i-12345678
-// The "traditional" format is "i-12345678"
-// A new longer format is also being introduced: "i-12345678abcdef01"
-// We should not assume anything about the length or format, though it seems
-// reasonable to assume that instances will continue to start with "i-".
-type InstanceID string
-
-func (i InstanceID) awsString() *string {
-	return aws.String(string(i))
-}
-
-// KubernetesInstanceID represents the id for an instance in the kubernetes API;
-// the following form
+// ParseProviderID turns a Kubernetes ProviderID into an AWS node id
+// the following are forms of ProviderIDs that are supported:
 //   - aws:///<zone>/<awsInstanceId>
 //   - aws:////<awsInstanceId>
 //   - aws:///<zone>/fargate-<eni-ip-address>
 //   - <awsInstanceId>
-type KubernetesInstanceID string
-
-// MapToAWSInstanceID extracts the InstanceID from the KubernetesInstanceID
-func (name KubernetesInstanceID) MapToAWSInstanceID() (InstanceID, error) {
-	s := string(name)
-
+func ParseProviderID(providerID string) (awsnode.NodeID, error) {
+	s := providerID
 	if !strings.HasPrefix(s, "aws://") {
 		// Assume a bare aws instance id (i-1234...)
 		// Build a URL with an empty host (AZ)
@@ -66,10 +52,14 @@ func (name KubernetesInstanceID) MapToAWSInstanceID() (InstanceID, error) {
 	}
 	url, err := url.Parse(s)
 	if err != nil {
-		return "", fmt.Errorf("Invalid instance name (%s): %v", name, err)
+		return "", fmt.Errorf("Invalid instance name (%s): %v", providerID, err)
 	}
 	if url.Scheme != "aws" {
-		return "", fmt.Errorf("Invalid scheme for AWS instance (%s)", name)
+		return "", fmt.Errorf("Invalid scheme for AWS instance (%s)", providerID)
+	}
+
+	if nodeID := variant.GetNodeID(*url); nodeID != "" {
+		return nodeID, nil
 	}
 
 	awsID := ""
@@ -81,21 +71,21 @@ func (name KubernetesInstanceID) MapToAWSInstanceID() (InstanceID, error) {
 
 	// We sanity check the resulting instance ID; the two known formats are
 	// i-12345678 and i-12345678abcdef01
-	if awsID == "" || !(awsInstanceRegMatch.MatchString(awsID) || variant.IsVariantNode(awsID)) {
-		return "", fmt.Errorf("Invalid format for AWS instance (%s)", name)
+	if awsID == "" || !awsInstanceRegMatch.MatchString(awsID) {
+		return "", fmt.Errorf("Invalid format for AWS instance (%s)", providerID)
 	}
 
-	return InstanceID(awsID), nil
+	return awsnode.NodeID(awsID), nil
 }
 
 // mapToAWSInstanceID extracts the InstanceIDs from the Nodes, returning an error if a Node cannot be mapped
-func mapToAWSInstanceIDs(nodes []*v1.Node) ([]InstanceID, error) {
-	var instanceIDs []InstanceID
+func mapToAWSInstanceIDs(nodes []*v1.Node) ([]awsnode.NodeID, error) {
+	var instanceIDs []awsnode.NodeID
 	for _, node := range nodes {
 		if node.Spec.ProviderID == "" {
 			return nil, fmt.Errorf("node %q did not have ProviderID set", node.Name)
 		}
-		instanceID, err := KubernetesInstanceID(node.Spec.ProviderID).MapToAWSInstanceID()
+		instanceID, err := ParseProviderID(node.Spec.ProviderID)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse ProviderID %q for node %q", node.Spec.ProviderID, node.Name)
 		}
@@ -106,14 +96,14 @@ func mapToAWSInstanceIDs(nodes []*v1.Node) ([]InstanceID, error) {
 }
 
 // mapToAWSInstanceIDsTolerant extracts the InstanceIDs from the Nodes, skipping Nodes that cannot be mapped
-func mapToAWSInstanceIDsTolerant(nodes []*v1.Node) []InstanceID {
-	var instanceIDs []InstanceID
+func mapToAWSInstanceIDsTolerant(nodes []*v1.Node) []awsnode.NodeID {
+	var instanceIDs []awsnode.NodeID
 	for _, node := range nodes {
 		if node.Spec.ProviderID == "" {
 			klog.Warningf("node %q did not have ProviderID set", node.Name)
 			continue
 		}
-		instanceID, err := KubernetesInstanceID(node.Spec.ProviderID).MapToAWSInstanceID()
+		instanceID, err := ParseProviderID(node.Spec.ProviderID)
 		if err != nil {
 			klog.Warningf("unable to parse ProviderID %q for node %q", node.Spec.ProviderID, node.Name)
 			continue
@@ -125,9 +115,9 @@ func mapToAWSInstanceIDsTolerant(nodes []*v1.Node) []InstanceID {
 }
 
 // Gets the full information about this instance from the EC2 API
-func describeInstance(ec2Client iface.EC2, instanceID InstanceID) (*ec2.Instance, error) {
+func describeInstance(ec2Client iface.EC2, instanceID string) (*ec2.Instance, error) {
 	request := &ec2.DescribeInstancesInput{
-		InstanceIds: []*string{instanceID.awsString()},
+		InstanceIds: []*string{&instanceID},
 	}
 
 	instances, err := ec2Client.DescribeInstances(request)
@@ -165,9 +155,9 @@ func (c *instanceCache) describeAllInstancesUncached() (*allInstancesSnapshot, e
 		return nil, err
 	}
 
-	m := make(map[InstanceID]*ec2.Instance)
+	m := make(map[awsnode.NodeID]*ec2.Instance)
 	for _, i := range instances {
-		id := InstanceID(aws.StringValue(i.InstanceId))
+		id := awsnode.NodeID(aws.StringValue(i.InstanceId))
 		m[id] = i
 	}
 
@@ -190,7 +180,7 @@ type cacheCriteria struct {
 
 	// HasInstances is a list of InstanceIDs that must be in a cached snapshot for it to be considered valid.
 	// If an instance is not found in the cached snapshot, the snapshot be ignored and we will re-fetch.
-	HasInstances []InstanceID
+	HasInstances []awsnode.NodeID
 }
 
 // describeAllInstancesCached returns all instances, using cached results if applicable
@@ -238,12 +228,12 @@ func (s *allInstancesSnapshot) MeetsCriteria(criteria cacheCriteria) bool {
 // along with the timestamp for cache-invalidation purposes
 type allInstancesSnapshot struct {
 	timestamp time.Time
-	instances map[InstanceID]*ec2.Instance
+	instances map[awsnode.NodeID]*ec2.Instance
 }
 
 // FindInstances returns the instances corresponding to the specified ids.  If an id is not found, it is ignored.
-func (s *allInstancesSnapshot) FindInstances(ids []InstanceID) map[InstanceID]*ec2.Instance {
-	m := make(map[InstanceID]*ec2.Instance)
+func (s *allInstancesSnapshot) FindInstances(ids []awsnode.NodeID) map[awsnode.NodeID]*ec2.Instance {
+	m := make(map[awsnode.NodeID]*ec2.Instance)
 	for _, id := range ids {
 		instance := s.instances[id]
 		if instance != nil {


### PR DESCRIPTION
== Motivation ==

Allow further variant specific customization

== Details ==

This change adds the ability for variants to implement their own logic to parse a k8s providerID into an identifier specific to that variant. This is done by adding a new method 'NodeId' on each variant that takes the providerID (in pre-parsed url format) and returns a respective NodeId. That said, the behavior of the existing Fargate variant and EC2 node are left unchanged. 

NodeId is a refactor of the previous InstanceId which was inadequately named for variants other than EC2 instances (e.g. fargate). I have also taken this opportunity to add a bit more strong typing to the variant methods to make these methods a bit easier to grok and safer to implement. I have also renamed the KubernetesInstanceId to KubernetesProviderId which felt a more adequate name as well. Finally, in order to prevent circular depedencies and to maintain (what I felt) was a more logical concept of a NodeId, we have created a new submodule in the v1 package named 'awsnode' which contains the NodeId type. This allows both the base v1 module and the variant submodule to use this NodeId type withou circular dependencies.

I have opted not to change variables named `instanceId` or similar for the time being given the bloat that would cause on this CR size. 

Im pushing this change now to get feedback quickly. Can work on adding the necessary testing steps/release notes as required. Based on https://github.com/kubernetes/cloud-provider-aws/pull/917, it seems this may not be required for this change. 