### PR TITLE
docs/devel: add CI monitoring information for developers

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -194,9 +194,12 @@ The CI jobs are defined in the [kubernetes/test-infra repository][k-test-infra-c
 
 The e2e test suite is defined in [tests/e2e](https://github.com/kubernetes/cloud-provider-aws/tree/master/tests/e2e).
 
+When you need to investigate CI infrastructure issues (such as build timeouts, resource constraints, or job failures), you can use the Grafana instance available at [monitoring-eks.prow.k8s.io][monitoring-eks]. The [Build Dashboard][monitoring-eks-dash-build] is commonly used to monitor resource usage from build jobs.
 
 [prow]: https://github.com/kubernetes-sigs/prow
 [kops]: https://github.com/kubernetes/kops/tree/master
 [test-grid]: https://testgrid.k8s.io/amazon-ec2
 [test-grid-e2e]: https://testgrid.k8s.io/amazon-ec2#ci-cloud-provider-aws-e2e
 [k-test-infra-ccm]: https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
+[monitoring-eks]: https://monitoring-eks.prow.k8s.io/
+[monitoring-eks-dash-build]: https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Update docs/development.md with useful information about monitoring dashboards to investigate CI build issues.

With this change, developers will have more information about failures in their PRs and CI test infrastructure, allowing them to investigate and distinguish between CI infrastructure issues and code-related failures. 

The main motivation is to:
- Decrease the total time for proposal readiness
- Reduce maintainer time spent reviewing CI-related known issues  
- Maintain stability and confidence in the development process

**Which issue(s) this PR fixes**:

Fixes #

Related to: 
- https://github.com/kubernetes/test-infra/pull/35274
- https://kubernetes.slack.com/archives/C7J9RP96G/p1754505741634999

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
