### PR TITLE
add InvalidID error handling for tagging controller

### DIFF
--- a/pkg/controllers/tagging/tagging_controller.go
+++ b/pkg/controllers/tagging/tagging_controller.go
@@ -340,6 +340,12 @@ func (tc *Controller) tagEc2Instance(ctx context.Context, node *v1.Node) error {
 			klog.Infof("Skip tagging since EC2 instance %s for node %s does not exist", instanceID, node.GetName())
 			return nil
 		}
+		if awsv1.IsAWSErrorInvalidInstanceID(err) {
+			// The instance ID format is not valid for AWS (e.g. KWOK/virtual nodes with fake instance IDs).
+			// Tagging will never succeed, and the event should not be re-queued.
+			klog.Infof("Skip tagging since EC2 instance %s for node %s has an invalid instance ID", instanceID, node.GetName())
+			return nil
+		}
 		klog.Errorf("Error in tagging EC2 instance %s for node %s, error: %v", instanceID, node.GetName(), err)
 		return err
 	}
@@ -389,6 +395,10 @@ func (tc *Controller) untagEc2Instance(ctx context.Context, node *taggingControl
 	}
 
 	if err != nil {
+		if awsv1.IsAWSErrorInvalidInstanceID(err) {
+			klog.Infof("Skip untagging since EC2 instance %s for node %s has an invalid instance ID", instanceID, node.name)
+			return nil
+		}
 		klog.Errorf("Error in untagging EC2 instance %s for node %s, error: %v", instanceID, node.name, err)
 		return err
 	}

--- a/pkg/controllers/tagging/tagging_controller_test.go
+++ b/pkg/controllers/tagging/tagging_controller_test.go
@@ -193,6 +193,34 @@ func Test_NodesJoiningAndLeaving(t *testing.T) {
 			toBeTagged:       true,
 			expectedMessages: []string{"Skip tagging since EC2 instance i-not-found for node node0 does not exist"},
 		},
+		{
+			name: "node with invalid instance ID (e.g. KWOK node) joins the cluster, skip tagging",
+			currNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "kwok-node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "i-invalid-id-kwok-0001",
+				},
+			},
+			toBeTagged:       true,
+			expectedMessages: []string{"Skip tagging since EC2 instance i-invalid-id-kwok-0001 for node kwok-node0 has an invalid instance ID"},
+		},
+		{
+			name: "node with invalid instance ID (e.g. KWOK node) leaves the cluster, skip untagging",
+			currNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "kwok-node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "i-invalid-id-kwok-0001",
+				},
+			},
+			toBeTagged:       false,
+			expectedMessages: []string{"Skip untagging since EC2 instance i-invalid-id-kwok-0001 for node kwok-node0 has an invalid instance ID"},
+		},
 	}
 
 	awsServices := awsv1.NewFakeAWSServices(TestClusterID)

--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -1093,6 +1093,26 @@ func IsAWSErrorInstanceNotFound(err error) bool {
 	return false
 }
 
+// IsAWSErrorInvalidInstanceID returns true if the specified error indicates that the instance ID format is invalid.
+// This is different from IsAWSErrorInstanceNotFound: "InvalidID" means the ID format itself is not valid,
+// while "InvalidInstanceId.NotFound" means the format is valid but no instance with that ID exists.
+// This can happen with virtual/simulated nodes (e.g. KWOK) that generate
+// instance IDs which pass the basic `i-*` prefix check but are not valid AWS instance IDs.
+func IsAWSErrorInvalidInstanceID(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		return ae.ErrorCode() == "InvalidID"
+	} else if strings.Contains(err.Error(), "InvalidID") {
+		return true
+	}
+
+	return false
+}
+
 // Builds the awsInstance for the EC2 instance on which we are running.
 // This is called when the AWSCloud is initialized, and should not be called otherwise (because the awsInstance for the local instance is a singleton with drive mapping state)
 func (c *Cloud) buildSelfAWSInstance(ctx context.Context) (*awsInstance, error) {

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -394,6 +394,9 @@ func (ec2i *FakeEC2Impl) CreateTags(ctx context.Context, input *ec2.CreateTagsIn
 				return nil, errors.New("InvalidInstanceID.NotFound: Instance not found")
 			}
 		}
+		if strings.HasPrefix(id, "i-invalid-id") {
+			return nil, errors.New("InvalidID: The ID '" + id + "' is not valid")
+		}
 	}
 	return &ec2.CreateTagsOutput{}, nil
 }
@@ -407,6 +410,9 @@ func (ec2i *FakeEC2Impl) DeleteTags(ctx context.Context, input *ec2.DeleteTagsIn
 
 		if id == "i-not-found" {
 			return nil, errors.New("InvalidInstanceID.NotFound: Instance not found")
+		}
+		if strings.HasPrefix(id, "i-invalid-id") {
+			return nil, errors.New("InvalidID: The ID '" + id + "' is not valid")
 		}
 	}
 	return &ec2.DeleteTagsOutput{}, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
adding handling for InvalidID errors when trying to tag nodes with invalid instance ids like KWOK nodes

in clusters with kwok nodes, we see errors like
```
E0422 17:39:44.497037      11 tagging_controller.go:318] Error in tagging EC2 instance i-eCHmOTcEW0OZ9KbNe for node amazing-cheetah-3240919213, error: operation error EC2: CreateTags, https response error StatusCode: 400, RequestID: 22fj3d8c-ca7a-1d88-0316-3jfb99sdfj154, api error InvalidID: The ID 'i-eCHmOTcEW0OZ9KbNe' is not valid

E0422 17:39:43.263647      11 tagging_controller.go:271] "Unhandled Error" err="error processing work item '[Node: amazing-cheetah-3240919213, RequeuingCount: 6, EnqueueTime: 2026-04-22 17:39:42.844113692 +0000 UTC m=+1673841.845249380]': operation error EC2: CreateTags, https response error StatusCode: 400, RequestID: 193nsbf9-32js-3jds-39ds-93dsl7f6jg8d, api error InvalidID: The ID 'i-eCHmOTcEW0OZ9KbNe' is not valid, requeuing count 6" logger="UnhandledError"
```

where the kwok nodes keeps on getting requeued over and over again, resulting in a constant stream of unhandled errors, we just drop trying to tag it

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
