### PR TITLE
Automated cherry pick of #1266: bump go sdk to 1.24.7 for CVE

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.4.0-go1.24.4-bookworm.0
+defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.4.0-go1.24.7-bookworm.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.24.4
+ARG GOLANG_IMAGE=golang:1.24.7
 
 # The distroless image on which the CPI manager image is built.
 #
@@ -22,7 +22,7 @@ ARG GOLANG_IMAGE=golang:1.24.4
 # deterministic builds. Follow what kubernetes uses to build
 # kube-controller-manager, for example for 1.23.x:
 # https://github.com/kubernetes/kubernetes/blob/release-1.24/build/common.sh#L94
-ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.4.0-go1.24.4-bookworm.0
+ARG DISTROLESS_IMAGE=registry.k8s.io/build-image/go-runner:v2.4.0-go1.24.7-bookworm.0
 
 ################################################################################
 ##                              BUILD STAGE                                   ##

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
       - --platform=linux/amd64,linux/arm64
       - .
   # Build cloudbuild artifacts (for attestation)
-  - name: 'docker.io/library/golang:1.24.4-bookworm'
+  - name: 'docker.io/library/golang:1.24.7-bookworm'
     id: cloudbuild-artifacts
     entrypoint: make
     env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-aws
 
-go 1.24.4
+go 1.24.7
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-aws/tests/e2e
 
-go 1.24.4
+go 1.24.7
 
 require (
 	github.com/onsi/ginkgo/v2 v2.9.4


### PR DESCRIPTION
Cherry pick of #1266 on release-1.32.

#1266: bump go sdk to 1.24.7 for CVE

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```