### PR TITLE
fix: allow providing unused ServiceAccountToken

### DIFF
--- a/cmd/ecr-credential-provider/main.go
+++ b/cmd/ecr-credential-provider/main.go
@@ -207,20 +207,20 @@ func (e *ecrPlugin) buildCredentialsProvider(ctx context.Context, request *v1.Cr
 	}
 
 	return aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
-			assumeOutput, err := e.sts.AssumeRoleWithWebIdentity(ctx, &sts.AssumeRoleWithWebIdentityInput{
-				RoleArn:          aws.String(arn),
-				RoleSessionName:  aws.String("ecr-credential-provider"),
-				WebIdentityToken: aws.String(request.ServiceAccountToken),
-			})
-			if err != nil {
-				return aws.Credentials{}, fmt.Errorf("failed to assume role: %w", err)
-			}
-			return aws.Credentials{
-				AccessKeyID:     *assumeOutput.Credentials.AccessKeyId,
-				SecretAccessKey: *assumeOutput.Credentials.SecretAccessKey,
-				SessionToken:    *assumeOutput.Credentials.SessionToken,
-			}, nil
+		assumeOutput, err := e.sts.AssumeRoleWithWebIdentity(ctx, &sts.AssumeRoleWithWebIdentityInput{
+			RoleArn:          aws.String(arn),
+			RoleSessionName:  aws.String("ecr-credential-provider"),
+			WebIdentityToken: aws.String(request.ServiceAccountToken),
 		})
+		if err != nil {
+			return aws.Credentials{}, fmt.Errorf("failed to assume role: %w", err)
+		}
+		return aws.Credentials{
+			AccessKeyID:     *assumeOutput.Credentials.AccessKeyId,
+			SecretAccessKey: *assumeOutput.Credentials.SecretAccessKey,
+			SessionToken:    *assumeOutput.Credentials.SessionToken,
+		}, nil
+	})
 }
 
 func (e *ecrPlugin) GetCredentials(ctx context.Context, request *v1.CredentialProviderRequest, args []string) (*v1.CredentialProviderResponse, error) {

--- a/cmd/ecr-credential-provider/main_test.go
+++ b/cmd/ecr-credential-provider/main_test.go
@@ -259,7 +259,7 @@ func Test_GetCredentials_PrivateForServiceAccount(t *testing.T) {
 					SessionToken:    aws.String("session-token"),
 				},
 			},
-			response:      generateResponse("123456789123.dkr.ecr.us-west-2.amazonaws.com", "user", "pass"),
+			response: generateResponse("123456789123.dkr.ecr.us-west-2.amazonaws.com", "user", "pass"),
 		},
 		{
 			name:                           "assume error",


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
When ecr-credential-provider is configured to use ServiceAccountTokens for fetching ECR credentials, it should allow ignoring those credentials if the service account doesn't have the corresponding annotations.

Update the provider to try to use a ServiceAccountToken and fall back to standard local credentials otherwise.

---

Kind of related to #1264.

**Does this PR introduce a user-facing change?**

```
Changed ecr-credential-provider to fall back to using default credentials when a ServiceAccountToken is provided but there is no corresponding role ARN provided to assume. This should not cause changes for users using the default credential provider config.
```
