### PR TITLE
Allow configuring of cloudconfig using helm chart values

### DIFF
--- a/charts/aws-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/aws-cloud-controller-manager/templates/_helpers.tpl
@@ -2,4 +2,5 @@
 {{- .Values.nameOverride }}
 {{- end -}}
 
-
+{{- define "aws-cloud-config.name" }}
+{{- end }}

--- a/charts/aws-cloud-controller-manager/templates/cloudconfigmap.yaml
+++ b/charts/aws-cloud-controller-manager/templates/cloudconfigmap.yaml
@@ -1,0 +1,17 @@
+---
+{{- if .Values.cloudConfig.enabled }}
+apiVersion: v1
+data:
+  cloudconfig.cfg: |
+    {{- range $key, $value := .Values.cloudConfig }}
+    {{- if not (eq $key "enabled") }}
+    [{{ camelcase $key }}]
+      {{- range $subKey, $subValue := $value }}
+    {{ $subKey }}={{ $subValue }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+kind: ConfigMap
+metadata:
+  name: {{ template "aws-cloud-config.name" . }}
+{{- end }}

--- a/charts/aws-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/aws-cloud-controller-manager/templates/daemonset.yaml
@@ -32,15 +32,15 @@ spec:
       hostNetwork: true
       {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- $args := .Values.args }}
+          {{- if and (.Values.cloudConfig.enabled) (not (contains  "--cloud-config" (cat $args))) }}
+            {{- $args = append $args "--cloud-config=/etc/cloudconfig.cfg" }}
+          {{- end }}
           args:
-            {{- range .Values.args }}
+            {{- range $args }}
             - {{ . }}
             {{- end }}
           resources:
@@ -48,12 +48,26 @@ spec:
           env: {{- toYaml .Values.env | nindent 12 }}
           securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- with .Values.extraVolumeMounts  }}
+          {{- if or (.Values.cloudConfig.enabled) (.Values.extraVolumeMounts) }}
           volumeMounts:
+          {{- if .Values.cloudConfig.enabled }}
+            - name: {{ template "aws-cloud-config.name" . }}
+              mountPath: /etc/cloudconfig.cfg
+              subPath: cloudconfig.cfg
+          {{- end }}
+          {{- with .Values.extraVolumeMounts}}
           {{- toYaml .| nindent 12 }}
           {{- end }}
-      {{- with .Values.extraVolumes  }}
+          {{- end }}
+      {{- if or (.Values.cloudConfig.enabled) (.Values.extraVolumes) }}
       volumes:
+      {{- with .Values.extraVolumes}}
       {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.cloudConfig.enabled  }}
+        - name: {{ template "aws-cloud-config.name" . }}
+          configMap:
+            name: {{ template "aws-cloud-config.name" . }}
       {{- end }}
 ---

--- a/charts/aws-cloud-controller-manager/values.yaml
+++ b/charts/aws-cloud-controller-manager/values.yaml
@@ -8,9 +8,6 @@ image:
     repository: registry.k8s.io/provider-aws/cloud-controller-manager
     tag: v1.27.1
 
-# Specify image pull secrets
-imagePullSecrets: []
-
 # nameOverride overrides `cloud-controller-manager.fullname`
 nameOverride: "aws-cloud-controller-manager"
 
@@ -98,18 +95,6 @@ clusterRoleRules:
   - serviceaccounts/token
   verbs:
   - create
-- apiGroups:
-    - authentication.k8s.io
-  resources:
-    - tokenreviews
-  verbs:
-    - create
-- apiGroups:
-    - authorization.k8s.io
-  resources:
-    - subjectaccessreviews
-  verbs:
-    - create
 
 # resources -- Pod resource requests and limits.
 resources:
@@ -153,3 +138,6 @@ roleName: extension-apiserver-authentication-reader
 
 extraVolumes: []
 extraVolumeMounts: []
+
+cloudConfig:
+  enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR allows users to configure the cloud config file via helm chart values. For example to set the KubernetesClusterID value in the cloud config file a user would enter the following in their values.yaml file:
```
cloudConfig:
  enabled: true
  global:
    KubernetesClusterID: xyz
```
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
