### PR TITLE
Automated cherry pick of #1332: feat(ecr-cred-provider): support public dualstack endpoints

### DIFF
--- a/cmd/ecr-credential-provider/main.go
+++ b/cmd/ecr-credential-provider/main.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -40,7 +41,8 @@ import (
 )
 
 const ecrPublicRegion string = "us-east-1"
-const ecrPublicHost string = "public.ecr.aws"
+
+var ecrPublicHosts []string = []string{"public.ecr.aws", "ecr-public.aws.com"}
 
 var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.(?:com(?:\.cn)?|eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
 
@@ -162,7 +164,7 @@ func (e *ecrPlugin) GetCredentials(ctx context.Context, image string, args []str
 		return nil, err
 	}
 
-	if imageHost == ecrPublicHost {
+	if slices.Contains(ecrPublicHosts, imageHost) {
 		creds, err = e.getPublicCredsData(ctx)
 	} else {
 		creds, err = e.getPrivateCredsData(ctx, imageHost, image)

--- a/cmd/ecr-credential-provider/main_test.go
+++ b/cmd/ecr-credential-provider/main_test.go
@@ -211,6 +211,12 @@ func Test_GetCredentials_Public(t *testing.T) {
 			response:                    generateResponse("public.ecr.aws", "user", "pass"),
 		},
 		{
+			name:                        "dualstack success",
+			image:                       "ecr-public.aws.com",
+			getAuthorizationTokenOutput: generatePublicGetAuthorizationTokenOutput("user", "pass", "", nil),
+			response:                    generateResponse("ecr-public.aws.com", "user", "pass"),
+		},
+		{
 			name:                        "empty authorization data",
 			image:                       "public.ecr.aws",
 			getAuthorizationTokenOutput: &ecrpublic.GetAuthorizationTokenOutput{},
@@ -241,6 +247,17 @@ func Test_GetCredentials_Public(t *testing.T) {
 		{
 			name:  "invalid authorization token",
 			image: "public.ecr.aws",
+			getAuthorizationTokenOutput: &ecrpublic.GetAuthorizationTokenOutput{
+				AuthorizationData: &publictypes.AuthorizationData{
+					AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte("foo"))),
+				},
+			},
+			getAuthorizationTokenError: nil,
+			expectedError:              errors.New("error parsing username and password from authorization token"),
+		},
+		{
+			name:  "dualstack invalid authorization token",
+			image: "ecr-public.aws.com",
 			getAuthorizationTokenOutput: &ecrpublic.GetAuthorizationTokenOutput{
 				AuthorizationData: &publictypes.AuthorizationData{
 					AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte("foo"))),


### PR DESCRIPTION
Cherry pick of #1332 on release-1.31.

#1332: feat(ecr-cred-provider): support public dualstack endpoints

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```