### PR TITLE
[WIP] Support ServiceAccountToken in ecr-credential-provider

### DIFF
--- a/cmd/ecr-credential-provider/main_test.go
+++ b/cmd/ecr-credential-provider/main_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
 	publictypes "github.com/aws/aws-sdk-go-v2/service/ecrpublic/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
@@ -40,6 +42,15 @@ type MockedECR struct {
 
 func (m *MockedECR) GetAuthorizationToken(ctx context.Context, params *ecr.GetAuthorizationTokenInput, optFns ...func(*ecr.Options)) (*ecr.GetAuthorizationTokenOutput, error) {
 	args := m.Called(ctx, params)
+
+	opts := ecr.Options{}
+	for _, fn := range optFns {
+		fn(&opts)
+	}
+	if opts.Credentials != nil {
+		opts.Credentials.Retrieve(ctx)
+	}
+
 	if args.Get(1) != nil {
 		return args.Get(0).(*ecr.GetAuthorizationTokenOutput), args.Get(1).(error)
 	}
@@ -57,6 +68,18 @@ func (m *MockedECRPublic) GetAuthorizationToken(ctx context.Context, params *ecr
 		return args.Get(0).(*ecrpublic.GetAuthorizationTokenOutput), args.Get(1).(error)
 	}
 	return args.Get(0).(*ecrpublic.GetAuthorizationTokenOutput), nil
+}
+
+type MockedSTS struct {
+	mock.Mock
+}
+
+func (m *MockedSTS) AssumeRoleWithWebIdentity(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(1) != nil {
+		return args.Get(0).(*sts.AssumeRoleWithWebIdentityOutput), args.Get(1).(error)
+	}
+	return args.Get(0).(*sts.AssumeRoleWithWebIdentityOutput), nil
 }
 
 func generatePrivateGetAuthorizationTokenOutput(user string, password string, proxy string, expiration *time.Time) *ecr.GetAuthorizationTokenOutput {
@@ -159,7 +182,7 @@ func Test_GetCredentials_Private(t *testing.T) {
 			p := &ecrPlugin{ecr: &mockECR}
 			mockECR.On("GetAuthorizationToken", mock.Anything, mock.Anything).Return(testcase.getAuthorizationTokenOutput, testcase.getAuthorizationTokenError)
 
-			creds, err := p.GetCredentials(context.TODO(), testcase.image, testcase.args)
+			creds, err := p.GetCredentials(context.TODO(), &v1.CredentialProviderRequest{Image: testcase.image}, testcase.args)
 
 			if testcase.expectedError != nil && (testcase.expectedError.Error() != err.Error()) {
 				t.Fatalf("expected %s, got %s", testcase.expectedError.Error(), err.Error())
@@ -172,6 +195,100 @@ func Test_GetCredentials_Private(t *testing.T) {
 
 				if creds.Auth[testcase.image] != testcase.response.Auth[testcase.image] {
 					t.Fatalf("Unexpected Auth. Expected: %s, got: %s", testcase.response.Auth[testcase.image], creds.Auth[testcase.image])
+				}
+
+				if creds.CacheDuration.Duration != testcase.response.CacheDuration.Duration {
+					t.Fatalf("Unexpected CacheDuration. Expected: %s, got: %s", testcase.response.CacheDuration.Duration, creds.CacheDuration.Duration)
+				}
+			}
+		})
+	}
+}
+
+func Test_GetCredentials_PrivateForServiceAccount(t *testing.T) {
+	testcases := []struct {
+		name                            string
+		request                         *v1.CredentialProviderRequest
+		args                            []string
+		expectedAssumeArn               string
+		getAuthorizationTokenOutput     *ecr.GetAuthorizationTokenOutput
+		getAuthorizationTokenError      error
+		assumeRoleWithWebIdentityOutput *sts.AssumeRoleWithWebIdentityOutput
+		assumeRoleWithWebIdentityError  error
+		response                        *v1.CredentialProviderResponse
+		expectedError                   error
+	}{
+		{
+			name:                        "success",
+			request:                     &v1.CredentialProviderRequest{Image: "123456789123.dkr.ecr.us-west-2.amazonaws.com", ServiceAccountToken: "DEADBEEF=", ServiceAccountAnnotations: map[string]string{"eks.amazonaws.com/ecr-role-arn": "arn:expected"}},
+			expectedAssumeArn:           "arn:expected",
+			getAuthorizationTokenOutput: generatePrivateGetAuthorizationTokenOutput("user", "pass", "", nil),
+			assumeRoleWithWebIdentityOutput: &sts.AssumeRoleWithWebIdentityOutput{
+				Credentials: &ststypes.Credentials{
+					AccessKeyId:     aws.String("access-key-id"),
+					SecretAccessKey: aws.String("secret-access-key"),
+					SessionToken:    aws.String("session-token"),
+				},
+			},
+			response: generateResponse("123456789123.dkr.ecr.us-west-2.amazonaws.com", "user", "pass"),
+		},
+		{
+			name:                        "no arn provided",
+			request:                     &v1.CredentialProviderRequest{Image: "123456789123.dkr.ecr.us-west-2.amazonaws.com", ServiceAccountToken: "DEADBEEF="},
+			expectedAssumeArn:           "arn:expected",
+			getAuthorizationTokenOutput: generatePrivateGetAuthorizationTokenOutput("user", "pass", "", nil),
+			assumeRoleWithWebIdentityOutput: &sts.AssumeRoleWithWebIdentityOutput{
+				Credentials: &ststypes.Credentials{
+					AccessKeyId:     aws.String("access-key-id"),
+					SecretAccessKey: aws.String("secret-access-key"),
+					SessionToken:    aws.String("session-token"),
+				},
+			},
+			response:      generateResponse("123456789123.dkr.ecr.us-west-2.amazonaws.com", "user", "pass"),
+			expectedError: errors.New("no arn provided, cannot assume role using ServiceAccountToken"),
+		},
+		{
+			name:                           "assume error",
+			request:                        &v1.CredentialProviderRequest{Image: "123456789123.dkr.ecr.us-west-2.amazonaws.com", ServiceAccountToken: "DEADBEEF=", ServiceAccountAnnotations: map[string]string{"eks.amazonaws.com/ecr-role-arn": "arn:expected"}},
+			expectedAssumeArn:              "arn:expected",
+			getAuthorizationTokenOutput:    generatePrivateGetAuthorizationTokenOutput("user", "pass", "", nil),
+			assumeRoleWithWebIdentityError: errors.New("injected error"),
+			response:                       generateResponse("123456789123.dkr.ecr.us-west-2.amazonaws.com", "user", "pass"),
+			expectedError:                  errors.New("injected error"),
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			mockECR := MockedECR{}
+			mockSTS := MockedSTS{}
+			p := &ecrPlugin{ecr: &mockECR, sts: &mockSTS}
+			mockECR.On("GetAuthorizationToken", mock.Anything, mock.Anything).Return(testcase.getAuthorizationTokenOutput, testcase.getAuthorizationTokenError)
+
+			expectedInput := sts.AssumeRoleWithWebIdentityInput{
+				RoleArn:          aws.String(testcase.expectedAssumeArn),
+				RoleSessionName:  aws.String("ecr-credential-provider"),
+				WebIdentityToken: aws.String(testcase.request.ServiceAccountToken),
+			}
+			mockSTS.On("AssumeRoleWithWebIdentity", mock.Anything, &expectedInput).Return(testcase.assumeRoleWithWebIdentityOutput, testcase.assumeRoleWithWebIdentityError)
+			creds, err := p.GetCredentials(context.TODO(), testcase.request, testcase.args)
+			if err != nil {
+				if testcase.expectedError == nil {
+					t.Fatalf("got unexpected error %s", err.Error())
+
+				}
+
+				if testcase.expectedError.Error() != err.Error() {
+					t.Fatalf("expected %s, got %s", testcase.expectedError.Error(), err.Error())
+				}
+			}
+
+			if testcase.expectedError == nil {
+				if creds.CacheKeyType != testcase.response.CacheKeyType {
+					t.Fatalf("Unexpected CacheKeyType. Expected: %s, got: %s", testcase.response.CacheKeyType, creds.CacheKeyType)
+				}
+
+				if creds.Auth[testcase.request.Image] != testcase.response.Auth[testcase.request.Image] {
+					t.Fatalf("Unexpected Auth. Expected: %s, got: %s", testcase.response.Auth[testcase.request.Image], creds.Auth[testcase.request.Image])
 				}
 
 				if creds.CacheDuration.Duration != testcase.response.CacheDuration.Duration {
@@ -209,6 +326,13 @@ func Test_GetCredentials_Public(t *testing.T) {
 			image:                       "public.ecr.aws",
 			getAuthorizationTokenOutput: generatePublicGetAuthorizationTokenOutput("user", "pass", "", nil),
 			response:                    generateResponse("public.ecr.aws", "user", "pass"),
+		},
+		{
+			name:                        "empty image",
+			image:                       "",
+			getAuthorizationTokenOutput: &ecrpublic.GetAuthorizationTokenOutput{},
+			getAuthorizationTokenError:  nil,
+			expectedError:               errors.New("image in plugin request was empty"),
 		},
 		{
 			name:                        "empty authorization data",
@@ -257,7 +381,7 @@ func Test_GetCredentials_Public(t *testing.T) {
 			p := &ecrPlugin{ecrPublic: &mockECRPublic}
 			mockECRPublic.On("GetAuthorizationToken", mock.Anything, mock.Anything).Return(testcase.getAuthorizationTokenOutput, testcase.getAuthorizationTokenError)
 
-			creds, err := p.GetCredentials(context.TODO(), testcase.image, testcase.args)
+			creds, err := p.GetCredentials(context.TODO(), &v1.CredentialProviderRequest{Image: testcase.image}, testcase.args)
 
 			if testcase.expectedError != nil && (testcase.expectedError.Error() != err.Error()) {
 				t.Fatalf("expected %s, got %s", testcase.expectedError.Error(), err.Error())

--- a/cmd/ecr-credential-provider/plugin.go
+++ b/cmd/ecr-credential-provider/plugin.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/kubelet/pkg/apis/credentialprovider/install"
-	"k8s.io/kubelet/pkg/apis/credentialprovider/v1"
+	v1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
 )
 
 var (
@@ -43,7 +43,7 @@ func init() {
 // CredentialProvider is an interface implemented by the kubelet credential provider plugin to fetch
 // the username/password based on the provided image name.
 type CredentialProvider interface {
-	GetCredentials(ctx context.Context, image string, args []string) (response *v1.CredentialProviderResponse, err error)
+	GetCredentials(ctx context.Context, request *v1.CredentialProviderRequest, args []string) (response *v1.CredentialProviderResponse, err error)
 }
 
 // ExecPlugin implements the exec-based plugin for fetching credentials that is invoked by the kubelet.
@@ -85,11 +85,7 @@ func (e *ExecPlugin) runPlugin(ctx context.Context, r io.Reader, w io.Writer, ar
 		return err
 	}
 
-	if request.Image == "" {
-		return errors.New("image in plugin request was empty")
-	}
-
-	response, err := e.plugin.GetCredentials(ctx, request.Image, args)
+	response, err := e.plugin.GetCredentials(ctx, request, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/ecr-credential-provider/plugin_test.go
+++ b/cmd/ecr-credential-provider/plugin_test.go
@@ -24,13 +24,13 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubelet/pkg/apis/credentialprovider/v1"
+	v1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
 )
 
 type fakePlugin struct {
 }
 
-func (f *fakePlugin) GetCredentials(ctx context.Context, image string, args []string) (*v1.CredentialProviderResponse, error) {
+func (f *fakePlugin) GetCredentials(ctx context.Context, request *v1.CredentialProviderRequest, args []string) (*v1.CredentialProviderResponse, error) {
 	return &v1.CredentialProviderResponse{
 		CacheKeyType:  v1.RegistryPluginCacheKeyType,
 		CacheDuration: &metav1.Duration{Duration: 10 * time.Minute},
@@ -66,12 +66,6 @@ func Test_runPlugin(t *testing.T) {
 		{
 			name:        "invalid apiVersion",
 			in:          bytes.NewBufferString(`{"kind":"CredentialProviderRequest","apiVersion":"foo.k8s.io/v1","image":"test.registry.io/foobar"}`),
-			expectedOut: nil,
-			expectErr:   true,
-		},
-		{
-			name:        "empty image",
-			in:          bytes.NewBufferString(`{"kind":"CredentialProviderRequest","apiVersion":"credentialprovider.kubelet.k8s.io/v1","image":""}`),
 			expectedOut: nil,
 			expectErr:   true,
 		},

--- a/tests/e2e/ecr_creds.go
+++ b/tests/e2e/ecr_creds.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	gingko "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+)
+
+var _ = gingko.Describe("[cloud-provider-aws-e2e] ecr", func() {
+	f := framework.NewDefaultFramework("cloud-provider-aws")
+
+	gingko.It("should start pod using public ecr image", func(ctx context.Context) {
+		podclient := e2epod.NewPodClient(f)
+		pod := podclient.Create(&v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "test",
+						Image: "public.ecr.aws/nginx/nginx:latest",
+					},
+				},
+			},
+		})
+
+		event, err := podclient.WaitForErrorEventOrSuccess(pod)
+		framework.ExpectNoError(err)
+
+		if event != nil {
+			framework.Failf("got error event: %v", event)
+		}
+	})
+})


### PR DESCRIPTION
Extend ecr-credential-provider to support fine-grained access via kubernetes ServiceAccount tokens and STS's AssumeRoleWithWebIdentity.

This allows users to avoid long-lived secrets in their pods/nodes and instead use a short-lived credential generated by kubernetes in order to access private ECR images.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: This PR

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1147 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note

This PR adds support for using ServiceAccount tokens to authenticate with AWS when pulling images from private ECR registries. (See https://github.com/kubernetes/enhancements/issues/4412)
Users who wish to use this new feature will need to opt in to the feature flag and configure their kubernetes cluster and AWS resources appropriately.

```
