### PR TITLE
Automated cherry pick of #1028: Make metadata logging best-effort

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.5-bookworm.0
+defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.7-bookworm.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.22.5
+ARG GOLANG_IMAGE=golang:1.22.7
 
 # The distroless image on which the CPI manager image is built.
 #
@@ -22,7 +22,7 @@ ARG GOLANG_IMAGE=golang:1.22.5
 # deterministic builds. Follow what kubernetes uses to build
 # kube-controller-manager, for example for 1.23.x:
 # https://github.com/kubernetes/kubernetes/blob/release-1.24/build/common.sh#L94
-ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.5-bookworm.0
+ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.3.1-go1.22.7-bookworm.0
 
 ################################################################################
 ##                              BUILD STAGE                                   ##

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
       - --platform=linux/amd64,linux/arm64
       - .
   # Build cloudbuild artifacts (for attestation)
-  - name: 'docker.io/library/golang:1.22.5-bookworm'
+  - name: 'docker.io/library/golang:1.22.7-bookworm'
     id: cloudbuild-artifacts
     entrypoint: make
     env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-aws
 
-go 1.22.5
+go 1.22.7
 
 require (
 	github.com/aws/aws-sdk-go v1.55.5

--- a/pkg/providers/v1/aws_sdk.go
+++ b/pkg/providers/v1/aws_sdk.go
@@ -211,18 +211,17 @@ func (p *awsSDKProvider) Metadata() (config.EC2Metadata, error) {
 	p.addAPILoggingHandlers(&client.Handlers)
 
 	identity, err := client.GetInstanceIdentityDocument()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get instance identity document: %v", err)
+	if err == nil {
+		klog.InfoS("instance metadata identity",
+			"region", identity.Region,
+			"availability-zone", identity.AvailabilityZone,
+			"instance-type", identity.InstanceType,
+			"architecture", identity.Architecture,
+			"instance-id", identity.InstanceID,
+			"private-ip", identity.PrivateIP,
+			"account-id", identity.AccountID,
+			"image-id", identity.ImageID)
 	}
-	klog.InfoS("instance metadata identity",
-		"region", identity.Region,
-		"availability-zone", identity.AvailabilityZone,
-		"instance-type", identity.InstanceType,
-		"architecture", identity.Architecture,
-		"instance-id", identity.InstanceID,
-		"private-ip", identity.PrivateIP,
-		"account-id", identity.AccountID,
-		"image-id", identity.ImageID)
 	return client, nil
 }
 

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-aws/tests/e2e
 
-go 1.22.5
+go 1.22.7
 
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0


### PR DESCRIPTION
Cherry pick of #1028 on release-1.31.

#1028: Make metadata logging best-effort

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes an issue introduced in v1.31.0 where a fatal error occurs when AWS_EC2_METADATA_DISABLED is `true`
```