### PR TITLE
fix: Add explicit HTTP request timeouts to all AWS SDK clients

### DIFF
--- a/cmd/ecr-credential-provider/main.go
+++ b/cmd/ecr-credential-provider/main.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -42,6 +43,8 @@ import (
 )
 
 const ecrPublicRegion string = "us-east-1"
+
+var defaultHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 var ecrPublicHosts []string = []string{"public.ecr.aws", "ecr-public.aws.com"}
 
@@ -74,10 +77,13 @@ func defaultECRProvider(ctx context.Context, region string) (ECR, error) {
 	if region != "" {
 		cfg, err = config.LoadDefaultConfig(ctx,
 			config.WithRegion(region),
+			config.WithHTTPClient(defaultHTTPClient),
 		)
 	} else {
 		klog.Warningf("No region found in the image reference, the default region will be used. Please refer to AWS SDK documentation for configuration purpose.")
-		cfg, err = config.LoadDefaultConfig(ctx)
+		cfg, err = config.LoadDefaultConfig(ctx,
+			config.WithHTTPClient(defaultHTTPClient),
+		)
 	}
 
 	if err != nil {
@@ -92,6 +98,7 @@ func publicECRProvider(ctx context.Context) (ECRPublic, error) {
 	// in the "aws" partition.
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(ecrPublicRegion),
+		config.WithHTTPClient(defaultHTTPClient),
 	)
 	if err != nil {
 		return nil, err
@@ -106,10 +113,13 @@ func stsProvider(ctx context.Context, region string) (STS, error) {
 	if region != "" {
 		cfg, err = config.LoadDefaultConfig(ctx,
 			config.WithRegion(region),
+			config.WithHTTPClient(defaultHTTPClient),
 		)
 	} else {
 		klog.Warningf("No region found in the image reference, the default region will be used. Please refer to AWS SDK documentation for configuration purpose.")
-		cfg, err = config.LoadDefaultConfig(ctx)
+		cfg, err = config.LoadDefaultConfig(ctx,
+			config.WithHTTPClient(defaultHTTPClient),
+		)
 	}
 
 	if err != nil {

--- a/cmd/ecr-credential-provider/main.go
+++ b/cmd/ecr-credential-provider/main.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -30,6 +29,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
@@ -44,7 +44,7 @@ import (
 
 const ecrPublicRegion string = "us-east-1"
 
-var defaultHTTPClient = &http.Client{Timeout: 30 * time.Second}
+var defaultHTTPClient = awshttp.NewBuildableClient().WithTimeout(30 * time.Second)
 
 var ecrPublicHosts []string = []string{"public.ecr.aws", "ecr-public.aws.com"}
 

--- a/pkg/providers/v1/aws_sdk.go
+++ b/pkg/providers/v1/aws_sdk.go
@@ -19,7 +19,9 @@ package aws
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/middleware"
@@ -39,6 +41,12 @@ import (
 	"k8s.io/cloud-provider-aws/pkg/providers/v1/iface"
 	"k8s.io/klog/v2"
 )
+
+// defaultHTTPClient is shared across all AWS SDK clients to enforce an explicit
+// HTTP request timeout and reuse connection pools. Without a timeout, a single
+// slow response can trigger the Go SDK's clock skew overcorrection and break all
+// subsequent API calls (COE-389792).
+var defaultHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 type awsSDKProvider struct {
 	creds aws.CredentialsProvider
@@ -114,6 +122,7 @@ func (p *awsSDKProvider) getCrossRequestRetryDelay(regionName string) *CrossRequ
 func (p *awsSDKProvider) Compute(ctx context.Context, regionName string, assumeRoleProvider *stscredsv2.AssumeRoleProvider) (iface.EC2, error) {
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithDefaultsMode(aws.DefaultsModeInRegion),
 		awsConfig.WithRegion(regionName),
+		awsConfig.WithHTTPClient(defaultHTTPClient),
 	)
 	if assumeRoleProvider != nil {
 		cfg.Credentials = aws.NewCredentialsCache(assumeRoleProvider)
@@ -142,6 +151,7 @@ func (p *awsSDKProvider) Compute(ctx context.Context, regionName string, assumeR
 func (p *awsSDKProvider) LoadBalancing(ctx context.Context, regionName string, assumeRoleProvider *stscredsv2.AssumeRoleProvider) (ELB, error) {
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithDefaultsMode(aws.DefaultsModeInRegion),
 		awsConfig.WithRegion(regionName),
+		awsConfig.WithHTTPClient(defaultHTTPClient),
 	)
 	if assumeRoleProvider != nil {
 		cfg.Credentials = aws.NewCredentialsCache(assumeRoleProvider)
@@ -167,6 +177,7 @@ func (p *awsSDKProvider) LoadBalancing(ctx context.Context, regionName string, a
 func (p *awsSDKProvider) LoadBalancingV2(ctx context.Context, regionName string, assumeRoleProvider *stscredsv2.AssumeRoleProvider) (ELBV2, error) {
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithDefaultsMode(aws.DefaultsModeInRegion),
 		awsConfig.WithRegion(regionName),
+		awsConfig.WithHTTPClient(defaultHTTPClient),
 	)
 	if assumeRoleProvider != nil {
 		cfg.Credentials = aws.NewCredentialsCache(assumeRoleProvider)
@@ -190,7 +201,9 @@ func (p *awsSDKProvider) LoadBalancingV2(ctx context.Context, regionName string,
 }
 
 func (p *awsSDKProvider) Metadata(ctx context.Context) (config.EC2Metadata, error) {
-	cfg, err := awsConfig.LoadDefaultConfig(context.TODO(), awsConfig.WithDefaultsMode(aws.DefaultsModeInRegion))
+	cfg, err := awsConfig.LoadDefaultConfig(context.TODO(), awsConfig.WithDefaultsMode(aws.DefaultsModeInRegion),
+		awsConfig.WithHTTPClient(defaultHTTPClient),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize AWS config: %v", err)
 	}
@@ -226,6 +239,7 @@ func (p *awsSDKProvider) Metadata(ctx context.Context) (config.EC2Metadata, erro
 func (p *awsSDKProvider) KeyManagement(ctx context.Context, regionName string, assumeRoleProvider *stscredsv2.AssumeRoleProvider) (KMS, error) {
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithDefaultsMode(aws.DefaultsModeInRegion),
 		awsConfig.WithRegion(regionName),
+		awsConfig.WithHTTPClient(defaultHTTPClient),
 	)
 	if assumeRoleProvider != nil {
 		cfg.Credentials = aws.NewCredentialsCache(assumeRoleProvider)

--- a/pkg/providers/v1/aws_sdk.go
+++ b/pkg/providers/v1/aws_sdk.go
@@ -19,13 +19,13 @@ package aws
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	stscredsv2 "github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
@@ -45,8 +45,8 @@ import (
 // defaultHTTPClient is shared across all AWS SDK clients to enforce an explicit
 // HTTP request timeout and reuse connection pools. Without a timeout, a single
 // slow response can trigger the Go SDK's clock skew overcorrection and break all
-// subsequent API calls (COE-389792).
-var defaultHTTPClient = &http.Client{Timeout: 30 * time.Second}
+// subsequent API calls.
+var defaultHTTPClient = awshttp.NewBuildableClient().WithTimeout(30 * time.Second)
 
 type awsSDKProvider struct {
 	creds aws.CredentialsProvider

--- a/pkg/providers/v1/aws_timeout_test.go
+++ b/pkg/providers/v1/aws_timeout_test.go
@@ -13,7 +13,7 @@ import (
 // TestAllLoadDefaultConfigHaveHTTPClient scans all .go source files and verifies
 // that every call to LoadDefaultConfig includes a WithHTTPClient option.
 // This prevents SDK clients from being created without an explicit HTTP timeout,
-// which can lead to clock skew overcorrection on slow responses (COE-389792).
+// which can lead to clock skew overcorrection on slow responses.
 func TestAllLoadDefaultConfigHaveHTTPClient(t *testing.T) {
 	repoRoot := filepath.Join("..", "..", "..")
 	var violations []string

--- a/pkg/providers/v1/aws_timeout_test.go
+++ b/pkg/providers/v1/aws_timeout_test.go
@@ -1,0 +1,93 @@
+package aws
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAllLoadDefaultConfigHaveHTTPClient scans all .go source files and verifies
+// that every call to LoadDefaultConfig includes a WithHTTPClient option.
+// This prevents SDK clients from being created without an explicit HTTP timeout,
+// which can lead to clock skew overcorrection on slow responses (COE-389792).
+func TestAllLoadDefaultConfigHaveHTTPClient(t *testing.T) {
+	repoRoot := filepath.Join("..", "..", "..")
+	var violations []string
+
+	err := filepath.Walk(repoRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			name := info.Name()
+			if name == "vendor" || name == ".git" || name == "tests" {
+				return filepath.SkipDir
+			}
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		node, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return nil
+		}
+
+		ast.Inspect(node, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if !isLoadDefaultConfig(call) {
+				return true
+			}
+			if !hasWithHTTPClient(call) {
+				pos := fset.Position(call.Pos())
+				violations = append(violations, pos.String())
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk source tree: %v", err)
+	}
+
+	for _, v := range violations {
+		t.Errorf("LoadDefaultConfig without WithHTTPClient at %s", v)
+	}
+}
+
+func isLoadDefaultConfig(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return sel.Sel.Name == "LoadDefaultConfig"
+}
+
+func hasWithHTTPClient(call *ast.CallExpr) bool {
+	for _, arg := range call.Args {
+		if containsIdent(arg, "WithHTTPClient") {
+			return true
+		}
+	}
+	return false
+}
+
+func containsIdent(node ast.Node, name string) bool {
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		if ident, ok := n.(*ast.Ident); ok && ident.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/pkg/services/aws_sts.go
+++ b/pkg/services/aws_sts.go
@@ -70,7 +70,7 @@ func WithStsHeadersMiddleware(headers map[string]string) func(*sts.Options) {
 func NewStsClient(ctx context.Context, region, roleARN, sourceARN string) (*sts.Client, error) {
 	klog.Infof("Using AWS assumed role %v", roleARN)
 	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithHTTPClient(awshttp.NewBuildableClient().WithTimeout(30 * time.Second)),
+		config.WithHTTPClient(awshttp.NewBuildableClient().WithTimeout(30*time.Second)),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/services/aws_sts.go
+++ b/pkg/services/aws_sts.go
@@ -19,6 +19,8 @@ package services
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -67,7 +69,9 @@ func WithStsHeadersMiddleware(headers map[string]string) func(*sts.Options) {
 // NewStsClient provides a new STS client.
 func NewStsClient(ctx context.Context, region, roleARN, sourceARN string) (*sts.Client, error) {
 	klog.Infof("Using AWS assumed role %v", roleARN)
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithHTTPClient(&http.Client{Timeout: 30 * time.Second}),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/aws_sts.go
+++ b/pkg/services/aws_sts.go
@@ -19,10 +19,10 @@ package services
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go/middleware"
@@ -70,7 +70,7 @@ func WithStsHeadersMiddleware(headers map[string]string) func(*sts.Options) {
 func NewStsClient(ctx context.Context, region, roleARN, sourceARN string) (*sts.Client, error) {
 	klog.Infof("Using AWS assumed role %v", roleARN)
 	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithHTTPClient(&http.Client{Timeout: 30 * time.Second}),
+		config.WithHTTPClient(awshttp.NewBuildableClient().WithTimeout(30 * time.Second)),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add explicit HTTP request timeouts (30s) to all AWS SDK clients using the SDK's BuildableClient via WithHTTPClient on every LoadDefaultConfig call. Using BuildableClient instead of a bare http.Client preserves the SDK's default transport settings (TLS 1.2, connection pooling, dialer config). This prevents the Go SDK's clock skew overcorrection from breaking all API calls when a single response is slow. Added AST test to fail if any future LoadDefaultConfig is added without WithHTTPClient.

/kind bug

**What this PR does / why we need it**:
Add explicit HTTP request timeouts (30s) to all AWS SDK clients by configuring
`WithHTTPClient` on every `LoadDefaultConfig` call. Without a timeout, a single
slow API response can trigger the Go AWS SDK v2's clock skew overcorrection,
breaking all subsequent API calls with HTTP 401 errors.

Also adds an AST-based test that scans source files and fails if any
`LoadDefaultConfig` is added without `WithHTTPClient`.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
`tests/e2e/loadbalancer.go` has one `LoadDefaultConfig` without timeout —
intentionally excluded since it's test tooling, not production controller code.
The AST test skips the `tests/` directory accordingly.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```