### PR TITLE
Automated cherry pick of #1069: Update ECR Regex to support new dual stack endpoints, modify

### DIFF
--- a/cmd/ecr-credential-provider/main.go
+++ b/cmd/ecr-credential-provider/main.go
@@ -42,7 +42,7 @@ import (
 const ecrPublicRegion string = "us-east-1"
 const ecrPublicHost string = "public.ecr.aws"
 
-var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr\.ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(\.cn)?|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
+var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
 
 // ECR abstracts the calls we make to aws-sdk for testing purposes
 type ECR interface {
@@ -234,7 +234,7 @@ func parseHostFromImageReference(image string) (string, error) {
 
 func parseRegionFromECRPrivateHost(host string) string {
 	splitHost := ecrPrivateHostPattern.FindStringSubmatch(host)
-	if len(splitHost) != 6 {
+	if len(splitHost) != 5 {
 		return ""
 	}
 	return splitHost[3]

--- a/cmd/ecr-credential-provider/main_test.go
+++ b/cmd/ecr-credential-provider/main_test.go
@@ -328,11 +328,61 @@ func Test_parseRegionFromECRPrivateHost(t *testing.T) {
 		host   string
 		region string
 	}{
+		// us-west-2
 		{
 			name:   "success",
 			host:   "123456789123.dkr.ecr.us-west-2.amazonaws.com",
 			region: "us-west-2",
 		},
+		// CN region
+		{
+			name:   "success",
+			host:   "123456789123.dkr.ecr.cn-north-1.amazonaws.com.cn",
+			region: "cn-north-1",
+		},
+		// GovCloud
+		{
+			name:   "success",
+			host:   "123456789123.dkr.ecr.us-gov-east-1.amazonaws.com",
+			region: "us-gov-east-1",
+		},
+		// ISO
+		{
+			name:   "success",
+			host:   "123456789123.dkr.ecr.us-iso-east-1.c2s.ic.gov",
+			region: "us-iso-east-1",
+		},
+		// Dual-Stack
+		{
+			name:   "success",
+			host:   "123456789123.dkr-ecr.us-west-2.on.aws",
+			region: "us-west-2",
+		},
+		// Dual-Stack FIPS
+		{
+			name:   "success",
+			host:   "123456789123.dkr-ecr-fips.us-west-2.on.aws",
+			region: "us-west-2",
+		},
+		// IPv6 CN
+		{
+			name:   "success",
+			host:   "123456789123.dkr-ecr.cn-north-1.on.amazonwebservices.com.cn",
+			region: "cn-north-1",
+		},
+		// IPv6 GovCloud
+		{
+			name:   "success",
+			host:   "123456789123.dkr-ecr.us-gov-east-1.on.aws",
+			region: "us-gov-east-1",
+		},
+		// IPv6 GovCloud FIPS
+		{
+			name:   "success",
+			host:   "123456789123.dkr-ecr-fips.us-gov-east-1.on.aws",
+			region: "us-gov-east-1",
+		},
+		// Invalid name
 		{
 			name:   "invalid registry",
 			host:   "foobar",
@@ -395,6 +445,12 @@ func TestRegistryPatternMatch(t *testing.T) {
 		{"123456789012.dkr.ecr.us-isof-east-1.csp.hci.ic.gov", true},
 		// invalid gov endpoint
 		{"123456789012.dkr.ecr.us-iso-east-1.amazonaws.gov", false},
+		//IPv6 dual stack endpoint
+		{"123456789012.dkr-ecr.lala-land-1.on.aws", true},
+		//IPv6 dual stack endpoint fips
+		{"123456789012.dkr-ecr-fips.lala-land-1.on.aws", true},
+		//IPv6 dual stack endpoint .cn
+		{"123456789012.dkr-ecr.lala-land-1.on.amazonwebservices.com.cn", true},
 	}
 	for _, g := range grid {
 		actual := ecrPrivateHostPattern.MatchString(g.Registry)


### PR DESCRIPTION
Cherry pick of #1069 on release-1.31.

#1069: Update ECR Regex to support new dual stack endpoints, modify

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```