### PR TITLE
Automated cherry pick of #997: Handle error while registering/deregistering target during

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -4492,7 +4492,8 @@ func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, serv
 
 	err = c.ensureLoadBalancerInstances(aws.StringValue(lb.LoadBalancerName), lb.Instances, instances)
 	if err != nil {
-		return nil
+		klog.Warningf("Error registering/deregistering instances with the load balancer: %q", err)
+		return err
 	}
 
 	err = c.updateInstanceSecurityGroupsForLoadBalancer(lb, instances, service.Annotations)


### PR DESCRIPTION
Cherry pick of #997 on release-1.29.

#997: Handle error while registering/deregistering target during

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```