### PR TITLE
Automated cherry pick of #1399: cloudbuild: bump gcb-docker-gcloud to v20260205-38cfa9523f

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ options:
 steps:
   - name: gcr.io/cloud-builders/git
     args: ['fetch', '--tags']
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221214-1b4dd4d69a'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f'
     entrypoint: /buildx-entrypoint
     args:
       - build


### PR DESCRIPTION
Cherry pick of #1399 on release-1.32.

#1399: cloudbuild: bump gcb-docker-gcloud to v20260205-38cfa9523f

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```