### PR TITLE
fix: add nil check for instance State in InstanceExistsByProviderID

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -911,6 +911,11 @@ func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID strin
 		return false, fmt.Errorf("multiple instances found for instance: %s", instanceID)
 	}
 
+	if instances[0].State == nil {
+		klog.Warningf("the instance %s has nil state, assuming it no longer exists", instanceID)
+		return false, nil
+	}
+
 	state := instances[0].State.Name
 	if state == ec2types.InstanceStateNameTerminated {
 		klog.Warningf("the instance %s is terminated", instanceID)

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -3756,6 +3756,76 @@ func TestInstanceExistsByProviderIDForInstanceNotFound(t *testing.T) {
 	assert.False(t, instanceExists)
 }
 
+func TestInstanceExistsByProviderIDNilState(t *testing.T) {
+	mockedEC2API := newMockedEC2API()
+	c := &Cloud{ec2: &awsSdkEC2{ec2: mockedEC2API}, describeInstanceBatcher: newdescribeInstanceBatcher(context.Background(), &awsSdkEC2{ec2: mockedEC2API})}
+
+	mockedEC2API.On("DescribeInstances", mock.Anything).Return(&ec2.DescribeInstancesOutput{
+		Reservations: []ec2types.Reservation{
+			{
+				Instances: []ec2types.Instance{
+					{
+						InstanceId: aws.String("i-nil-state"),
+						State:      nil,
+					},
+				},
+			},
+		},
+	}, nil)
+
+	instanceExists, err := c.InstanceExistsByProviderID(context.TODO(), "aws:///us-west-2c/1abc-2def/i-nil-state")
+	assert.Nil(t, err)
+	assert.False(t, instanceExists)
+}
+
+func TestInstanceExistsByProviderIDTerminated(t *testing.T) {
+	mockedEC2API := newMockedEC2API()
+	c := &Cloud{ec2: &awsSdkEC2{ec2: mockedEC2API}, describeInstanceBatcher: newdescribeInstanceBatcher(context.Background(), &awsSdkEC2{ec2: mockedEC2API})}
+
+	mockedEC2API.On("DescribeInstances", mock.Anything).Return(&ec2.DescribeInstancesOutput{
+		Reservations: []ec2types.Reservation{
+			{
+				Instances: []ec2types.Instance{
+					{
+						InstanceId: aws.String("i-terminated"),
+						State: &ec2types.InstanceState{
+							Name: ec2types.InstanceStateNameTerminated,
+						},
+					},
+				},
+			},
+		},
+	}, nil)
+
+	instanceExists, err := c.InstanceExistsByProviderID(context.TODO(), "aws:///us-west-2c/1abc-2def/i-terminated")
+	assert.Nil(t, err)
+	assert.False(t, instanceExists)
+}
+
+func TestInstanceExistsByProviderIDRunning(t *testing.T) {
+	mockedEC2API := newMockedEC2API()
+	c := &Cloud{ec2: &awsSdkEC2{ec2: mockedEC2API}, describeInstanceBatcher: newdescribeInstanceBatcher(context.Background(), &awsSdkEC2{ec2: mockedEC2API})}
+
+	mockedEC2API.On("DescribeInstances", mock.Anything).Return(&ec2.DescribeInstancesOutput{
+		Reservations: []ec2types.Reservation{
+			{
+				Instances: []ec2types.Instance{
+					{
+						InstanceId: aws.String("i-running"),
+						State: &ec2types.InstanceState{
+							Name: ec2types.InstanceStateNameRunning,
+						},
+					},
+				},
+			},
+		},
+	}, nil)
+
+	instanceExists, err := c.InstanceExistsByProviderID(context.TODO(), "aws:///us-west-2c/1abc-2def/i-running")
+	assert.Nil(t, err)
+	assert.True(t, instanceExists)
+}
+
 func TestInstanceNotExistsByProviderIDForFargate(t *testing.T) {
 	awsServices := newMockedFakeAWSServices(TestClusterID)
 	c, _ := newAWSCloud(config.CloudConfig{}, awsServices)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`InstanceExistsByProviderID` panics with a nil pointer dereference when `DescribeInstances` returns an instance with a nil `State` field. This can happen when an EC2 instance has been terminated and is in the process of being cleaned up by AWS.

The sibling method `InstanceShutdownByProviderID` already has a nil guard on `instance.State` ([aws.go:953](https://github.com/kubernetes/cloud-provider-aws/blob/v1.34.2/pkg/providers/v1/aws.go#L953)), but `InstanceExistsByProviderID` is missing it, leading to the panic:

```
E0320 20:59:44.196294       1 panic.go:262] "Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference"
	k8s.io/cloud-provider-aws/pkg/providers/v1.(*Cloud).InstanceExistsByProviderID
		k8s.io/cloud-provider-aws/pkg/providers/v1/aws.go:903
```

This PR adds a nil check on `instances[0].State` before accessing `.Name`, consistent with `InstanceShutdownByProviderID`. When `State` is nil, the instance is treated as no longer existing.

**Which issue(s) this PR fixes**:

Fixes #1365

**Special notes for your reviewer**:

The fix is a 5-line nil check. Three new tests are added:
- `TestInstanceExistsByProviderIDNilState` — verifies nil State returns `(false, nil)` instead of panicking
- `TestInstanceExistsByProviderIDTerminated` — verifies terminated state returns `(false, nil)`
- `TestInstanceExistsByProviderIDRunning` — verifies running state returns `(true, nil)`

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a panic (nil pointer dereference) in cloud-controller-manager when InstanceExistsByProviderID encounters an instance with nil State from the EC2 API.
```