### PR TITLE
Adding batching to describe instance API calls

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -397,8 +397,9 @@ type Cloud struct {
 	eventRecorder    record.EventRecorder
 
 	// Batching AWS api calls
-	createTagsBatcher *createTagsBatcher
-	deleteTagsBatcher *deleteTagsBatcher
+	createTagsBatcher      *createTagsBatcher
+	deleteTagsBatcher      *deleteTagsBatcher
+	descibeInstanceBatcher *descibeInstanceBatcher
 }
 
 // Interface to make the CloudConfig immutable for awsSDKProvider
@@ -614,15 +615,16 @@ func newAWSCloud2(cfg config.CloudConfig, awsServices Services, provider config.
 	}
 
 	awsCloud := &Cloud{
-		ec2:               ec2,
-		elb:               elb,
-		elbv2:             elbv2,
-		metadata:          metadata,
-		kms:               kms,
-		cfg:               &cfg,
-		region:            regionName,
-		createTagsBatcher: newCreateTagsBatcher(ctx, ec2),
-		deleteTagsBatcher: newDeleteTagsBatcher(ctx, ec2),
+		ec2:                    ec2,
+		elb:                    elb,
+		elbv2:                  elbv2,
+		metadata:               metadata,
+		kms:                    kms,
+		cfg:                    &cfg,
+		region:                 regionName,
+		createTagsBatcher:      newCreateTagsBatcher(ctx, ec2),
+		deleteTagsBatcher:      newDeleteTagsBatcher(ctx, ec2),
+		descibeInstanceBatcher: newDescibeInstanceBatcher(ctx, ec2),
 	}
 	awsCloud.instanceCache.cloud = awsCloud
 	awsCloud.zoneCache.cloud = awsCloud
@@ -905,7 +907,7 @@ func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID strin
 		InstanceIds: []*string{instanceID.awsString()},
 	}
 
