### PR TITLE
fix(e2e): increase test timeout and load balancer propagation to cover EUSC region

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -3,7 +3,7 @@ module k8s.io/cloud-provider-aws/tests/e2e
 go 1.25.0
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.36.3
+	github.com/aws/aws-sdk-go-v2 v1.37.1
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.45.2
 	github.com/onsi/ginkgo/v2 v2.27.2
@@ -29,7 +29,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 // indirect
-	github.com/aws/smithy-go v1.22.2 // indirect
+	github.com/aws/smithy-go v1.22.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -6,8 +6,8 @@ github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
-github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
+github.com/aws/aws-sdk-go-v2 v1.37.1 h1:SMUxeNz3Z6nqGsXv0JuJXc8w5YMtrQMuIBmDx//bBDY=
+github.com/aws/aws-sdk-go-v2 v1.37.1/go.mod h1:9Q0OoGQoboYIAJyslFyF1f5K1Ryddop8gqMhWx/n4Wg=
 github.com/aws/aws-sdk-go-v2/config v1.29.14 h1:f+eEi/2cKCg9pqKBoAIwRGzVb70MRKqWX4dg1BDcSJM=
 github.com/aws/aws-sdk-go-v2/config v1.29.14/go.mod h1:wVPHWcIFv3WO89w0rE10gzf17ZYy+UVS1Geq8Iei34g=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.67 h1:9KxtdcIA/5xPNQyZRgUSpYOE6j9Bc4+D7nZua0KGYOM=
@@ -32,8 +32,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 h1:hXmVKytPfTy5axZ+fYbR5d0c
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1/go.mod h1:MlYRNmYu/fGPoxBQVvBYr9nyr948aY/WLUvwBMBJubs=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 h1:1XuUZ8mYJw9B6lzAkXhqHlJd/XvaX32evhproijJEZY=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
-github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
-github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=
+github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/tests/e2e/loadbalancer.go
+++ b/tests/e2e/loadbalancer.go
@@ -34,6 +34,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
@@ -674,32 +675,49 @@ func getAWSClientLoadBalancer(ctx context.Context) (*elbv2.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to load AWS config: %v", err)
 	}
-	return elbv2.NewFromConfig(cfg), nil
+
+	// Configure custom retryer to handle primarily transient AWS API errors and DNS failures.
+	customRetryer := retry.NewStandard(func(o *retry.StandardOptions) {
+		o.MaxAttempts = 10              // Handle transient errors
+		o.MaxBackoff = 30 * time.Second // Cap backoff to avoid excessive waiting
+	})
+
+	return elbv2.NewFromConfig(cfg, func(o *elbv2.Options) {
+		o.Retryer = customRetryer
+	}), nil
 }
 
 func getAWSLoadBalancerFromDNSName(ctx context.Context, elbClient *elbv2.Client, lbDNSName string) (*elbv2types.LoadBalancer, error) {
 	var foundLB *elbv2types.LoadBalancer
 	framework.Logf("describing load balancers with DNS %s", lbDNSName)
 
-	paginator := elbv2.NewDescribeLoadBalancersPaginator(elbClient, &elbv2.DescribeLoadBalancersInput{})
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to describe load balancers: %v", err)
-		}
+	// Retry wrapper for DNS failures in EUSC regions
+	// AWS endpoint DNS may take up to 15 minutes to propagate in new regions
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+		paginator := elbv2.NewDescribeLoadBalancersPaginator(elbClient, &elbv2.DescribeLoadBalancersInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				framework.Logf("transient error describing load balancers (will retry): %v", err)
+				return false, nil // Retry on any error
+			}
 
-		framework.Logf("found %d load balancers in page", len(page.LoadBalancers))
-		// Search for the load balancer with matching DNS name in this page
-		for i := range page.LoadBalancers {
-			if aws.ToString(page.LoadBalancers[i].DNSName) == lbDNSName {
-				foundLB = &page.LoadBalancers[i]
-				framework.Logf("found load balancer with DNS %s", aws.ToString(foundLB.DNSName))
-				break
+			framework.Logf("found %d load balancers in page", len(page.LoadBalancers))
+			// Search for the load balancer with matching DNS name in this page
+			for i := range page.LoadBalancers {
+				if aws.ToString(page.LoadBalancers[i].DNSName) == lbDNSName {
+					foundLB = &page.LoadBalancers[i]
+					framework.Logf("found load balancer with DNS %s", aws.ToString(foundLB.DNSName))
+					return true, nil
+				}
 			}
 		}
-		if foundLB != nil {
-			break
-		}
+		// Load balancer not found yet, retry
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to find load balancer with DNS name %s: %v", lbDNSName, err)
 	}
 
 	if foundLB == nil {
@@ -749,12 +767,16 @@ func inClusterTestReachableHTTP(cs clientset.Interface, namespace, nodeName, tar
 					Image:   imageutils.GetE2EImage(imageutils.Agnhost),
 					Command: []string{"curl"},
 					Args: []string{
-						"--retry", "15", // Retry up to 15 times in case of transient network issues.
-						"--retry-delay", "20", // Wait 20 seconds between retries.
-						"--retry-max-time", "480", // Maximum time for retries is 480 seconds.
-						"--retry-all-errors",                                                       // Retry on all errors, ensuring robustness against temporary failures.
-						"--trace-time",                                                             // Include timestamps in trace output for debugging.
-						"-w", "\\\"\\n---> HTTPCode=%{http_code} Time=%{time_total}ms <---\\n\\\"", // Format output to include HTTP code and response time.
+						"--retry", "30", // Retry in case of transient network issues.
+						"--retry-delay", "30", // Wait in seconds between retries.
+						"--retry-max-time", "1200", // Max time for retries.
+						"--retry-all-errors",  // Retry on all errors
+						"--retry-connrefused", // Retry connection refused
+						"--connect-timeout", "30",
+						"--max-time", "60", // Max time for each operation.
+						"--trace-time", // Include timestamps in trace output for debugging
+						"--verbose",
+						"-w", "\\\"\\n---> HTTPCode=%{http_code} time_total('%{time_total}s') time_namelookup('%{time_namelookup}s') time_connect('%{time_connect}s') time_appconnect('%{time_appconnect}s') time_pretransfer('%{time_pretransfer}s') time_redirect('%{time_redirect}s') time_starttransfer('%{time_starttransfer}s') <---\\n\\\"",
 						fmt.Sprintf("http://%s:%d/echo?msg=hello", target, targetPort),
 					},
 				},
@@ -821,7 +843,7 @@ func inClusterTestReachableHTTP(cs clientset.Interface, namespace, nodeName, tar
 	// Wait for the test pod to complete. Limit waiter be higher than curl retries.
 	waitCount := 0
 	pendingCount := 0
-	err = wait.PollImmediate(15*time.Second, 15*time.Minute, func() (bool, error) {
+	err = wait.PollImmediate(15*time.Second, 25*time.Minute, func() (bool, error) {
 		p, err := cs.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("Error getting pod %s: %v", podName, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test
/kind flake

**What this PR does / why we need it**:

This PR increases reliability of API calls and curl tests on regions where resources takes longer to propagate and/or DNS cache are higher than usual public cloud, such as EUSC.

This change is solely to increase reliability of e2e tests for loadbalancer.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

Skipping release notes as it is more related to fine tuning e2e tests for reliability in different scenarios.