### PR TITLE
Cherry picks gracefully handles getting instance topology and unhandled variants in 1.31

### DIFF
--- a/pkg/resourcemanagers/topology.go
+++ b/pkg/resourcemanagers/topology.go
@@ -114,6 +114,11 @@ func (t *instanceTopologyManager) addUnsupported(key string) {
 }
 
 func (t *instanceTopologyManager) mightSupportTopology(instanceType string, region string) bool {
+	// In the case of fargate and possibly other variants, the instance type will be empty.
+	if len(instanceType) == 0 {
+		return false
+	}
+
 	if _, exists, err := t.unsupportedKeyStore.GetByKey(region); exists {
 		return false
 	} else if err != nil {

--- a/pkg/resourcemanagers/topology_test.go
+++ b/pkg/resourcemanagers/topology_test.go
@@ -26,6 +26,21 @@ import (
 )
 
 func TestGetNodeTopology(t *testing.T) {
+	t.Run("Should skip nodes that don't have instance type set", func(t *testing.T) {
+		mockedEc2SdkV2 := services.MockedEc2SdkV2{}
+		topologyManager := NewInstanceTopologyManager(&mockedEc2SdkV2)
+		// Loop multiple times to check cache use
+		topology, err := topologyManager.GetNodeTopology(context.TODO(), "" /* empty instance type */, "some-region", "some-id")
+		if err != nil {
+			t.Errorf("Should not error getting node topology: %s", err)
+		}
+		if topology != nil {
+			t.Errorf("Should not be returning a topology: %v", topology)
+		}
+
+		mockedEc2SdkV2.AssertNumberOfCalls(t, "DescribeInstanceTopology", 0)
+	})
+
 	t.Run("Should handle unsupported regions and utilize cache", func(t *testing.T) {
 		mockedEc2SdkV2 := services.MockedEc2SdkV2{}
 		topologyManager := NewInstanceTopologyManager(&mockedEc2SdkV2)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
[Fixes issue described here.](https://github.com/kubernetes/cloud-provider-aws/pull/1060)
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
