### PR TITLE
Handle error while registering/deregistering target during load balancer update calls

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.4-bookworm.0
+defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.5-bookworm.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.22.4
+ARG GOLANG_IMAGE=golang:1.22.5
 
 # The distroless image on which the CPI manager image is built.
 #
@@ -22,7 +22,7 @@ ARG GOLANG_IMAGE=golang:1.22.4
 # deterministic builds. Follow what kubernetes uses to build
 # kube-controller-manager, for example for 1.23.x:
 # https://github.com/kubernetes/kubernetes/blob/release-1.24/build/common.sh#L94
-ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.4-bookworm.0
+ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.5-bookworm.0
 
 ################################################################################
 ##                              BUILD STAGE                                   ##

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
       - --platform=linux/amd64,linux/arm64
       - .
   # Build cloudbuild artifacts (for attestation)
-  - name: 'docker.io/library/golang:1.22.4-bookworm'
+  - name: 'docker.io/library/golang:1.22.5-bookworm'
     id: cloudbuild-artifacts
     entrypoint: make
     env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-aws
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/aws/aws-sdk-go v1.54.15

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -3013,7 +3013,8 @@ func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, serv
 
 	err = c.ensureLoadBalancerInstances(aws.StringValue(lb.LoadBalancerName), lb.Instances, instances)
 	if err != nil {
-		return nil
+		klog.Warningf("Error registering/deregistering instances with the load balancer: %q", err)
+		return err
 	}
 
 	err = c.updateInstanceSecurityGroupsForLoadBalancer(lb, instances, service.Annotations)

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-aws/tests/e2e
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/onsi/ginkgo/v2 v2.9.4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here: 
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If the RegisterInstancesWithLoadBalancer fails for any reason during an LoadBalancer Update call, we do not throw the error and return nil. So we will never know if the target group registration passes or fails



For testing - 
I tried to mock the ELB API as I wasn't able to hit the throttling every time. 

I introduced a 50% chance of ELB API failing to register the target using Mocked return message 
```
		val := rand.Int()
		if val%2 != 0 {
			klog.V(1).Infof("Not using Mocked call %s", loadBalancerName)
			_, err = c.elb.RegisterInstancesWithLoadBalancer(registerRequest)
		} else {
			klog.V(1).Infof("Using Mocked call %s", loadBalancerName)
			err = fmt.Errorf("mocked throttled call")
		}

		if err != nil {
			return err
		}
		klog.V(1).Infof("Instances added to load-balancer %s", loadBalancerName)
```


The events on the service 

```
Warning  UnAvailableLoadBalancer   6m31s                 service-controller  There are no available nodes for LoadBalancer
  Warning  UpdateLoadBalancerFailed  2m34s                 service-controller  Error updating load balancer with new hosts [i-035ae0c5cd612d191 i-05560870005eef14b i-0661ad74a5ae13914 i-0a48dd4251b3e24d3] [node names limited, total number of nodes: 4], error: mocked throttled call
  Normal   UpdatedLoadBalancer       2m6s (x6 over 6m58s)  service-controller  Updated load balancer with new hosts
  Warning  UpdateLoadBalancerFailed  53s                   service-controller  Error updating load balancer with new hosts [i-00153b6992defc5d0 i-035ae0c5cd612d191 i-05560870005eef14b i-0661ad74a5ae13914 i-0a48dd4251b3e24d3 i-0cc2ee458bb7db682] [node names limited, total number of nodes: 6], error: mocked throttled call
  Warning  SyncLoadBalancerFailed    28s (x6 over 2m30s)   service-controller  Error syncing load balancer: failed to ensure load balancer: mocked throttled call
  Normal   EnsuringLoadBalancer      8s (x9 over 13m)      service-controller  Ensuring load balancer
  Normal   EnsuredLoadBalancer       8s (x3 over 13m)      service-controller  Ensured load balancer
``` 

This shows that the controller retries and reconciles again in case of failures. 

The logs in the controller shows the new warn message that was added 

```
W0729 21:20:19.689788       1 aws.go:3016] Error registering/deregistering instances with the load balancer: "mocked throttled call"
I0729 21:20:19.747638       1 event.go:389] "Event occurred" object="ui/ui-nlb-11" fieldPath="" kind="Service" apiVersion="v1" type="Warning" reason="UpdateLoadBalancerFailed" message="Error updating load balancer with new hosts [i-00153b6992defc5d0 i-035ae0c5cd612d191 i-05560870005eef14b i-0661ad74a5ae13914 i-0a48dd4251b3e24d3 i-0cc2ee458bb7db682] [node names limited, total number of nodes: 6], error: mocked throttled call"
```




**Which issue(s) this PR fixes**:
N/A
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
N.A

**Does this PR introduce a user-facing change?**:
N/A
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Fixes an bug with UpdateLoadBalancer call where any failure in RegisterInstances API to ELB is always returned as success
```
