### PR TITLE
Optimize node controller describe instances call volumne

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -857,6 +857,10 @@ func (c *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string
 		return nil, err
 	}
 
+	return c.getInstanceNodeAddress(instance)
+}
+
+func (c *Cloud) getInstanceNodeAddress(instance *ec2.Instance) ([]v1.NodeAddress, error) {
 	var addresses []v1.NodeAddress
 
 	for _, family := range c.cfg.Global.NodeIPFamilies {
@@ -993,8 +997,11 @@ func (c *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string)
 	if err != nil {
 		return "", err
 	}
+	return c.getInstanceType(instance), nil
+}
 
-	return aws.StringValue(instance.InstanceType), nil
+func (c *Cloud) getInstanceType(instance *ec2.Instance) string {
+	return aws.StringValue(instance.InstanceType)
 }
 
 // InstanceType returns the type of the node with the specified nodeName.
@@ -1034,13 +1041,14 @@ func (c *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (clo
 	if err != nil {
 		return cloudprovider.Zone{}, err
 	}
+	return c.getInstanceZone(instance), nil
+}
 
-	zone := cloudprovider.Zone{
+func (c *Cloud) getInstanceZone(instance *ec2.Instance) cloudprovider.Zone {
+	return cloudprovider.Zone{
 		FailureDomain: *(instance.Placement.AvailabilityZone),
 		Region:        c.region,
 	}
-
-	return zone, nil
 }
 
 // GetZoneByNodeName implements Zones.GetZoneByNodeName

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -199,6 +199,7 @@ type FakeEC2Impl struct {
 // DescribeInstances returns fake instance descriptions
 func (ec2i *FakeEC2Impl) DescribeInstances(request *ec2.DescribeInstancesInput) ([]*ec2.Instance, error) {
 	matches := []*ec2.Instance{}
+	var matchedInstances []string
 	for _, instance := range ec2i.aws.instances {
 		if request.InstanceIds != nil {
 			if instance.InstanceId == nil {
@@ -230,8 +231,10 @@ func (ec2i *FakeEC2Impl) DescribeInstances(request *ec2.DescribeInstancesInput) 
 			}
 		}
 		matches = append(matches, instance)
+		matchedInstances = append(matchedInstances, *instance.InstanceId)
 	}
 
+	ec2i.aws.countCall("ec2", "DescribeInstances", strings.Join(matchedInstances, ","))
 	return matches, nil
 }
 

--- a/pkg/providers/v1/instances_v2.go
+++ b/pkg/providers/v1/instances_v2.go
@@ -22,6 +22,8 @@ package aws
 
 import (
 	"context"
+	"fmt"
+	"k8s.io/cloud-provider-aws/pkg/providers/v1/variant"
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
@@ -110,25 +112,43 @@ func (c *Cloud) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprov
 	if err != nil {
 		return nil, err
 	}
-
-	instanceType, err := c.InstanceTypeByProviderID(ctx, providerID)
-	if err != nil {
-		return nil, err
-	}
-
-	zone, err := c.GetZoneByProviderID(ctx, providerID)
-	if err != nil {
-		return nil, err
-	}
-
-	nodeAddresses, err := c.NodeAddressesByProviderID(ctx, providerID)
-	if err != nil {
-		return nil, err
-	}
-
 	instanceID, err := KubernetesInstanceID(providerID).MapToAWSInstanceID()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to map provider ID to AWS instance ID for node %s: %w", node.Name, err)
+	}
+
+	var (
+		instanceType  string
+		zone          cloudprovider.Zone
+		nodeAddresses []v1.NodeAddress
+	)
+	if variant.IsVariantNode(string(instanceID)) {
+		instanceType, err = c.InstanceTypeByProviderID(ctx, providerID)
+		if err != nil {
+			return nil, err
+		}
+
+		zone, err = c.GetZoneByProviderID(ctx, providerID)
+		if err != nil {
+			return nil, err
+		}
+
+		nodeAddresses, err = c.NodeAddressesByProviderID(ctx, providerID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		instance, err := c.getInstanceByID(string(instanceID))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get instance by ID %s: %w", instanceID, err)
+		}
+
+		instanceType = c.getInstanceType(instance)
+		zone = c.getInstanceZone(instance)
+		nodeAddresses, err = c.getInstanceNodeAddress(instance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get node addresses for instance %s: %w", instanceID, err)
+		}
 	}
 
 	additionalLabels, err := c.getAdditionalLabels(ctx, zone.FailureDomain, string(instanceID), instanceType, zone.Region, node.Labels)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Currently, we make multiple ```ec2:DescribeInstances``` API calls to populate various fields in InstanceMetadata. This PR consolidates multiple API calls into a single request per instance, aiming to improve node join latency

#### Does this PR introduce a user-facing change?
No functional changes; the behavior remains the same, with fewer ```ec2:DescribeInstances``` API calls.