### PR TITLE
Automated cherry pick of #981: add support for new aws partitions in credential provider

### DIFF
--- a/cmd/ecr-credential-provider/main.go
+++ b/cmd/ecr-credential-provider/main.go
@@ -42,7 +42,7 @@ import (
 const ecrPublicRegion string = "us-east-1"
 const ecrPublicHost string = "public.ecr.aws"
 
-var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr\.ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(\.cn)?|sc2s\.sgov\.gov|c2s\.ic\.gov)$`)
+var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr\.ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(\.cn)?|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
 
 // ECR abstracts the calls we make to aws-sdk for testing purposes
 type ECR interface {

--- a/cmd/ecr-credential-provider/main_test.go
+++ b/cmd/ecr-credential-provider/main_test.go
@@ -375,6 +375,16 @@ func TestRegistryPatternMatch(t *testing.T) {
 		{"123456789012.dkr.cat.lala-land-1.awsamazon.com", false},
 		// too short
 		{"123456789012.lala-land-1.amazonaws.com", false},
+		// iso
+		{"123456789012.dkr.ecr.us-iso-east-1.c2s.ic.gov", true},
+		// iso-b
+		{"123456789012.dkr.ecr.us-isob-east-1.sc2s.sgov.gov", true},
+		// iso-e
+		{"123456789012.dkr.ecr.eu-isoe-west-1.cloud.adc-e.uk", true},
+		// iso-f
+		{"123456789012.dkr.ecr.us-isof-east-1.csp.hci.ic.gov", true},
+		// invalid gov endpoint
+		{"123456789012.dkr.ecr.us-iso-east-1.amazonaws.gov", false},
 	}
 	for _, g := range grid {
 		actual := ecrPrivateHostPattern.MatchString(g.Registry)


### PR DESCRIPTION
Cherry pick of #981 on release-1.28.

#981: add support for new aws partitions in credential provider

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```