### PR TITLE
Add network topology information to nodes (continued)

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -44,6 +44,7 @@ For the `aws-cloud-controller-manager` to be able to communicate to AWS APIs, yo
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress",
         "ec2:DescribeVpcs",
+        "ec2:DescribeInstanceTopology",
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -391,6 +391,7 @@ type Cloud struct {
 
 	instanceCache instanceCache
 	zoneCache     zoneCache
+	topologyCache topologyCache
 
 	clientBuilder cloudprovider.ControllerClientBuilder
 	kubeClient    clientset.Interface
@@ -618,6 +619,7 @@ func newAWSCloud2(cfg config.CloudConfig, awsServices Services, provider config.
 	}
 	awsCloud.instanceCache.cloud = awsCloud
 	awsCloud.zoneCache.cloud = awsCloud
+	awsCloud.topologyCache.cloud = awsCloud
 
 	tagged := cfg.Global.KubernetesClusterTag != "" || cfg.Global.KubernetesClusterID != ""
 	if cfg.Global.VPC != "" && (cfg.Global.SubnetID != "" || cfg.Global.RoleARN != "") && tagged {

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -389,9 +389,9 @@ type Cloud struct {
 	// Note that we cache some state in awsInstance (mountpoints), so we must preserve the instance
 	selfAWSInstance *awsInstance
 
-	instanceCache instanceCache
-	zoneCache     zoneCache
-	topologyCache topologyCache
+	instanceCache           instanceCache
+	zoneCache               zoneCache
+	instanceTopologyManager *instanceTopologyManager
 
 	clientBuilder cloudprovider.ControllerClientBuilder
 	kubeClient    clientset.Interface
@@ -619,7 +619,7 @@ func newAWSCloud2(cfg config.CloudConfig, awsServices Services, provider config.
 	}
 	awsCloud.instanceCache.cloud = awsCloud
 	awsCloud.zoneCache.cloud = awsCloud
-	awsCloud.topologyCache.cloud = awsCloud
+	awsCloud.instanceTopologyManager = newInstanceTopologyManager(awsCloud.ec2)
 
 	tagged := cfg.Global.KubernetesClusterTag != "" || cfg.Global.KubernetesClusterID != ""
 	if cfg.Global.VPC != "" && (cfg.Global.SubnetID != "" || cfg.Global.RoleARN != "") && tagged {

--- a/pkg/providers/v1/aws_ec2.go
+++ b/pkg/providers/v1/aws_ec2.go
@@ -30,6 +30,16 @@ type awsSdkEC2 struct {
 	ec2 ec2iface.EC2API
 }
 
+func (s *awsSdkEC2) DescribeInstanceTopology(request *ec2.DescribeInstanceTopologyInput) ([]*ec2.InstanceTopology, error) {
+	resp, err := s.ec2.DescribeInstanceTopology(request)
+	if err != nil {
+		return nil, fmt.Errorf("error describe AWS Instance Topology: %q", err)
+	} else if len(resp.Instances) == 0 {
+		return []*ec2.InstanceTopology{}, nil
+	}
+	return resp.Instances, err
+}
+
 // Implementation of EC2.Instances
 func (s *awsSdkEC2) DescribeInstances(request *ec2.DescribeInstancesInput) ([]*ec2.Instance, error) {
 	// Instances are paged

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -240,6 +240,22 @@ func (ec2i *FakeEC2Impl) DescribeInstances(request *ec2.DescribeInstancesInput) 
 	return matches, nil
 }
 
+// DescribeInstanceTopology returns fake instance descriptions
+func (ec2i *FakeEC2Impl) DescribeInstanceTopology(request *ec2.DescribeInstanceTopologyInput) ([]*ec2.InstanceTopology, error) {
+	return []*ec2.InstanceTopology{
+		{
+			AvailabilityZone: aws.String("us-west-2b"),
+			InstanceId:       aws.String("i-123456789"),
+			NetworkNodes: []*string{
+				aws.String("nn-123456789"),
+				aws.String("nn-234567890"),
+				aws.String("nn-345678901"),
+			},
+			ZoneId: aws.String("az2"),
+		},
+	}, nil
+}
+
 // AttachVolume is not implemented but is required for interface conformance
 func (ec2i *FakeEC2Impl) AttachVolume(request *ec2.AttachVolumeInput) (resp *ec2.VolumeAttachment, err error) {
 	panic("Not implemented")

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -3725,6 +3725,11 @@ func (m *MockedEC2API) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec
 	return args.Get(0).(*ec2.DescribeInstancesOutput), args.Error(1)
 }
 
+func (m *MockedEC2API) DescribeInstanceTopology(input *ec2.DescribeInstanceTopologyInput) (*ec2.DescribeInstanceTopologyOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*ec2.DescribeInstanceTopologyOutput), args.Error(1)
+}
+
 func (m *MockedEC2API) DescribeAvailabilityZones(input *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
 	args := m.Called(input)
 	return args.Get(0).(*ec2.DescribeAvailabilityZonesOutput), args.Error(1)

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -3725,9 +3725,12 @@ func (m *MockedEC2API) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec
 	return args.Get(0).(*ec2.DescribeInstancesOutput), args.Error(1)
 }
 
-func (m *MockedEC2API) DescribeInstanceTopology(input *ec2.DescribeInstanceTopologyInput) (*ec2.DescribeInstanceTopologyOutput, error) {
+func (m *MockedEC2API) DescribeInstanceTopologyPages(input *ec2.DescribeInstanceTopologyInput, fn func(*ec2.DescribeInstanceTopologyOutput, bool) bool) error {
 	args := m.Called(input)
-	return args.Get(0).(*ec2.DescribeInstanceTopologyOutput), args.Error(1)
+	if args.Get(0) != nil {
+		fn(args.Get(0).(*ec2.DescribeInstanceTopologyOutput), true)
+	}
+	return args.Error(1)
 }
 
 func (m *MockedEC2API) DescribeAvailabilityZones(input *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {

--- a/pkg/providers/v1/iface/types.go
+++ b/pkg/providers/v1/iface/types.go
@@ -8,6 +8,7 @@ import "github.com/aws/aws-sdk-go/service/ec2"
 type EC2 interface {
 	// Query EC2 for instances matching the filter
 	DescribeInstances(request *ec2.DescribeInstancesInput) ([]*ec2.Instance, error)
+	DescribeInstanceTopology(request *ec2.DescribeInstanceTopologyInput) ([]*ec2.InstanceTopology, error)
 
 	DescribeSecurityGroups(request *ec2.DescribeSecurityGroupsInput) ([]*ec2.SecurityGroup, error)
 

--- a/pkg/providers/v1/instances_v2_test.go
+++ b/pkg/providers/v1/instances_v2_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
+	"strconv"
 	"testing"
 )
 
@@ -187,7 +188,10 @@ func TestInstanceMetadata(t *testing.T) {
 		assert.Equal(t, "us-west-2a", result.Zone)
 		assert.Equal(t, "us-west-2", result.Region)
 		assert.Equal(t, map[string]string{
-			LabelZoneID: "az1",
+			LabelZoneID:                        "az1",
+			LabelNetworkNode + strconv.Itoa(1): "nn-123456789",
+			LabelNetworkNode + strconv.Itoa(2): "nn-234567890",
+			LabelNetworkNode + strconv.Itoa(3): "nn-345678901",
 		}, result.AdditionalLabels)
 	})
 }

--- a/pkg/providers/v1/instances_v2_test.go
+++ b/pkg/providers/v1/instances_v2_test.go
@@ -19,14 +19,14 @@ package aws
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
-	"strconv"
-	"testing"
 )
 
 func TestGetProviderId(t *testing.T) {
@@ -188,11 +188,36 @@ func TestInstanceMetadata(t *testing.T) {
 		assert.Equal(t, "us-west-2a", result.Zone)
 		assert.Equal(t, "us-west-2", result.Region)
 		assert.Equal(t, map[string]string{
-			LabelZoneID:                        "az1",
-			LabelNetworkNode + strconv.Itoa(1): "nn-123456789",
-			LabelNetworkNode + strconv.Itoa(2): "nn-234567890",
-			LabelNetworkNode + strconv.Itoa(3): "nn-345678901",
+			LabelZoneID:                  "az1",
+			LabelNetworkNodePrefix + "1": "nn-123456789",
+			LabelNetworkNodePrefix + "2": "nn-234567890",
+			LabelNetworkNodePrefix + "3": "nn-345678901",
 		}, result.AdditionalLabels)
+	})
+
+	t.Run("Should skip additional labels if already set", func(t *testing.T) {
+		instance := makeInstance("i-00000000000000000", "192.168.0.1", "1.2.3.4", "instance-same.ec2.internal", "instance-same.ec2.external", nil, true)
+		c, _ := mockInstancesResp(&instance, []*ec2.Instance{&instance})
+		node := &v1.Node{
+			Spec: v1.NodeSpec{
+				ProviderID: fmt.Sprintf("aws:///us-west-2c/1abc-2def/%s", *instance.InstanceId),
+			},
+		}
+		// Set labels to skip attempts to update them
+		node.Labels = map[string]string{
+			LabelZoneID:                  "az1",
+			LabelNetworkNodePrefix + "1": "nn-123456789",
+			LabelNetworkNodePrefix + "2": "nn-234567890",
+			LabelNetworkNodePrefix + "3": "nn-345678901",
+		}
+
+		result, err := c.InstanceMetadata(context.TODO(), node)
+		if err != nil {
+			t.Errorf("Should not error getting InstanceMetadata: %s", err)
+		}
+
+		// Validate that labels are unchanged.
+		assert.Equal(t, map[string]string{}, result.AdditionalLabels)
 	})
 }
 

--- a/pkg/providers/v1/topology.go
+++ b/pkg/providers/v1/topology.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/klog/v2"
+)
+
+type topologyCache struct {
+	cloud               *Cloud
+	mutex               sync.RWMutex
+	unsupportedInstance []string
+	unsupportedRegion   []string
+}
+
+func (t *topologyCache) getNodeTopology(instanceType string, region string, instanceID string) (*ec2.InstanceTopology, error) {
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
+	if t.mightSupportTopology(instanceType, region) {
+		topologyRequest := &ec2.DescribeInstanceTopologyInput{InstanceIds: []*string{&instanceID}}
+		topology, err := t.cloud.ec2.DescribeInstanceTopology(topologyRequest)
+		if err != nil {
+			klog.Errorf("Error describing instance topology: %q", err)
+			if strings.Contains(err.Error(), "The functionality you requested is not available in this region") {
+				t.unsupportedRegion = append(t.unsupportedRegion, region)
+				return nil, nil
+			} else if strings.Contains(err.Error(), "You are not authorized to perform this operation") {
+				// gracefully handle the DecribeInstanceTopology access missing error
+				klog.Infof("Not authorized to perform: ec2:DescribeInstanceTopology, permission missing")
+				return nil, nil
+			}
+			return nil, err
+		} else if len(topology) == 0 {
+			// instanceType is not support topology info and the result is empty
+			t.unsupportedInstance = append(t.unsupportedInstance, instanceType)
+		}
+		return topology[0], nil
+	}
+	return nil, nil
+}
+
+func (t *topologyCache) mightSupportTopology(instanceType string, region string) bool {
+	// Initialize the map if it's unset
+	if t.unsupportedInstance == nil {
+		t.unsupportedInstance = []string{}
+	}
+	if t.unsupportedRegion == nil {
+		t.unsupportedRegion = []string{}
+	}
+	// if both instanceType and region are not in unsupported cache, the instance type and region might be supported
+	// or we haven't check the supportness and cache it yet. If they are unsupported and not cached, we will run
+	// describeTopology api once for them
+	// Initialize the map if it's unset
+	return !slices.Contains(t.unsupportedInstance, instanceType) && !slices.Contains(t.unsupportedRegion, region)
+}

--- a/pkg/providers/v1/topology_test.go
+++ b/pkg/providers/v1/topology_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGetNodeTopology(t *testing.T) {
+	t.Run("Should handle unsupported regions and utilize cache", func(t *testing.T) {
+		mockedEC2API := newMockedEC2API()
+		topologyManager := newInstanceTopologyManager(&awsSdkEC2{ec2: mockedEC2API})
+
+		mockedEC2API.On("DescribeInstanceTopologyPages", mock.Anything).Return(nil,
+			awserr.New("UnsupportedOperation", "Not supported in region", nil))
+
+		// Loop multiple times to check cache use
+		for i := 0; i < 2; i++ {
+			topology, err := topologyManager.getNodeTopology("some-type", "some-region", "some-id")
+			if err != nil {
+				t.Errorf("Should not error getting node topology: %s", err)
+			}
+			if topology != nil {
+				t.Errorf("Should not be returning a topology: %v", topology)
+			}
+		}
+
+		mockedEC2API.AssertNumberOfCalls(t, "DescribeInstanceTopologyPages", 1)
+	})
+
+	t.Run("Should handle unsupported instance types and utilize cache", func(t *testing.T) {
+		mockedEC2API := newMockedEC2API()
+		topologyManager := newInstanceTopologyManager(&awsSdkEC2{ec2: mockedEC2API})
+
+		mockedEC2API.On("DescribeInstanceTopologyPages", mock.Anything).Return(&ec2.DescribeInstanceTopologyOutput{}, nil)
+
+		// Loop multiple times to check cache use
+		for i := 0; i < 2; i++ {
+			topology, err := topologyManager.getNodeTopology("some-type", "some-region", "some-id")
+			if err != nil {
+				t.Errorf("Should not error getting node topology: %s", err)
+			}
+			if topology != nil {
+				t.Errorf("Should not be returning a topology: %v", topology)
+			}
+		}
+
+		mockedEC2API.AssertNumberOfCalls(t, "DescribeInstanceTopologyPages", 1)
+	})
+
+	t.Run("Should handle missing permissions to call DescribeInstanceTopology", func(t *testing.T) {
+		mockedEC2API := newMockedEC2API()
+		topologyManager := newInstanceTopologyManager(&awsSdkEC2{ec2: mockedEC2API})
+
+		mockedEC2API.On("DescribeInstanceTopologyPages", mock.Anything).Return(nil,
+			awserr.New("UnauthorizedOperation", "Update your perms", nil))
+
+		// Loop multiple times to check cache use
+		for i := 0; i < 2; i++ {
+			topology, err := topologyManager.getNodeTopology("some-type", "some-region", "some-id")
+			if err != nil {
+				t.Errorf("Should not error getting node topology: %s", err)
+			}
+			if topology != nil {
+				t.Errorf("Should not be returning a topology: %v", topology)
+			}
+		}
+
+		mockedEC2API.AssertNumberOfCalls(t, "DescribeInstanceTopologyPages", 2)
+	})
+
+	t.Run("Should handle exceeding request limits for DescribeInstanceTopology", func(t *testing.T) {
+		mockedEC2API := newMockedEC2API()
+		topologyManager := newInstanceTopologyManager(&awsSdkEC2{ec2: mockedEC2API})
+
+		mockedEC2API.On("DescribeInstanceTopologyPages", mock.Anything).Return(nil,
+			awserr.New("RequestLimitExceeded", "Slow down!", nil))
+
+		// Loop multiple times to check cache use
+		for i := 0; i < 2; i++ {
+			topology, err := topologyManager.getNodeTopology("some-type", "some-region", "some-id")
+			if err != nil {
+				t.Errorf("Should not error getting node topology: %s", err)
+			}
+			if topology != nil {
+				t.Errorf("Should not be returning a topology: %v", topology)
+			}
+		}
+
+		mockedEC2API.AssertNumberOfCalls(t, "DescribeInstanceTopologyPages", 2)
+	})
+
+	t.Run("Should return unhandled errors", func(t *testing.T) {
+		mockedEC2API := newMockedEC2API()
+		topologyManager := newInstanceTopologyManager(&awsSdkEC2{ec2: mockedEC2API})
+
+		mockedEC2API.On("DescribeInstanceTopologyPages", mock.Anything).Return(nil,
+			awserr.New("NOPE", "Nice try.", nil))
+
+		_, err := topologyManager.getNodeTopology("some-type", "some-region", "some-id")
+		if err == nil {
+			t.Errorf("Should have gotten an error")
+		}
+
+		mockedEC2API.AssertNumberOfCalls(t, "DescribeInstanceTopologyPages", 1)
+	})
+}

--- a/pkg/providers/v1/well_known_labels.go
+++ b/pkg/providers/v1/well_known_labels.go
@@ -20,7 +20,8 @@ const (
 	// LabelZoneID is a topology label that can be applied to any resource
 	// but will be initially applied to nodes.
 	LabelZoneID = "topology.k8s.aws/zone-id"
-	// LabelNetworkNode is a topology label that can be applied to any resource
-	// but will be initially applied to nodes.
-	LabelNetworkNode = "topology.k8s.aws/network-node-layer-"
+	// LabelNetworkNodePrefix is a topology label that can be applied to any resource,
+	// but will be initially applied to nodes. The suffix should be an incremented
+	// integer starting at 1.
+	LabelNetworkNodePrefix = "topology.k8s.aws/network-node-layer-"
 )

--- a/pkg/providers/v1/well_known_labels.go
+++ b/pkg/providers/v1/well_known_labels.go
@@ -20,4 +20,7 @@ const (
 	// LabelZoneID is a topology label that can be applied to any resource
 	// but will be initially applied to nodes.
 	LabelZoneID = "topology.k8s.aws/zone-id"
+	// LabelNetworkNode is a topology label that can be applied to any resource
+	// but will be initially applied to nodes.
+	LabelNetworkNode = "topology.k8s.aws/network-node-layer-"
 )

--- a/tests/e2e/nodes.go
+++ b/tests/e2e/nodes.go
@@ -22,6 +22,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	authv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 )
@@ -42,6 +45,62 @@ var _ = Describe("[cloud-provider-aws-e2e] nodes", func() {
 
 		for _, node := range nodeList.Items {
 			gomega.Expect(node.Labels).To(gomega.HaveKey("topology.k8s.aws/zone-id"))
+		}
+	})
+
+	It("should label nodes with topology network info if instance is supported", func(ctx context.Context) {
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(f.ClientSet, 10*time.Minute))
+		nodeList, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err)
+
+		if len(nodeList.Items) < 2 {
+			framework.Failf("Conformance requires at least two nodes")
+		}
+		clientConfig, err := framework.LoadConfig()
+		framework.ExpectNoError(err)
+		client, err := kubernetes.NewForConfig(clientConfig)
+		framework.ExpectNoError(err)
+
+		ssar := &authv1.SelfSubjectAccessReview{
+			Spec: authv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authv1.ResourceAttributes{
+					Group:    "ec2.amazonaws.com",
+					Resource: "describeInstanceTopology",
+					Verb:     "get",
+				},
+			},
+		}
+		result, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(context.TODO(), ssar, metav1.CreateOptions{})
+		if err != nil {
+			framework.Failf("Error checking EC2 describeInstanceTopology access: %v", err)
+		}
+		allowed := result.Status.Allowed
+		supportedInstanceType := "p4d.24xlarge"
+		topologyNetworkLabel1 := "topology.k8s.aws/network-node-layer-1"
+		topologyNetworkLabel2 := "topology.k8s.aws/network-node-layer-2"
+		topologyNetworkLabel3 := "topology.k8s.aws/network-node-layer-3"
+
+		for _, node := range nodeList.Items {
+			instanceType, hasInstanceType := node.Labels["node.kubernetes.io/instance-type"]
+			if !hasInstanceType {
+				framework.Failf("Node %s does not have instance-type label", node.Name)
+			}
+
+			if instanceType == supportedInstanceType && allowed {
+				gomega.Expect(node.Labels).To(gomega.HaveKey(topologyNetworkLabel1),
+					"Node with instance type %s should have label %s", supportedInstanceType, topologyNetworkLabel1)
+				gomega.Expect(node.Labels).To(gomega.HaveKey(topologyNetworkLabel2),
+					"Node with instance type %s should have label %s", supportedInstanceType, topologyNetworkLabel2)
+				gomega.Expect(node.Labels).To(gomega.HaveKey(topologyNetworkLabel3),
+					"Node with instance type %s should have label %s", supportedInstanceType, topologyNetworkLabel3)
+			} else {
+				gomega.Expect(node.Labels).NotTo(gomega.HaveKey(topologyNetworkLabel1),
+					"Node with instance type %s should not have label %s", instanceType, topologyNetworkLabel1)
+				gomega.Expect(node.Labels).NotTo(gomega.HaveKey(topologyNetworkLabel2),
+					"Node with instance type %s should not have label %s", instanceType, topologyNetworkLabel2)
+				gomega.Expect(node.Labels).NotTo(gomega.HaveKey(topologyNetworkLabel3),
+					"Node with instance type %s should not have label %s", instanceType, topologyNetworkLabel3)
+			}
 		}
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR is to Add network topology information to nodes for #998.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #998

**Special notes for your reviewer**:

I'm taking over #1025 because the author left on vacation and I'm continuing her work to get this merged.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Label nodes with network topology labels. AWS customers can use the `topology.k8s.aws/network-node-layer-N`
labels on their nodes to schedule workloads in close network proximity to each other.
```