-	instances, err := c.ec2.DescribeInstances(request)
+	instances, err := c.descibeInstanceBatcher.DescribeInstances(ctx, request)
 	if err != nil {
 		// if err is InstanceNotFound, return false with no error
 		if IsAWSErrorInstanceNotFound(err) {
@@ -944,7 +946,7 @@ func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID str
 		InstanceIds: []*string{instanceID.awsString()},
 	}
 
-	instances, err := c.ec2.DescribeInstances(request)
+	instances, err := c.descibeInstanceBatcher.DescribeInstances(ctx, request)
 	if err != nil {
 		return false, err
 	}
@@ -3147,7 +3149,7 @@ func (c *Cloud) getInstancesByIDs(instanceIDs []*string) (map[string]*ec2.Instan
 		InstanceIds: instanceIDs,
 	}
 
-	instances, err := c.ec2.DescribeInstances(request)
+	instances, err := c.descibeInstanceBatcher.DescribeInstances(context.Background(), request)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -3753,7 +3753,7 @@ func TestInstanceExistsByProviderIDWithNodeNameForFargate(t *testing.T) {
 
 func TestInstanceExistsByProviderIDForInstanceNotFound(t *testing.T) {
 	mockedEC2API := newMockedEC2API()
-	c := &Cloud{ec2: &awsSdkEC2{ec2: mockedEC2API}}
+	c := &Cloud{ec2: &awsSdkEC2{ec2: mockedEC2API}, descibeInstanceBatcher: newDescibeInstanceBatcher(context.Background(), &awsSdkEC2{ec2: mockedEC2API})}
 
 	mockedEC2API.On("DescribeInstances", mock.Anything).Return(&ec2.DescribeInstancesOutput{}, awserr.New("InvalidInstanceID.NotFound", "Instance not found", nil))
 

--- a/pkg/providers/v1/descibe_instance_batch.go
+++ b/pkg/providers/v1/descibe_instance_batch.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/mitchellh/hashstructure/v2"
+	"github.com/samber/lo"
+	"k8s.io/cloud-provider-aws/pkg/providers/v1/batcher"
+	"k8s.io/cloud-provider-aws/pkg/providers/v1/iface"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// descibeInstanceBatcher contains the batcher details
+type descibeInstanceBatcher struct {
+	batcher *batcher.Batcher[ec2.DescribeInstancesInput, ec2.Instance]
+}
+
+// newDescibeInstanceBatcher creates a createDescibeInstanceBatcher object
+func newDescibeInstanceBatcher(ctx context.Context, ec2api iface.EC2) *descibeInstanceBatcher {
+	options := batcher.Options[ec2.DescribeInstancesInput, ec2.Instance]{
+		Name:          "create_tags",
+		IdleTimeout:   100 * time.Millisecond,
+		MaxTimeout:    1 * time.Second,
+		MaxItems:      50,
+		RequestHasher: describeInstanceHasher,
+		BatchExecutor: execDescribeInstanceBatch(ec2api),
+	}
+	return &descibeInstanceBatcher{batcher: batcher.NewBatcher(ctx, options)}
+}
+
+// CreateTags adds create tag input to batcher
+func (b *descibeInstanceBatcher) DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput) ([]*ec2.Instance, error) {
+	if len(input.InstanceIds) != 1 {
+		return nil, fmt.Errorf("expected to receive a single instance only, found %d", len(input.InstanceIds))
+	}
+	result := b.batcher.Add(ctx, input)
+	return []*ec2.Instance{result.Output}, result.Err
+}
+
+// DescribeInstanceHasher generates hash for different create tag inputs
+// Same inputs have same hash, so they get executed together
+func describeInstanceHasher(ctx context.Context, input *ec2.DescribeInstancesInput) uint64 {
+	hash, err := hashstructure.Hash(input.Filters, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed hashing input filters")
+	}
+	return hash
+}
+
+func execDescribeInstanceBatch(ec2api iface.EC2) batcher.BatchExecutor[ec2.DescribeInstancesInput, ec2.Instance] {
+	return func(ctx context.Context, inputs []*ec2.DescribeInstancesInput) []batcher.Result[ec2.Instance] {
+		results := make([]batcher.Result[ec2.Instance], len(inputs))
+		firstInput := inputs[0]
+		// aggregate instanceIDs into 1 input
+		for _, input := range inputs[1:] {
+			firstInput.InstanceIds = append(firstInput.InstanceIds, input.InstanceIds...)
+		}
+		batchedInput := &ec2.DescribeInstancesInput{
+			InstanceIds: firstInput.InstanceIds,
+		}
+		klog.Infof("Batched describe instances %v", batchedInput)
+		output, err := ec2api.DescribeInstances(batchedInput)
+		if err != nil {
+			klog.Errorf("Error occurred trying to batch describe instance, trying individually, %v", err)
+			var wg sync.WaitGroup
+			for idx, input := range inputs {
+				wg.Add(1)
+				go func(input *ec2.DescribeInstancesInput) {
+					defer wg.Done()
+					out, err := ec2api.DescribeInstances(input)
+					if err != nil {
+						results[idx] = batcher.Result[ec2.Instance]{Output: nil, Err: err}
+						return
+					}
+					results[idx] = batcher.Result[ec2.Instance]{Output: out[0], Err: err}
+				}(input)
+			}
+			wg.Wait()
+		} else {
+			instanceIDToOutputMap := map[string]*ec2.Instance{}
+			lo.ForEach(output, func(o *ec2.Instance, _ int) { instanceIDToOutputMap[lo.FromPtr(o.InstanceId)] = o })
+			for idx, input := range inputs {
+				results[idx] = batcher.Result[ec2.Instance]{Output: instanceIDToOutputMap[lo.FromPtr(input.InstanceIds[0])]}
+			}
+		}
+		return results
+	}
+}

--- a/pkg/providers/v1/instances_v2_test.go
+++ b/pkg/providers/v1/instances_v2_test.go
@@ -19,6 +19,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
@@ -102,7 +103,7 @@ func TestInstanceExists(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			c := getCloudWithMockedDescribeInstances(tc.instanceExists, tc.instanceState)
+			c := getCloudWithMockedDescribeInstances(tc.instanceExists, tc.instanceState, "i-abc")
 
 			result, err := c.InstanceExists(context.TODO(), &v1.Node{
 				Spec: v1.NodeSpec{
@@ -147,7 +148,7 @@ func TestInstanceShutdown(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			c := getCloudWithMockedDescribeInstances(tc.instanceExists, tc.instanceState)
+			c := getCloudWithMockedDescribeInstances(tc.instanceExists, tc.instanceState, "i-abc")
 
 			result, err := c.InstanceShutdown(context.TODO(), &v1.Node{
 				Spec: v1.NodeSpec{
@@ -303,9 +304,63 @@ func TestInstanceMetadata(t *testing.T) {
 	})
 }
 
-func getCloudWithMockedDescribeInstances(instanceExists bool, instanceState string) *Cloud {
+func TestDescribeInstanceBatching(t *testing.T) {
 	mockedEC2API := newMockedEC2API()
-	c := &Cloud{ec2: &awsSdkEC2{ec2: mockedEC2API}}
+	batcher := newDescibeInstanceBatcher(context.Background(), &awsSdkEC2{ec2: mockedEC2API})
+
+	mockedEC2API.On("DescribeInstances", mock.Anything).Return(&ec2.DescribeInstancesOutput{
+		Reservations: []*ec2.Reservation{
+			{
+				Instances: []*ec2.Instance{
+					{
+						InstanceId: aws.String("Test-1"),
+					},
+					{
+						InstanceId: aws.String("Test-2"),
+					},
+					{
+						InstanceId: aws.String("Test-3"),
+					},
+				},
+			},
+		},
+	}, nil)
+
+	type result struct {
+		input  string
+		output []*ec2.Instance
+		err    error
+	}
+
+	// Add extra space to channel so that we can ensure there were only 3 responses
+	resCh := make(chan result, 5)
+	helper := func(wg *sync.WaitGroup, input string) {
+		defer wg.Done()
+		res, err := batcher.DescribeInstances(context.Background(), &ec2.DescribeInstancesInput{InstanceIds: []*string{aws.String(input)}})
+		resCh <- result{input: input, output: res, err: err}
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+	go helper(&wg, "Test-1")
+	go helper(&wg, "Test-2")
+	go helper(&wg, "Test-3")
+	wg.Wait()
+	close(resCh)
+
+	assert.Len(t, resCh, 3)
+	for res := range resCh {
+		assert.NoError(t, res.err)
+		assert.Len(t, res.output, 1)
+		assert.Equal(t, res.input, *res.output[0].InstanceId)
+	}
+
+	mockedEC2API.AssertNumberOfCalls(t, "DescribeInstances", 1)
+}
+
+func getCloudWithMockedDescribeInstances(instanceExists bool, instanceState, instanceID string) *Cloud {
+	mockedEC2API := newMockedEC2API()
+	c := &Cloud{ec2: &awsSdkEC2{ec2: mockedEC2API}, descibeInstanceBatcher: newDescibeInstanceBatcher(context.Background(), &awsSdkEC2{ec2: mockedEC2API})}
 
 	if !instanceExists {
 		mockedEC2API.On("DescribeInstances", mock.Anything).Return(&ec2.DescribeInstancesOutput{}, awserr.New("InvalidInstanceID.NotFound", "Instance not found", nil))
@@ -315,6 +370,7 @@ func getCloudWithMockedDescribeInstances(instanceExists bool, instanceState stri
 				{
 					Instances: []*ec2.Instance{
 						{
+							InstanceId: aws.String(instanceID),
 							State: &ec2.InstanceState{
 								Name: aws.String(instanceState),
 							},

--- a/pkg/services/errors_mock.go
+++ b/pkg/services/errors_mock.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"errors"
+
 	"github.com/aws/smithy-go"
 )
 
@@ -14,6 +16,7 @@ type MockAPIError struct {
 // NewMockAPIError returns a new APIError
 func NewMockAPIError(code string, message string) smithy.APIError {
 	return &MockAPIError{
+		error:   errors.New(message),
 		code:    code,
 		message: message,
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

Node-controller calls DescribeInstances API every time a node joins the cluster. When multiple nodes join the cluster simultaneously, separate EC2 DescribeInstances API calls are made for each node, even though the API supports querying multiple instances in a single call. We are batching the call to EC2 API which reduces the overall call volumes made to EC2 and improve performance.

We have a similar batching for other EC2 calls in [Karpenter](https://github.com/aws/karpenter-provider-aws/tree/0a8251d6eba027c7d34acaf9d0fee2fc40832b67/pkg/batcher)

Sample Logs
```
I0520 00:04:26.135372   16837 descibe_instance_batch.go:83] Batched describe instances {
  InstanceIds: [
    "i-038c319c1b9c0c75e",
    "i-02b5e9c459a6cc573",
    "i-04908d55bbfe8be74",
    "i-072a0a9491bacf270"
  ]
}
```

Reduction in EC2 call volumes with batch -
<img width="1652" alt="Screenshot 2025-05-27 at 11 40 39 AM" src="https://github.com/user-attachments/assets/545aa021-6337-4aac-a346-79e99acad321" />

Without batch -

<img width="1702" alt="image" src="https://github.com/user-attachments/assets/da7d855d-cf88-4e32-bbc4-b4a6b844ccdb" />


```release-note
Improve tagging controller performance by batching EC2 describe instance API calls.
```
