### PR TITLE
Automated cherry pick of #1284: support new aws partition in credential provider

### DIFF
--- a/cmd/ecr-credential-provider/main.go
+++ b/cmd/ecr-credential-provider/main.go
@@ -42,7 +42,7 @@ import (
 const ecrPublicRegion string = "us-east-1"
 const ecrPublicHost string = "public.ecr.aws"
 
-var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
+var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.(?:com(?:\.cn)?|eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
 
 // ECR abstracts the calls we make to aws-sdk for testing purposes
 type ECR interface {

--- a/cmd/ecr-credential-provider/main_test.go
+++ b/cmd/ecr-credential-provider/main_test.go
@@ -352,6 +352,12 @@ func Test_parseRegionFromECRPrivateHost(t *testing.T) {
 			host:   "123456789123.dkr.ecr.us-iso-east-1.c2s.ic.gov",
 			region: "us-iso-east-1",
 		},
+		// EUSC
+		{
+			name:   "success",
+			host:   "123456789123.dkr.ecr.eusc-de-east-1.amazonaws.eu",
+			region: "eusc-de-east-1",
+		},
 		// Dual-Stack
 		{
 			name:   "success",
@@ -411,6 +417,10 @@ func TestRegistryPatternMatch(t *testing.T) {
 		{"123456789012.dkr.ecr-fips.lala-land-1.amazonaws.com", true},
 		// .cn
 		{"123456789012.dkr.ecr.lala-land-1.amazonaws.com.cn", true},
+		// .eu
+		{"123456789012.dkr.ecr.eusc-de-east-1.amazonaws.eu", true},
+		// .eu with fips
+		{"123456789012.dkr.ecr-fips.eusc-de-east-1.amazonaws.eu", true},
 		// registry ID too long
 		{"1234567890123.dkr.ecr.lala-land-1.amazonaws.com", false},
 		// registry ID too short


### PR DESCRIPTION
Cherry pick of #1284 on release-1.33.

#1284: support new aws partition in credential provider

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```