### PR TITLE
refact e2e test config enhancing setup, logging, steps and documenting hooks

### DIFF
--- a/tests/e2e/loadbalancer.go
+++ b/tests/e2e/loadbalancer.go
@@ -34,10 +34,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 )
 
 const (
 	annotationLBType             = "service.beta.kubernetes.io/aws-load-balancer-type"
+	annotationLBInternal         = "service.beta.kubernetes.io/aws-load-balancer-internal"
 	annotationLBTargetNodeLabels = "service.beta.kubernetes.io/aws-load-balancer-target-node-labels"
 )
 
@@ -49,13 +51,6 @@ var (
 		"node-role.kubernetes.io/node",   // used in ccm-aws CI
 	}
 )
-
-// ClusterNodeDiscovery holds information about discovered worker nodes.
-type ClusterNodeDiscovery struct {
-	Selector     string
-	Count        int
-	SingleWorker string
-}
 
 // loadbalancer tests
 var _ = Describe("[cloud-provider-aws-e2e] loadbalancer", func() {
@@ -77,187 +72,237 @@ var _ = Describe("[cloud-provider-aws-e2e] loadbalancer", func() {
 	})
 
 	type loadBalancerTestCases struct {
-		Name                           string
-		ResourceSuffix                 string
-		Annotations                    map[string]string
-		PostConfigService              func(cfg *configServiceLB, svc *v1.Service, nodeDiscovery ClusterNodeDiscovery)
-		PostRunValidation              func(cfg *configServiceLB, svc *v1.Service, nodeDiscovery ClusterNodeDiscovery)
-		HookInClusterTestReachableHTTP bool
-		RequireAffinity                bool
-		SkipTestFailure                bool
+		// Overall test case configuration.
+		name             string
+		resourceSuffix   string
+		extraAnnotations map[string]string
+		listenerCount    int
+
+		// Hooks
+		// HookPostServiceConfig hook runs after the service manifest is created, and before the service is created.
+		hookPostServiceConfig func(cfg *e2eTestConfig)
+		// HookPostServiceCreate hook runs after the test is run.
+		hookPostServiceCreate func(cfg *e2eTestConfig)
+		// HookPreTest hook runs before the test is run.
+		hookPreTest func(cfg *e2eTestConfig)
+
+		// Flags to override default test behavior.
+		overrideTestRunInClusterReachableHTTP bool
+		requireAffinity                       bool
+
+		// Test verification
+		skipTestFailure bool
 	}
 	cases := []loadBalancerTestCases{
 		{
-			Name:           "should configure the loadbalancer based on annotations",
-			ResourceSuffix: "",
-			Annotations:    map[string]string{},
+			name:             "CLB should be reachable with default configurations",
+			resourceSuffix:   "",
+			extraAnnotations: map[string]string{},
 		},
 		{
-			Name:           "NLB should configure the loadbalancer based on annotations",
-			ResourceSuffix: "nlb",
-			Annotations: map[string]string{
-				annotationLBType: "nlb",
-			},
+			name:             "NLB should be reachable with default configurations",
+			resourceSuffix:   "nlb",
+			extraAnnotations: map[string]string{annotationLBType: "nlb"},
 		},
 		{
-			Name:           "NLB should configure the loadbalancer with target-node-labels",
-			ResourceSuffix: "sg-nd",
-			Annotations:    map[string]string{annotationLBType: "nlb"},
-			PostConfigService: func(cfg *configServiceLB, svc *v1.Service, nodeDiscovery ClusterNodeDiscovery) {
-				By(fmt.Sprintf("found %d nodes with selector %q\n", nodeDiscovery.Count, nodeDiscovery.Selector))
-				if svc.Annotations == nil {
-					svc.Annotations = map[string]string{}
+			name:             "NLB should be reachable with target-node-labels",
+			resourceSuffix:   "sg-nd",
+			extraAnnotations: map[string]string{annotationLBType: "nlb"},
+			hookPostServiceConfig: func(cfg *e2eTestConfig) {
+				framework.Logf("running hook post-service-config patching service annotations to test node label selector")
+				if cfg.svc.Annotations == nil {
+					cfg.svc.Annotations = map[string]string{}
 				}
-				svc.Annotations[annotationLBTargetNodeLabels] = nodeDiscovery.Selector
-				By(fmt.Sprintf("using service with annotations: %v", svc.Annotations))
+				cfg.svc.Annotations[annotationLBTargetNodeLabels] = cfg.nodeSelector
 			},
-			PostRunValidation: func(cfg *configServiceLB, svc *v1.Service, nodeDiscovery ClusterNodeDiscovery) {
-				if len(svc.Status.LoadBalancer.Ingress) == 0 {
-					framework.Failf("No ingress found in LoadBalancer status for service %s/%s", svc.Namespace, svc.Name)
+			hookPostServiceCreate: func(cfg *e2eTestConfig) {
+				framework.Logf("running hook post-service-create to validate the number of targets in the load balancer selected")
+				if len(cfg.svc.Status.LoadBalancer.Ingress) == 0 {
+					framework.Failf("No ingress found in LoadBalancer status for service %s/%s", cfg.svc.Namespace, cfg.svc.Name)
 				}
-				lbDNS := svc.Status.LoadBalancer.Ingress[0].Hostname
-				framework.ExpectNoError(getLBTargetCount(context.TODO(), lbDNS, nodeDiscovery.Count), "AWS LB target count validation failed")
+				lbDNS := cfg.svc.Status.LoadBalancer.Ingress[0].Hostname
+				framework.ExpectNoError(getLBTargetCount(cfg.ctx, lbDNS, cfg.nodeCount), "AWS LB target count validation failed")
 			},
 		},
-		// hairpin connection tests for internal CLB and NLB services LBs.
+		// Hairpining traffic test for CLB.
 		{
-			Name:           "internal should support hairpin connection",
-			ResourceSuffix: "hp-clb-int",
-			Annotations: map[string]string{
-				"service.beta.kubernetes.io/aws-load-balancer-internal": "true",
+			name:           "CLB internal should be reachable with hairpinning traffic",
+			resourceSuffix: "hp-clb-int",
+			extraAnnotations: map[string]string{
+				annotationLBInternal: "true",
 			},
-			PostConfigService: func(cfg *configServiceLB, svc *v1.Service, nodeDiscovery ClusterNodeDiscovery) {
-				if svc.Annotations == nil {
-					svc.Annotations = map[string]string{}
+			hookPostServiceConfig: func(cfg *e2eTestConfig) {
+				framework.Logf("running hook post-service-config patching service annotations to enforce LB pins/selects target to a single node: kubernetes.io/hostname=%s", cfg.nodeSingleSample)
+				if cfg.svc.Annotations == nil {
+					cfg.svc.Annotations = map[string]string{}
 				}
-				svc.Annotations[annotationLBTargetNodeLabels] = fmt.Sprintf("kubernetes.io/hostname=%s", nodeDiscovery.SingleWorker)
-				framework.Logf("Using service annotations: %v", svc.Annotations)
+				cfg.svc.Annotations[annotationLBTargetNodeLabels] = fmt.Sprintf("kubernetes.io/hostname=%s", cfg.nodeSingleSample)
 			},
-			HookInClusterTestReachableHTTP: true,
-			RequireAffinity:                true,
+			overrideTestRunInClusterReachableHTTP: true,
+			requireAffinity:                       true,
 		},
-		// FIXME: https://github.com/kubernetes/cloud-provider-aws/issues/1160
+		// Hairpining traffic test for NLB.
 		// Hairpin connection work with target type as instance only when preserve client IP is disabled.
 		// Currently CCM does not provide an interface to create a service with that setup, making an internal
 		// Service to fail.
+		// FIXME: https://github.com/kubernetes/cloud-provider-aws/issues/1160
+		// Once issue 1160 is fixed, the skipTestFailure must be unset/false.
 		{
-			Name:           "NLB internal should support hairpin connection",
-			ResourceSuffix: "hp-nlb-int",
-			Annotations: map[string]string{
-				annotationLBType: "nlb",
-				"service.beta.kubernetes.io/aws-load-balancer-internal": "true",
+			name:           "NLB internal should be reachable with hairpinning traffic",
+			resourceSuffix: "hp-nlb-int",
+			extraAnnotations: map[string]string{
+				annotationLBType:     "nlb",
+				annotationLBInternal: "true",
 			},
-			PostConfigService: func(cfg *configServiceLB, svc *v1.Service, nodeDiscovery ClusterNodeDiscovery) {
-				if svc.Annotations == nil {
-					svc.Annotations = map[string]string{}
+			listenerCount: 1,
+			hookPostServiceConfig: func(cfg *e2eTestConfig) {
+				framework.Logf("running hook post-service-config patching service annotations to enforce LB pins/selects target to a single node: kubernetes.io/hostname=%s", cfg.nodeSingleSample)
+				if cfg.svc.Annotations == nil {
+					cfg.svc.Annotations = map[string]string{}
 				}
-				svc.Annotations[annotationLBTargetNodeLabels] = fmt.Sprintf("kubernetes.io/hostname=%s", nodeDiscovery.SingleWorker)
-				framework.Logf("Using service annotations: %v", svc.Annotations)
+				cfg.svc.Annotations[annotationLBTargetNodeLabels] = fmt.Sprintf("kubernetes.io/hostname=%s", cfg.nodeSingleSample)
 			},
-			HookInClusterTestReachableHTTP: true,
-			RequireAffinity:                true,
-			SkipTestFailure:                true,
+			overrideTestRunInClusterReachableHTTP: true,
+			requireAffinity:                       true,
+			skipTestFailure:                       true,
 		},
 	}
 
 	serviceNameBase := "lbconfig-test"
 	for _, tc := range cases {
-		It(tc.Name, func() {
-			nodeDiscovery := discoverClusterWorkerNode(cs)
+		It(tc.name, func() {
+			By("setting up test environment and discovering worker nodes")
+			e2e := newE2eTestConfig(cs)
+			e2e.discoverClusterWorkerNode()
+			framework.Logf("[SETUP] Test case: %s", tc.name)
+			framework.Logf("[SETUP] Worker nodes discovered: %d nodes, selector: %s, sample node: %s", e2e.nodeCount, e2e.nodeSelector, e2e.nodeSingleSample)
+
 			loadBalancerCreateTimeout := e2eservice.GetServiceLoadBalancerCreationTimeout(cs)
-			framework.Logf("Running tests against AWS with timeout %s", loadBalancerCreateTimeout)
+			framework.Logf("[CONFIG] AWS load balancer timeout: %s", loadBalancerCreateTimeout)
 
-			// Create Configuration
+			By("building service configuration with annotations")
 			serviceName := serviceNameBase
-			if len(tc.ResourceSuffix) > 0 {
-				serviceName = serviceName + "-" + tc.ResourceSuffix
+			if len(tc.resourceSuffix) > 0 {
+				serviceName = serviceName + "-" + tc.resourceSuffix
 			}
-			framework.Logf("namespace for load balancer conig test: %s", ns.Name)
-
-			By("creating a TCP service " + serviceName + " with type=LoadBalancerType in namespace " + ns.Name)
-			lbConfig := newConfigServiceLB()
-			lbConfig.LBJig = e2eservice.NewTestJig(cs, ns.Name, serviceName)
+			framework.Logf("[CONFIG] Service name: %s, namespace: %s", serviceName, ns.Name)
+			e2e.LBJig = e2eservice.NewTestJig(cs, ns.Name, serviceName)
 
 			// Hook annotations to support dynamic config
-			lbServiceConfig := lbConfig.buildService(tc.Annotations)
+			e2e.svc = e2e.buildService(tc.listenerCount, tc.extraAnnotations)
+			framework.Logf("[CONFIG] Service ports: %d, extra annotations: %v", len(e2e.svc.Spec.Ports), tc.extraAnnotations)
 
-			// Hook: PostConfigService patchs service configuration.
-			if tc.PostConfigService != nil {
-				tc.PostConfigService(lbConfig, lbServiceConfig, nodeDiscovery)
+			if tc.hookPostServiceConfig != nil {
+				By("executing hook post-service-config: applying service configuration")
+				framework.Logf("[HOOK] Executing post-service-config hook")
+				tc.hookPostServiceConfig(e2e)
+				framework.Logf("[HOOK] Final service annotations: %v", e2e.svc.Annotations)
 			}
 
-			// Create Load Balancer
-			By("creating loadbalancer for service " + lbServiceConfig.Namespace + "/" + lbServiceConfig.Name)
-			if _, err := lbConfig.LBJig.Client.CoreV1().Services(lbConfig.LBJig.Namespace).Create(context.TODO(), lbServiceConfig, metav1.CreateOptions{}); err != nil {
-				framework.ExpectNoError(fmt.Errorf("failed to create LoadBalancer Service %q: %v", lbServiceConfig.Name, err))
+			By("creating LoadBalancer service in Kubernetes")
+			if _, err := e2e.LBJig.Client.CoreV1().Services(e2e.LBJig.Namespace).Create(context.TODO(), e2e.svc, metav1.CreateOptions{}); err != nil {
+				framework.ExpectNoError(fmt.Errorf("failed to create LoadBalancer Service %q: %v", e2e.svc.Name, err))
 			}
+			framework.Logf("[K8S] LoadBalancer service created successfully")
 
-			By("waiting for loadbalancer for service " + lbServiceConfig.Namespace + "/" + lbServiceConfig.Name)
-			lbService, err := lbConfig.LBJig.WaitForLoadBalancer(loadBalancerCreateTimeout)
+			By("waiting for AWS load balancer provisioning")
+			var err error
+			e2e.svc, err = e2e.LBJig.WaitForLoadBalancer(loadBalancerCreateTimeout)
 			framework.ExpectNoError(err)
+			framework.Logf("[AWS] Load balancer provisioned successfully")
 
-			// Run Workloads
-			By("creating a pod to be part of the TCP service " + serviceName)
-			_, err = lbConfig.LBJig.Run(lbConfig.buildReplicationController(tc.RequireAffinity, nodeDiscovery))
+			By("creating backend server pods")
+			_, err = e2e.LBJig.Run(e2e.buildReplicationController(tc.requireAffinity))
 			framework.ExpectNoError(err)
+			framework.Logf("[K8S] Backend pods created, affinity required: %t", tc.requireAffinity)
 
-			// Hook: PostRunValidation performs LB validations after it is created (before test).
-			if tc.PostRunValidation != nil {
-				By("running post run validations")
-				tc.PostRunValidation(lbConfig, lbService, nodeDiscovery)
+			if tc.hookPostServiceCreate != nil {
+				By("executing hook post-service-create: applying service configuration")
+				tc.hookPostServiceCreate(e2e)
 			}
 
-			// Test the Service Endpoint
-			By("hitting the TCP service's LB External IP")
-			if len(lbService.Spec.Ports) == 0 {
-				framework.Failf("No ports found in service spec for service %s/%s", lbService.Namespace, lbService.Name)
+			By("collecting service and load balancer information")
+			if len(e2e.svc.Spec.Ports) == 0 {
+				framework.Failf("No ports found in service spec for service %s/%s", e2e.svc.Namespace, e2e.svc.Name)
 			}
-			if len(lbService.Status.LoadBalancer.Ingress) == 0 {
-				framework.Failf("No ingress found in LoadBalancer status for service %s/%s", lbService.Namespace, lbService.Name)
+			if len(e2e.svc.Status.LoadBalancer.Ingress) == 0 {
+				framework.Failf("No ingress found in LoadBalancer status for service %s/%s", e2e.svc.Namespace, e2e.svc.Name)
 			}
-			svcPort := int(lbService.Spec.Ports[0].Port)
-			ingressIP := e2eservice.GetIngressPoint(&lbService.Status.LoadBalancer.Ingress[0])
-			framework.Logf("Load balancer's ingress IP: %s", ingressIP)
+			svcPort := int(e2e.svc.Spec.Ports[0].Port)
+			ingressAddress := e2eservice.GetIngressPoint(&e2e.svc.Status.LoadBalancer.Ingress[0])
+			framework.Logf("[LB-INFO] Ingress address: %s, port: %d", ingressAddress, svcPort)
 
-			// Hook: HookInClusterTestReachableHTTP changes the default test function to run the client in the cluster.
-			if tc.HookInClusterTestReachableHTTP {
-				err := inClusterTestReachableHTTP(cs, ns.Name, nodeDiscovery.SingleWorker, ingressIP, svcPort)
-				if err != nil && tc.SkipTestFailure {
+			if tc.hookPreTest != nil {
+				By("executing pre-test hook")
+				tc.hookPreTest(e2e)
+			}
+
+			// overrideTestRunInClusterReachableHTTP changes the default test function to run the client in the cluster.
+			if tc.overrideTestRunInClusterReachableHTTP {
+				By("testing HTTP connectivity from internal network")
+				framework.Logf("[TEST] Running internal connectivity test from node: %s", e2e.nodeSingleSample)
+				err := inClusterTestReachableHTTP(cs, ns.Name, e2e.nodeSingleSample, ingressAddress, svcPort)
+				if err != nil && tc.skipTestFailure {
 					Skip(err.Error())
 				}
 				framework.ExpectNoError(err)
 			} else {
-				e2eservice.TestReachableHTTP(ingressIP, svcPort, e2eservice.LoadBalancerLagTimeoutAWS)
+				By("testing HTTP connectivity from external client")
+				framework.Logf("[TEST] Running external connectivity test to %s:%d", ingressAddress, svcPort)
+				e2eservice.TestReachableHTTP(ingressAddress, svcPort, e2eservice.LoadBalancerLagTimeoutAWS)
 			}
+			framework.Logf("[TEST] HTTP connectivity test completed successfully")
 
 			// Update the service to cluster IP
-			By("changing TCP service back to type=ClusterIP")
-			_, err = lbConfig.LBJig.UpdateService(func(s *v1.Service) {
+			By("cleaning up: converting service to ClusterIP")
+			_, err = e2e.LBJig.UpdateService(func(s *v1.Service) {
 				s.Spec.Type = v1.ServiceTypeClusterIP
 			})
 			framework.ExpectNoError(err)
 
 			// Wait for the load balancer to be destroyed asynchronously
-			_, err = lbConfig.LBJig.WaitForLoadBalancerDestroy(ingressIP, svcPort, loadBalancerCreateTimeout)
+			By("cleaning up: waiting for load balancer destruction")
+			framework.Logf("[CLEANUP] Waiting for load balancer destruction")
+			_, err = e2e.LBJig.WaitForLoadBalancerDestroy(ingressAddress, svcPort, loadBalancerCreateTimeout)
 			framework.ExpectNoError(err)
+			framework.Logf("[CLEANUP] Load balancer destroyed successfully")
 		})
 	}
 })
 
-// configServiceLB hold loadbalancer test configurations used by e2e lib (jig).
-type configServiceLB struct {
-	PodPort            uint16
-	PodProtocol        v1.Protocol
-	DefaultAnnotations map[string]string
+type e2eTestConfig struct {
+	ctx        context.Context
+	kubeClient clientset.Interface
 
-	LBJig *e2eservice.TestJig
+	// service configuration
+	cfgPortCount          int
+	cfgPodPort            uint16
+	cfgPodProtocol        v1.Protocol
+	cfgDefaultAnnotations map[string]string
+	LBJig                 *e2eservice.TestJig
+
+	// service instance
+	svc *v1.Service
+
+	// node discovery
+	nodeSelector     string
+	nodeCount        int
+	nodeSingleSample string
 }
 
-func newConfigServiceLB() *configServiceLB {
-	return &configServiceLB{
-		PodPort:     8080,
-		PodProtocol: v1.ProtocolTCP,
-		DefaultAnnotations: map[string]string{
+func newE2eTestConfig(cs clientset.Interface) *e2eTestConfig {
+	// Create a context with a reasonable timeout for e2e tests
+	// E2E tests can take several minutes for load balancer provisioning and configuration
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	_ = cancel // We'll let the test framework handle cleanup
+
+	return &e2eTestConfig{
+		kubeClient:     cs,
+		cfgPortCount:   2,
+		ctx:            ctx,
+		cfgPodPort:     8080,
+		cfgPodProtocol: v1.ProtocolTCP,
+		cfgDefaultAnnotations: map[string]string{
 			"aws-load-balancer-backend-protocol": "http",
 			"aws-load-balancer-ssl-ports":        "https",
 		},
@@ -265,37 +310,34 @@ func newConfigServiceLB() *configServiceLB {
 }
 
 // buildService creates a service instance with custom annotations.
-func (s *configServiceLB) buildService(extraAnnotations map[string]string) *v1.Service {
+func (e2e *e2eTestConfig) buildService(portCount int, extraAnnotations map[string]string) *v1.Service {
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   s.LBJig.Namespace,
-			Name:        s.LBJig.Name,
-			Labels:      s.LBJig.Labels,
-			Annotations: make(map[string]string, len(s.DefaultAnnotations)+len(extraAnnotations)),
+			Namespace:   e2e.LBJig.Namespace,
+			Name:        e2e.LBJig.Name,
+			Labels:      e2e.LBJig.Labels,
+			Annotations: make(map[string]string, len(e2e.cfgDefaultAnnotations)+len(extraAnnotations)),
 		},
 		Spec: v1.ServiceSpec{
 			Type:            v1.ServiceTypeLoadBalancer,
 			SessionAffinity: v1.ServiceAffinityNone,
-			Selector:        s.LBJig.Labels,
-			Ports: []v1.ServicePort{
-				{
-					Name:       "http",
-					Protocol:   v1.ProtocolTCP,
-					Port:       int32(80),
-					TargetPort: intstr.FromInt(int(s.PodPort)),
-				},
-				{
-					Name:       "https",
-					Protocol:   v1.ProtocolTCP,
-					Port:       int32(443),
-					TargetPort: intstr.FromInt(int(s.PodPort)),
-				},
-			},
+			Selector:        e2e.LBJig.Labels,
 		},
+	}
+	if portCount == 0 {
+		portCount = e2e.cfgPortCount
+	}
+	for i := 0; i < portCount; i++ {
+		svc.Spec.Ports = append(svc.Spec.Ports, v1.ServicePort{
+			Name:       fmt.Sprintf("port-%d", i),
+			Protocol:   v1.ProtocolTCP,
+			Port:       int32(80 + i),
+			TargetPort: intstr.FromInt(int(e2e.cfgPodPort)),
+		})
 	}
 
 	// add default annotations - can be overriden by extra annotations
-	for aK, aV := range s.DefaultAnnotations {
+	for aK, aV := range e2e.cfgDefaultAnnotations {
 		svc.Annotations[aK] = aV
 	}
 
@@ -320,21 +362,21 @@ func (s *configServiceLB) buildService(extraAnnotations map[string]string) *v1.S
 // [1] https://github.com/kubernetes/kubernetes/blob/89d95c9713a8fd189e8ad555120838b3c4f888d1/test/e2e/framework/service/jig.go#L636
 // [2] https://github.com/kubernetes/kubernetes/issues/119021
 // [3] https://github.com/kubernetes/cloud-provider-aws/blob/master/tests/e2e/go.mod#L14
-func (s *configServiceLB) buildReplicationController(affinity bool, nodeDiscovery ClusterNodeDiscovery) func(rc *v1.ReplicationController) {
+func (e2e *e2eTestConfig) buildReplicationController(affinity bool) func(rc *v1.ReplicationController) {
 	return func(rc *v1.ReplicationController) {
 		var replicas int32 = 1
 		var grace int64 = 3
 		rc.ObjectMeta = metav1.ObjectMeta{
-			Namespace: s.LBJig.Namespace,
-			Name:      s.LBJig.Name,
-			Labels:    s.LBJig.Labels,
+			Namespace: e2e.LBJig.Namespace,
+			Name:      e2e.LBJig.Name,
+			Labels:    e2e.LBJig.Labels,
 		}
 		rc.Spec = v1.ReplicationControllerSpec{
 			Replicas: &replicas,
-			Selector: s.LBJig.Labels,
+			Selector: e2e.LBJig.Labels,
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: s.LBJig.Labels,
+					Labels: e2e.LBJig.Labels,
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -343,14 +385,14 @@ func (s *configServiceLB) buildReplicationController(affinity bool, nodeDiscover
 							Image: imageutils.GetE2EImage(imageutils.Agnhost),
 							Args: []string{
 								"netexec",
-								fmt.Sprintf("--http-port=%d", s.PodPort),
-								fmt.Sprintf("--udp-port=%d", s.PodPort),
+								fmt.Sprintf("--http-port=%d", e2e.cfgPodPort),
+								fmt.Sprintf("--udp-port=%d", e2e.cfgPodPort),
 							},
 							ReadinessProbe: &v1.Probe{
 								PeriodSeconds: 3,
 								ProbeHandler: v1.ProbeHandler{
 									HTTPGet: &v1.HTTPGetAction{
-										Port: intstr.FromInt(int(s.PodPort)),
+										Port: intstr.FromInt(int(e2e.cfgPodPort)),
 										Path: "/hostName",
 									},
 								},
@@ -371,7 +413,7 @@ func (s *configServiceLB) buildReplicationController(affinity bool, nodeDiscover
 									{
 										Key:      "kubernetes.io/hostname",
 										Operator: v1.NodeSelectorOpIn,
-										Values:   []string{nodeDiscovery.SingleWorker},
+										Values:   []string{e2e.nodeSingleSample},
 									},
 								},
 							},
@@ -383,6 +425,31 @@ func (s *configServiceLB) buildReplicationController(affinity bool, nodeDiscover
 	}
 }
 
+// discoverClusterWorkerNode identifies and selects worker nodes in the cluster based on predefined node label selectors.
+// It returns a ClusterNodeDiscovery struct with the discovered information.
+func (e2e *e2eTestConfig) discoverClusterWorkerNode() {
+	var workerNodeList []string
+	framework.Logf("discovering node label used in the kubernetes distributions")
+	for _, selector := range lookupNodeSelectors {
+		nodeList, err := e2e.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		framework.ExpectNoError(err, "failed to list worker nodes")
+		if len(nodeList.Items) > 0 {
+			for _, node := range nodeList.Items {
+				workerNodeList = append(workerNodeList, node.Name)
+			}
+			// Save the first worker node in the list to be used in cases.
+			sort.Strings(workerNodeList)
+			e2e.nodeCount = len(nodeList.Items)
+			e2e.nodeSingleSample = workerNodeList[0]
+			e2e.nodeSelector = selector
+			return
+		}
+	}
+	framework.ExpectNoError(fmt.Errorf("unable to find node selector for %v", lookupNodeSelectors))
+}
+
 // getLBTargetCount verifies the number of registered targets for a given LBv2 DNS name matches the expected count.
 // The steps includes:
 // - Get Load Balancer ARN from DNS name extracted from service Status.LoadBalancer.Ingress[0].Hostname
@@ -392,27 +459,17 @@ func (s *configServiceLB) buildReplicationController(affinity bool, nodeDiscover
 // - Verify count matches number of worker nodes
 func getLBTargetCount(ctx context.Context, lbDNSName string, expectedTargets int) error {
 	// Load AWS config
-	cfg, err := config.LoadDefaultConfig(ctx)
+	elbClient, err := getAWSClientLoadBalancer(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to load AWS config: %v", err)
+		return fmt.Errorf("unable to create AWS client: %v", err)
 	}
-	elbClient := elbv2.NewFromConfig(cfg)
 
 	// Get Load Balancer ARN from DNS name
-	describeLBs, err := elbClient.DescribeLoadBalancers(ctx, &elbv2.DescribeLoadBalancersInput{})
+	foundLB, err := getAWSLoadBalancerFromDNSName(ctx, elbClient, lbDNSName)
 	if err != nil {
-		return fmt.Errorf("failed to describe load balancers: %v", err)
+		return fmt.Errorf("failed to get load balancer from DNS name: %v", err)
 	}
-	var lbARN string
-	for _, lb := range describeLBs.LoadBalancers {
-		if strings.EqualFold(aws.ToString(lb.DNSName), lbDNSName) {
-			lbARN = aws.ToString(lb.LoadBalancerArn)
-			break
-		}
-	}
-	if lbARN == "" {
-		return fmt.Errorf("could not find LB with DNS name: %s", lbDNSName)
-	}
+	lbARN := aws.ToString(foundLB.LoadBalancerArn)
 
 	// List listeners for the load balancer
 	listenersOut, err := elbClient.DescribeListeners(ctx, &elbv2.DescribeListenersInput{
@@ -458,31 +515,43 @@ func getLBTargetCount(ctx context.Context, lbDNSName string, expectedTargets int
 	return nil
 }
 
-// discoverClusterWorkerNode identifies and selects worker nodes in the cluster based on predefined node label selectors.
-// It returns a ClusterNodeDiscovery struct with the discovered information.
-func discoverClusterWorkerNode(cs clientset.Interface) ClusterNodeDiscovery {
-	var workerNodeList []string
-	framework.Logf("discovering node label used in the kubernetes distributions")
-	for _, selector := range lookupNodeSelectors {
-		nodeList, err := cs.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-			LabelSelector: selector,
-		})
-		framework.ExpectNoError(err, "failed to list worker nodes")
-		if len(nodeList.Items) > 0 {
-			for _, node := range nodeList.Items {
-				workerNodeList = append(workerNodeList, node.Name)
-			}
-			// Save the first worker node in the list to be used in cases.
-			sort.Strings(workerNodeList)
-			return ClusterNodeDiscovery{
-				Selector:     selector,
-				Count:        len(nodeList.Items),
-				SingleWorker: workerNodeList[0],
+// AWS helpers
+func getAWSClientLoadBalancer(ctx context.Context) (*elbv2.Client, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS config: %v", err)
+	}
+	return elbv2.NewFromConfig(cfg), nil
+}
+
+func getAWSLoadBalancerFromDNSName(ctx context.Context, elbClient *elbv2.Client, lbDNSName string) (*elbv2types.LoadBalancer, error) {
+	var foundLB *elbv2types.LoadBalancer
+	framework.Logf("describing load balancers with DNS %s", lbDNSName)
+
+	paginator := elbv2.NewDescribeLoadBalancersPaginator(elbClient, &elbv2.DescribeLoadBalancersInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		framework.ExpectNoError(err)
+
+		framework.Logf("found %d load balancers", len(page.LoadBalancers))
+		// Search for the load balancer with matching DNS name in this page
+		for i := range page.LoadBalancers {
+			if aws.ToString(page.LoadBalancers[i].DNSName) == lbDNSName {
+				foundLB = &page.LoadBalancers[i]
+				framework.Logf("found load balancer with DNS %s", aws.ToString(foundLB.DNSName))
+				break
 			}
 		}
+		if foundLB != nil {
+			break
+		}
 	}
-	framework.ExpectNoError(fmt.Errorf("unable to find node selector for %v", lookupNodeSelectors))
-	return ClusterNodeDiscovery{}
+
+	if foundLB == nil {
+		framework.Failf("No load balancer found with DNS name: %s", lbDNSName)
+	}
+
+	return foundLB, nil
 }
 
 // inClusterTestReachableHTTP creates a pod within the cluster to test HTTP connectivity to a target IP and port.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR introduce several updates in the e2e loadbalancer reachable e2e test cases targeting to:
- enhance the e2e documentation on hooks utilization
- encapsulating test case configuration/data into a single container
- enhance ginkgo steps and framework logging 

The main motivation of this PR is to increase the flexibility to add new test cases with customization without losing existing reachable test configuration. This is an isolated PR from broad/unrelated changes from  https://github.com/kubernetes/cloud-provider-aws/pull/1214

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
