### PR TITLE
Update to latest ko

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ ko-build-tar: ko
 
 .PHONY: ko-build-local
 ko-build-local: ko
-	KO_DOCKER_REPO="$(IMAGE_REPOSITORY)" GOFLAGS="-ldflags=-X=k8s.io/component-base/version.gitVersion=$(VERSION)" ko build --tags ${VERSION} --platform=linux/amd64 --bare ./cmd/aws-cloud-controller-manager/ --push=false --local
+	KO_DOCKER_REPO="ko.local" GOFLAGS="-ldflags=-X=k8s.io/component-base/version.gitVersion=$(VERSION)" ko build --tags ${VERSION} --platform=linux/amd64 --bare ./cmd/aws-cloud-controller-manager/ --push=false --local
 	docker tag ko.local:${VERSION} $(IMAGE)
 
 .PHONY: e2e.test

--- a/hack/install-ko.sh
+++ b/hack/install-ko.sh
@@ -19,6 +19,5 @@ set -o nounset
 set -o pipefail
 
 if ! command -v ko &> /dev/null; then
-  go install github.com/google/ko@v0.11.2
+  go install github.com/google/ko@v0.17.1
 fi
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

CI jobs are broken because we were using an ancient version of `google/ko` that has a broken dependency chain:
```
> make ko-build-local
hack/install-ko.sh
go: downloading github.com/google/ko v0.11.2
go: github.com/google/ko@v0.11.2: version constraints conflict:
	github.com/google/ko@v0.11.2 indirectly requires nhooyr.io/websocket@v1.8.7: reading nhooyr.io/websocket/go.mod at revision v1.8.7: unknown revision v1.8.7
```

Results in:
```
 Error response from daemon: No such image: ko.local:v1.30.0-beta.0-110-gac63fea
The push refers to repository [209411653980.dkr.ecr.us-east-1.amazonaws.com/provider-aws/cloud-controller-manager]
An image does not exist locally with the tag: 209411653980.dkr.ecr.us-east-1.amazonaws.com/provider-aws/cloud-controller-manager 
```

See: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/cloud-provider-aws/1060/pull-cloud-provider-aws-e2e-kubetest2-quick/1861104799588552704

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
