### PR TITLE
Fix ELB healthcheck configuration when annotation value is lowercase

### DIFF
--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -1385,7 +1385,7 @@ func (c *Cloud) ensureLoadBalancerHealthCheck(ctx context.Context, loadBalancer 
 	actual := loadBalancer.HealthCheck
 	// Override healthcheck protocol, port and path based on annotations
 	if s, ok := annotations[ServiceAnnotationLoadBalancerHealthCheckProtocol]; ok {
-		protocol = s
+		protocol = strings.ToUpper(s)
 	}
 	if s, ok := annotations[ServiceAnnotationLoadBalancerHealthCheckPort]; ok && s != defaultHealthCheckPort {
 		p, err := strconv.ParseInt(s, 10, 0)
@@ -1394,7 +1394,7 @@ func (c *Cloud) ensureLoadBalancerHealthCheck(ctx context.Context, loadBalancer 
 		}
 		port = int32(p)
 	}
-	switch strings.ToUpper(protocol) {
+	switch protocol {
 	case "HTTP", "HTTPS":
 		if path == "" {
 			path = defaultHealthCheckPath

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -2192,6 +2192,19 @@ func TestEnsureLoadBalancerHealthCheck(t *testing.T) {
 				Target:             aws.String("TCP:8080"),
 			},
 		},
+		{
+			name: "healthcheck protocol written lowercase should be converted to uppercase",
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerHealthCheckProtocol: "tcp",
+			},
+			want: elbtypes.HealthCheck{
+				HealthyThreshold:   aws.Int32(2),
+				UnhealthyThreshold: aws.Int32(6),
+				Timeout:            aws.Int32(5),
+				Interval:           aws.Int32(10),
+				Target:             aws.String("TCP:8080"),
+			},
+		},
 	}
 	lbName := "myLB"
 	// this HC will always differ from the expected HC and thus it is expected an


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug
 
**What this PR does / why we need it**:
 
Fix a code error that creates a wrong healthcheck configuration when the value of `"service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol"` annotation is specified lowercase 
 
**Which issue(s) this PR fixes**:
 
Fixes #1181 
 
**Special notes for your reviewer**:
Also added a test for this specific use case
 
**Does this PR introduce a user-facing change?**:
None
 
```release-note
Fixing a bug that creates a wrong healthcheck configuration when the value of `"service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol"` annotation is specified lowercase
```