### PR TITLE
Remove potential nil ptr dereferences

### DIFF
--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing/types"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"k8s.io/klog/v2"
@@ -604,7 +605,7 @@ func (e *FakeELB) ConfigureHealthCheck(ctx context.Context, input *elb.Configure
 // CreateLoadBalancerPolicy is not implemented but is required for interface
 // conformance
 func (e *FakeELB) CreateLoadBalancerPolicy(ctx context.Context, input *elb.CreateLoadBalancerPolicyInput, opts ...func(*elb.Options)) (*elb.CreateLoadBalancerPolicyOutput, error) {
-	panic("Not implemented")
+	return &elb.CreateLoadBalancerPolicyOutput{}, nil
 }
 
 // SetLoadBalancerPoliciesForBackendServer is not implemented but is required
@@ -622,7 +623,13 @@ func (e *FakeELB) SetLoadBalancerPoliciesOfListener(ctx context.Context, input *
 // DescribeLoadBalancerPolicies is not implemented but is required for
 // interface conformance
 func (e *FakeELB) DescribeLoadBalancerPolicies(ctx context.Context, input *elb.DescribeLoadBalancerPoliciesInput, opts ...func(*elb.Options)) (*elb.DescribeLoadBalancerPoliciesOutput, error) {
-	panic("Not implemented")
+	if aws.ToString(input.LoadBalancerName) == "" {
+		return nil, &elbtypes.LoadBalancerAttributeNotFoundException{}
+	}
+	if len(input.PolicyNames) == 0 || input.PolicyNames[0] == "k8s-SSLNegotiationPolicy-" {
+		return nil, &elbtypes.PolicyNotFoundException{}
+	}
+	return &elb.DescribeLoadBalancerPoliciesOutput{}, nil
 }
 
 // DescribeLoadBalancerAttributes is not implemented but is required for

--- a/pkg/providers/v1/aws_loadbalancer_test.go
+++ b/pkg/providers/v1/aws_loadbalancer_test.go
@@ -1073,3 +1073,50 @@ func TestCloud_computeTargetGroupExpectedTargets(t *testing.T) {
 		})
 	}
 }
+
+// Make sure that errors returned by DescribeLoadBalancerPolicies are
+// handled gracefully, and don't progress further into the function
+func TestEnsureSSLNegotiationPolicyErrorHandling(t *testing.T) {
+	awsServices := NewFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(config.CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+
+	tests := []struct {
+		name         string
+		loadBalancer *elbtypes.LoadBalancerDescription
+		policyName   string
+		expectError  bool
+	}{
+		{
+			name: "Expect LoadBalancerAttributeNotFoundException, error",
+			loadBalancer: &elbtypes.LoadBalancerDescription{
+				LoadBalancerName: aws.String(""),
+			},
+			policyName:  "",
+			expectError: true,
+		},
+		{
+			name: "Expect PolicyNotFoundException, nil error",
+			loadBalancer: &elbtypes.LoadBalancerDescription{
+				LoadBalancerName: aws.String("test-lb"),
+			},
+			policyName:  "",
+			expectError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := c.ensureSSLNegotiationPolicy(context.TODO(), test.loadBalancer, test.policyName)
+			if test.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !test.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes a nil pointer dereference introduced by the SDK Go V2 migration in https://github.com/kubernetes/cloud-provider-aws/pull/1157.

The SDK migration's nil pointer dereference issue is in [pkg/providers/v1/aws_loadbalancer.go:ensureSSLNegotiationPolicy](https://github.com/kubernetes/cloud-provider-aws/pull/1223/files#diff-70a4ebdf516a65404dc3c3b3ba9925fc62d0f85bd75e272a4f8ddb4b7b8ab852R1515), and is due to the SDK Go V2 returning nil on error rather than an empty struct. So, when the code didn't return an error and continued into the code, the nil pointer dereference surfaced. 
V1 code: https://github.com/aws/aws-sdk-go/blob/main/service/elb/api.go#L1530-L1564
V2 code: https://github.com/aws/aws-sdk-go-v2/blob/service/elasticloadbalancing/v1.31.0/service/elasticloadbalancing/api_op_DescribeLoadBalancerPolicies.go#L29
 
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
