### PR TITLE
Add a dual stack configuration example

### DIFF
--- a/examples/existing-cluster-dual-stack/base/apiserver-authentication-reader-role-binding.yaml
+++ b/examples/existing-cluster-dual-stack/base/apiserver-authentication-reader-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-controller-manager:apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system

--- a/examples/existing-cluster-dual-stack/base/aws-cloud-controller-manager-daemonset.yaml
+++ b/examples/existing-cluster-dual-stack/base/aws-cloud-controller-manager-daemonset.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aws-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-app: aws-cloud-controller-manager
+spec:
+  selector:
+    matchLabels:
+      k8s-app: aws-cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: aws-cloud-controller-manager
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: aws-cloud-controller-manager
+          image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.27.1
+          args:
+            - --v=2
+            - --cloud-provider=aws
+            # Use the superset-role overlay if you don't want a token per controller
+            - --use-service-account-credentials=true
+            # Set --configure-cloud-routes=true if required by your CNI
+            - --configure-cloud-routes=false
+            - --cloud-config=/etc/kubernetes/cloud-config.conf
+            volumeMounts:
+             - name: cloud-config
+               mountPath: /etc/kubernetes/cloud-config.conf
+               subPath: cloud-config.conf
+          resources:
+            requests:
+              cpu: 200m
+      hostNetwork: true
+      volumes:
+      - name: cloud-config
+        configMap:
+          name: cloud-config
+---
+
+apiVersion: v1
+kind: ConfigMap
+  metadata:
+    name: cloud-config
+    namespace: kube-system
+  data:
+    cloud-config.conf: |
+      [Global]
+      NodeIPFamilies=ipv6
+      NodeIPFamilies=ipv4

--- a/examples/existing-cluster-dual-stack/base/aws-cloud-controller-manager-daemonset.yaml
+++ b/examples/existing-cluster-dual-stack/base/aws-cloud-controller-manager-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: aws-cloud-controller-manager
-          image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.27.1
+          image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.28.1
           args:
             - --v=2
             - --cloud-provider=aws
@@ -37,10 +37,10 @@ spec:
             # Set --configure-cloud-routes=true if required by your CNI
             - --configure-cloud-routes=false
             - --cloud-config=/etc/kubernetes/cloud-config.conf
-            volumeMounts:
-             - name: cloud-config
-               mountPath: /etc/kubernetes/cloud-config.conf
-               subPath: cloud-config.conf
+          volumeMounts:
+          - name: cloud-config
+            mountPath: /etc/kubernetes/cloud-config.conf
+            subPath: cloud-config.conf
           resources:
             requests:
               cpu: 200m
@@ -50,14 +50,13 @@ spec:
         configMap:
           name: cloud-config
 ---
-
 apiVersion: v1
 kind: ConfigMap
-  metadata:
-    name: cloud-config
-    namespace: kube-system
-  data:
-    cloud-config.conf: |
-      [Global]
-      NodeIPFamilies=ipv6
-      NodeIPFamilies=ipv4
+metadata:
+  name: cloud-config
+  namespace: kube-system
+data:
+  cloud-config.conf: |
+    [Global]
+    NodeIPFamilies=ipv6
+    NodeIPFamilies=ipv4

--- a/examples/existing-cluster-dual-stack/base/cluster-role-binding.yaml
+++ b/examples/existing-cluster-dual-stack/base/cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system

--- a/examples/existing-cluster-dual-stack/base/cluster-role.yaml
+++ b/examples/existing-cluster-dual-stack/base/cluster-role.yaml
@@ -1,0 +1,87 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create

--- a/examples/existing-cluster-dual-stack/base/kustomization.yaml
+++ b/examples/existing-cluster-dual-stack/base/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- apiserver-authentication-reader-role-binding.yaml
+- aws-cloud-controller-manager-daemonset.yaml
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- service-account.yaml
+

--- a/examples/existing-cluster-dual-stack/base/service-account.yaml
+++ b/examples/existing-cluster-dual-stack/base/service-account.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system

--- a/examples/existing-cluster-dual-stack/overlays/superset-role/aws-cloud-controller-manager-daemonset-patch.yaml
+++ b/examples/existing-cluster-dual-stack/overlays/superset-role/aws-cloud-controller-manager-daemonset-patch.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aws-cloud-controller-manager
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: aws-cloud-controller-manager
+          args:
+            - --v=2
+            - --cloud-provider=aws
+            - --use-service-account-credentials=false
+            # Set --configure-cloud-routes=true if required by your CNI
+            - --configure-cloud-routes=false

--- a/examples/existing-cluster-dual-stack/overlays/superset-role/cluster-role-patch.yaml
+++ b/examples/existing-cluster-dual-stack/overlays/superset-role/cluster-role-patch.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - node-controller
+  - service-controller
+  - route-controller
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create

--- a/examples/existing-cluster-dual-stack/overlays/superset-role/kustomization.yaml
+++ b/examples/existing-cluster-dual-stack/overlays/superset-role/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- ../../base
+
+patches:
+- cluster-role-patch.yaml
+- aws-cloud-controller-manager-daemonset-patch.yaml


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

This PR adds an example DaemonSet and cloud-config file for enabling IPv4 and IPv6 node IPs.

This change was made because https://github.com/kubernetes-sigs/provider-aws-test-infra/pull/530 relies on it - see https://github.com/kubernetes-sigs/provider-aws-test-infra/blob/main/kubetest2-ec2/config/run-post-install.sh#L25 where the examples directory is downloaded. Without these CCM options, nodes in a dual-stack install cannot come online.

This is also useful information for any user looking to use dual stack nodes in general, however.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```