### PR TITLE
Enable concurrent workers for tagging controller

### DIFF
--- a/pkg/controllers/options/tagging_controller.go
+++ b/pkg/controllers/options/tagging_controller.go
@@ -58,6 +58,10 @@ func (o *TaggingControllerOptions) Validate() error {
 		return fmt.Errorf("--tagging-controller-burst-limit should not be less than zero")
 	}
 
+	if o.WorkerCount <= 0 {
+		return fmt.Errorf("--tagging-controller-concurrent-node-syncs must be a positive number")
+	}
+
 	for _, r := range o.Resources {
 		for _, resource := range SupportedResources {
 			if r != resource {

--- a/pkg/controllers/options/tagging_controller.go
+++ b/pkg/controllers/options/tagging_controller.go
@@ -36,7 +36,7 @@ func (o *TaggingControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Steady-state rate limit (per sec) at which the controller processes items in its queue. A value of zero (default) disables rate limiting.")
 	fs.IntVar(&o.BurstLimit, "tagging-controller-burst-limit", o.BurstLimit,
 		"Burst limit at which the controller processes items in its queue. A value of zero (default) disables rate limiting.")
-	fs.IntVar(&o.WorkerCount, "tagging-controller-concurrent-node-syncs", 10,
+	fs.IntVar(&o.WorkerCount, "tagging-controller-concurrent-node-syncs", 1,
 		"The number of workers concurrently synchronizing nodes")
 }
 

--- a/pkg/controllers/options/tagging_controller.go
+++ b/pkg/controllers/options/tagging_controller.go
@@ -21,10 +21,11 @@ import (
 // TaggingControllerOptions contains the inputs that can
 // be used in the tagging controller
 type TaggingControllerOptions struct {
-	Tags       map[string]string
-	Resources  []string
-	RateLimit  float64
-	BurstLimit int
+	Tags        map[string]string
+	Resources   []string
+	RateLimit   float64
+	BurstLimit  int
+	WorkerCount int
 }
 
 // AddFlags add the additional flags for the controller
@@ -35,6 +36,8 @@ func (o *TaggingControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Steady-state rate limit (per sec) at which the controller processes items in its queue. A value of zero (default) disables rate limiting.")
 	fs.IntVar(&o.BurstLimit, "tagging-controller-burst-limit", o.BurstLimit,
 		"Burst limit at which the controller processes items in its queue. A value of zero (default) disables rate limiting.")
+	fs.IntVar(&o.WorkerCount, "tagging-controller-concurrent-node-syncs", 10,
+		"The number of workers concurrently synchronizing nodes")
 }
 
 // Validate checks for errors from user input

--- a/pkg/controllers/tagging/tagging_controller_test.go
+++ b/pkg/controllers/tagging/tagging_controller_test.go
@@ -301,7 +301,7 @@ func TestMultipleEnqueues(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	tc, err := NewTaggingController(nodeInformer, clientset, fakeAws, time.Second, nil, []string{}, 0, 0)
+	tc, err := NewTaggingController(nodeInformer, clientset, fakeAws, time.Second, nil, []string{}, 0, 0, 10)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/controllers/tagging/tagging_controller_wrapper.go
+++ b/pkg/controllers/tagging/tagging_controller_wrapper.go
@@ -48,7 +48,8 @@ func (tc *ControllerWrapper) startTaggingController(ctx context.Context, initCon
 		tc.Options.Tags,
 		tc.Options.Resources,
 		tc.Options.RateLimit,
-		tc.Options.BurstLimit)
+		tc.Options.BurstLimit,
+		tc.Options.WorkerCount)
 
 	if err != nil {
 		klog.Warningf("failed to start tagging controller: %s", err)


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
* Tagging controller currently operates as a single-threaded process, leading to a backlog when processing nodes in larger clusters. PR introduces ```tagging-controller-concurrent-node-syncs``` option, allowing multiple parallel workers to pull from the work queue.
* Testing with 1,000 nodes at a concurrency level of 10, over 50% of the nodes are tagged in under 1 second. In contrast, with single concurrency, 90% of the nodes take between 1 to 10 seconds to be tagged.

```release-note
A new command-line flag, `tagging-controller-concurrent-node-syncs`, allows more than one node to be processed at once.
```