### PR TITLE
Removes unused autoscaling code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,9 @@ e2e.test:
 .PHONY: check
 check: verify-fmt verify-lint vet
 
+.PHONY: develop
+develop: aws-cloud-controller-manager test update-fmt check
+
 .PHONY: test
 test:
 	go test -count=1 -race -v $(shell go list ./...)

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -168,11 +168,6 @@ func (s *FakeAWSServices) LoadBalancingV2(region string) (ELBV2, error) {
 	return s.elbv2, nil
 }
 
-// Autoscaling returns a fake ASG client
-func (s *FakeAWSServices) Autoscaling(region string) (ASG, error) {
-	return s.asg, nil
-}
-
 // Metadata returns a fake EC2Metadata client
 func (s *FakeAWSServices) Metadata() (config.EC2Metadata, error) {
 	return s.metadata, nil

--- a/pkg/providers/v1/aws_sdk.go
+++ b/pkg/providers/v1/aws_sdk.go
@@ -25,7 +25,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elbv2"
@@ -177,27 +176,6 @@ func (p *awsSDKProvider) LoadBalancingV2(regionName string) (ELBV2, error) {
 	p.AddHandlers(regionName, &elbClient.Handlers)
 
 	return elbClient, nil
-}
-
-func (p *awsSDKProvider) Autoscaling(regionName string) (ASG, error) {
-	awsConfig := &aws.Config{
-		Region:      &regionName,
-		Credentials: p.creds,
-	}
-	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true).
-		WithEndpointResolver(p.cfg.GetResolver())
-	sess, err := session.NewSessionWithOptions(session.Options{
-		Config:            *awsConfig,
-		SharedConfigState: session.SharedConfigEnable,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("unable to initialize AWS session: %v", err)
-	}
-	client := autoscaling.New(sess)
-
-	p.AddHandlers(regionName, &client.Handlers)
-
-	return client, nil
 }
 
 func (p *awsSDKProvider) Metadata() (config.EC2Metadata, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I'm going to continue work on the AWS SDK v2 migration, and I saw code related to autoscaling groups, which we don't actually use for anything here, so I just removed it.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
