### PR TITLE
cloudbuild: bump timeout to 3600s

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,4 +30,4 @@ substitutions:
   # Remove date prefix (first 10 characters) to create valid semver version:
   # v20220510-v1.24.0-alpha.0-15-g09bd268 => v1.24.0-alpha.0-15-g09bd268
   _SHORT_TAG: '${_GIT_TAG:10}'
-timeout: 1200s
+timeout: 3600s


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The `cloud-provider-aws-push-images` postsubmit has been running up against the 1200s (20 min) Cloud Build timeout. After #1399 fixed the image pin issue, step 1 (multi-arch buildx) now succeeds but consumes 16-19 of the 20 available minutes leaving step 2 (cloudbuild-artifacts) with essentially no budget. Step 2 is killed mid-`hack/install-gsutil.sh`, so no ecr-credential-provider binaries land in `gs://k8s-staging-provider-aws/releases/`.

Observed failures after #1399 landed:
- **release-1.36** (step 1 ok, step 2 TIMEOUT installing gsutil): https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/cloud-provider-aws-push-images/2051718180123971584
- **master** (step 1 buildkit session deadline during registry push): https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/cloud-provider-aws-push-images/2051514822092132352

Cross-check: the last successful binary upload to the staging releases bucket was `v1.35.1-5-g7dac1f6` on **2026-03-27** 
- step 2 has effectively been timing out for over a month, independent of the image pin issue. Staging image pushes continued through 2026-04-08 before the image GC killed step 1 too.

Bumping the overall build timeout to **3600s (60 min)** gives:
- Headroom for GCB pool variability
- Reliable multi-arch buildx pushes on step 1
- Enough budget for the existing gsutil install + upload on step 2


**Which issue(s) this PR fixes**:

N/A — depends on #1399 which already landed.

**Special notes for your reviewer**:

No behavior change for successful builds; only raises the ceiling for slow ones. Will need cherry-picks to release-1.36 (and older release branches) once this lands so that v1.36.0 / v1.35.x / etc. postsubmits can also succeed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```