### PR TITLE
Automated cherry pick of #1332: feat(ecr-cred-provider): support public dualstack endpoints

### DIFF
--- a/cmd/ecr-credential-provider/main.go
+++ b/cmd/ecr-credential-provider/main.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -41,7 +42,8 @@ import (
 )
 
 const ecrPublicRegion string = "us-east-1"
-const ecrPublicHost string = "public.ecr.aws"
+
+var ecrPublicHosts []string = []string{"public.ecr.aws", "ecr-public.aws.com"}
 
 var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.(?:com(?:\.cn)?|eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
 
@@ -192,7 +194,7 @@ func (e *ecrPlugin) buildCredentialsProvider(ctx context.Context, request *v1.Cr
 
 	if e.sts == nil {
 		region := ""
-		if imageHost != ecrPublicHost {
+		if !slices.Contains(ecrPublicHosts, imageHost) {
 			region = parseRegionFromECRPrivateHost(imageHost)
 		}
 		e.sts, err = stsProvider(ctx, region)
@@ -240,7 +242,7 @@ func (e *ecrPlugin) GetCredentials(ctx context.Context, request *v1.CredentialPr
 		}
 	}
 
-	if imageHost == ecrPublicHost {
+	if slices.Contains(ecrPublicHosts, imageHost) {
 		var optFns = []func(*ecrpublic.Options){}
 		if credentialsProvider != nil {
 			optFns = append(optFns, func(o *ecrpublic.Options) {

--- a/cmd/ecr-credential-provider/main_test.go
+++ b/cmd/ecr-credential-provider/main_test.go
@@ -328,6 +328,12 @@ func Test_GetCredentials_Public(t *testing.T) {
 			response:                    generateResponse("public.ecr.aws", "user", "pass"),
 		},
 		{
+			name:                        "dualstack success",
+			image:                       "ecr-public.aws.com",
+			getAuthorizationTokenOutput: generatePublicGetAuthorizationTokenOutput("user", "pass", nil),
+			response:                    generateResponse("ecr-public.aws.com", "user", "pass"),
+		},
+		{
 			name:                        "empty image",
 			image:                       "",
 			getAuthorizationTokenOutput: &ecrpublic.GetAuthorizationTokenOutput{},
@@ -365,6 +371,17 @@ func Test_GetCredentials_Public(t *testing.T) {
 		{
 			name:  "invalid authorization token",
 			image: "public.ecr.aws",
+			getAuthorizationTokenOutput: &ecrpublic.GetAuthorizationTokenOutput{
+				AuthorizationData: &publictypes.AuthorizationData{
+					AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte("foo"))),
+				},
+			},
+			getAuthorizationTokenError: nil,
+			expectedError:              errors.New("error parsing username and password from authorization token"),
+		},
+		{
+			name:  "dualstack invalid authorization token",
+			image: "ecr-public.aws.com",
 			getAuthorizationTokenOutput: &ecrpublic.GetAuthorizationTokenOutput{
 				AuthorizationData: &publictypes.AuthorizationData{
 					AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte("foo"))),


### PR DESCRIPTION
Cherry pick of #1332 on release-1.34.

#1332: feat(ecr-cred-provider): support public dualstack endpoints

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```