### PR TITLE
fix: add k8s.io/streaming replace directive in switch-to-latest-k8s

### DIFF
--- a/hack/switch-to-latest-k8s.sh
+++ b/hack/switch-to-latest-k8s.sh
@@ -29,6 +29,7 @@ go mod edit -replace k8s.io/csi-translation-lib=../../k8s.io/kubernetes/staging/
 go mod edit -replace k8s.io/apiserver=../../k8s.io/kubernetes/staging/src/k8s.io/apiserver
 go mod edit -replace k8s.io/component-helpers=../../k8s.io/kubernetes/staging/src/k8s.io/component-helpers
 go mod edit -replace k8s.io/kms=../../k8s.io/kubernetes/staging/src/k8s.io/kms
+go mod edit -replace k8s.io/streaming=../../k8s.io/kubernetes/staging/src/k8s.io/streaming
 
 
 go mod tidy


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The `hack/switch-to-latest-k8s.sh` script replaces `k8s.io/*` dependencies with local paths from the Kubernetes staging area to build against the latest Kubernetes master. The `k8s.io/streaming` module was recently extracted into `staging/src/k8s.io/streaming`, and `k8s.io/apiserver` now imports it. Without a corresponding replace directive, `go mod tidy` fails because the staging version (`v0.0.0`) cannot be resolved from the module proxy:

```
go: k8s.io/cloud-provider-aws/cmd/aws-cloud-controller-manager imports
	k8s.io/cloud-provider/app/config imports
	k8s.io/apiserver/pkg/server imports
	k8s.io/apiserver/pkg/endpoints/handlers/responsewriters imports
	k8s.io/streaming/pkg/httpstream/wsstream: reading k8s.io/streaming/go.mod at revision v0.0.0: unknown revision v0.0.0
```

This adds the missing `k8s.io/streaming` replace directive, consistent with the other staging modules already in the script.

**Which issue(s) this PR fixes**:

Fixes the `switch-to-latest-k8s` build failure caused by the new `k8s.io/streaming` staging module (observed in #1366 CI: `pull-cloud-provider-aws-e2e-kubetest2-quick`).

**Special notes for your reviewer**:

Single-line addition. The `k8s.io/streaming` module was extracted from `k8s.io/apimachinery/pkg/util/httpstream` into its own staging repo. The e2e CI jobs (`pull-cloud-provider-aws-e2e-kubetest2*`) invoke `make switch-to-latest-k8s` before building, which is where this failure occurs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```