### PR TITLE
Switch to latest master of kops

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -131,7 +131,7 @@ if [[ "${UP}" = "yes" ]]; then
       --create-args="--dns=none --zones=${ZONES} --node-size=m5.large --master-size=m5.large --override=cluster.spec.cloudControllerManager.cloudProvider=aws --override=cluster.spec.cloudControllerManager.image=${IMAGE_NAME}:${IMAGE_TAG}" \
       --admin-access="0.0.0.0/0" \
       --kubernetes-version="${KUBERNETES_VERSION}" \
-      --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+      --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
 
       # Use the kops tester once we have a way of consuming an arbitrary e2e.test binary.
       #--test=kops \


### PR DESCRIPTION
the URL we are using seems to have gotten outdated. let's use kops master latest url.

```
❯ curl https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
https://storage.googleapis.com/k8s-staging-kops/kops/releases/1.30.0-beta.2+v1.30.0-beta.1-35-gcd7fba97d5

❯ curl https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt
https://storage.googleapis.com/k8s-staging-kops/kops/releases/1.30.0-beta.2+v1.30.0-beta.1-110-g5d4d867086
```

/assign @hakuna-matatah 