### PR TITLE
go.mod: pinning go version to use patch from build env

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-aws
 
-go 1.24.7
+go 1.24.0
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-aws/tests/e2e
 
-go 1.24.7
+go 1.24.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind design

**What this PR does / why we need it**:

Pinning go patch version (`x.y.0`) to use the available in the build environment.

This approach follows practice of kubernetes/kubernetes project, as well contributes to downstream projects to keep compatibility when not following the same build environment used by this project.

This PR is intentionally not updating the Go image from `Dockerfile` to prevent bumping dependencies with existing  version.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

As per Slack discussion: https://kubernetes.slack.com/archives/C0LRMHZ1T/p1761150650682839

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
