### PR TITLE
apply annotation tags to NLB & listeners on update

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -86,6 +86,10 @@ const ProviderName = "aws"
 // services. Used currently for ELBs only.
 const TagNameKubernetesService = "kubernetes.io/service-name"
 
+// TagNameKubernetesManagedTags records the additional-tag keys the controller applied from
+// ServiceAnnotationLoadBalancerAdditionalTags, so removed keys can be reconciled away.
+const TagNameKubernetesManagedTags = "kubernetes.io/cloud-controller/managed-tags"
+
 // TagNameSubnetInternalELB is the tag name used on a subnet to designate that
 // it should be used for internal ELBs
 const TagNameSubnetInternalELB = "kubernetes.io/role/internal-elb"
@@ -354,6 +358,8 @@ type ELB interface {
 // ELBV2 is a simple pass-through of AWS' ELBV2 client interface, which allows for testing
 type ELBV2 interface {
 	AddTags(ctx context.Context, input *elbv2.AddTagsInput, optFns ...func(*elbv2.Options)) (*elbv2.AddTagsOutput, error)
+	RemoveTags(ctx context.Context, input *elbv2.RemoveTagsInput, optFns ...func(*elbv2.Options)) (*elbv2.RemoveTagsOutput, error)
+	DescribeTags(ctx context.Context, input *elbv2.DescribeTagsInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTagsOutput, error)
 
 	CreateLoadBalancer(ctx context.Context, input *elbv2.CreateLoadBalancerInput, optFns ...func(*elbv2.Options)) (*elbv2.CreateLoadBalancerOutput, error)
 	DescribeLoadBalancers(ctx context.Context, input *elbv2.DescribeLoadBalancersInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeLoadBalancersOutput, error)
@@ -1217,6 +1223,131 @@ func (c *Cloud) describeLoadBalancerv2(ctx context.Context, name string) (*elbv2
 	}
 
 	return nil, fmt.Errorf("NLB '%s' could not be found", name)
+}
+
+// addLoadBalancerTagsv2 tags a single ELBv2 resource (LB, listener, target group, etc.).
+func (c *Cloud) addLoadBalancerTagsv2(ctx context.Context, resourceARN string, requested map[string]string) error {
+	var tags []elbv2types.Tag
+	for k, v := range requested {
+		tags = append(tags, elbv2types.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+
+	_, err := c.elbv2.AddTags(ctx, &elbv2.AddTagsInput{
+		ResourceArns: []string{resourceARN},
+		Tags:         tags,
+	})
+	if err != nil {
+		return fmt.Errorf("error adding tags NLB resource %s: %w", resourceARN, err)
+	}
+	return nil
+}
+
+// removeLoadBalancerTagsv2 removes a set of tag keys from a single ELBv2 resource.
+func (c *Cloud) removeLoadBalancerTagsv2(ctx context.Context, resourceARN string, keys []string) error {
+	_, err := c.elbv2.RemoveTags(ctx, &elbv2.RemoveTagsInput{
+		ResourceArns: []string{resourceARN},
+		TagKeys:      keys,
+	})
+	if err != nil {
+		return fmt.Errorf("error removing tags from NLB resource %s: %w", resourceARN, err)
+	}
+	return nil
+}
+
+// parseManagedTagKeys parses the comma-separated list stored in the
+// TagNameKubernetesManagedTags marker tag into a set of keys.
+func parseManagedTagKeys(value string) sets.Set[string] {
+	keys := sets.New[string]()
+	for _, k := range strings.Split(value, ",") {
+		if k != "" {
+			keys.Insert(k)
+		}
+	}
+	return keys
+}
+
+// ensureLoadBalancerResourceTagsV2 makes sure every ELBv2 resource in resourceARNs carries the
+// desired tags. Tags are added or updated to match desired.
+func (c *Cloud) ensureLoadBalancerResourceTagsV2(ctx context.Context, resourceARNs []string, desired map[string]string) error {
+	if len(desired) == 0 || len(resourceARNs) == 0 {
+		return nil
+	}
+
+	// Keys the controller currently owns from the annotation.
+	var currentManaged sets.Set[string]
+	if keys, ok := desired[TagNameKubernetesManagedTags]; ok {
+		currentManaged = parseManagedTagKeys(keys)
+	}
+
+	// DescribeTags accepts at most 20 resource ARNs per call.
+	const describeTagsMaxARNs = 20
+
+	for start := 0; start < len(resourceARNs); start += describeTagsMaxARNs {
+		end := start + describeTagsMaxARNs
+		if end > len(resourceARNs) {
+			end = len(resourceARNs)
+		}
+
+		out, err := c.elbv2.DescribeTags(ctx, &elbv2.DescribeTagsInput{
+			ResourceArns: resourceARNs[start:end],
+		})
+		if err != nil {
+			return fmt.Errorf("error describing tags for NLB resources: %w", err)
+		}
+
+		for _, desc := range out.TagDescriptions {
+			actual := make(map[string]string, len(desc.Tags))
+			for _, t := range desc.Tags {
+				actual[aws.ToString(t.Key)] = aws.ToString(t.Value)
+			}
+
+			// Keep only the desired tags that are absent or have a stale value.
+			missing := map[string]string{}
+			for k, v := range desired {
+				if cur, ok := actual[k]; !ok || cur != v {
+					missing[k] = v
+				}
+			}
+			if len(missing) > 0 {
+				if err := c.addLoadBalancerTagsv2(ctx, aws.ToString(desc.ResourceArn), missing); err != nil {
+					return err
+				}
+			}
+
+			// Remove additional-tag keys the controller previously owned but no longer desires.
+			var previousManaged sets.Set[string]
+			if keys, ok := actual[TagNameKubernetesManagedTags]; ok {
+				previousManaged = parseManagedTagKeys(keys)
+			}
+			var toRemove []string
+			for key := range previousManaged {
+				if currentManaged.Has(key) {
+					continue
+				}
+				// Never remove a still-desired tag.
+				if _, ok := desired[key]; ok {
+					continue
+				}
+				toRemove = append(toRemove, key)
+			}
+			// Drop the marker itself once the user has cleared all additional tags, so no
+			// stale marker is left behind.
+			if currentManaged.Len() == 0 {
+				if _, ok := actual[TagNameKubernetesManagedTags]; ok {
+					toRemove = append(toRemove, TagNameKubernetesManagedTags)
+				}
+			}
+			if len(toRemove) > 0 {
+				if err := c.removeLoadBalancerTagsv2(ctx, aws.ToString(desc.ResourceArn), toRemove); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // Retrieves instance's vpc id from metadata

--- a/pkg/providers/v1/aws_fakes.go
+++ b/pkg/providers/v1/aws_fakes.go
@@ -695,6 +695,16 @@ func (elb *FakeELBV2) AddTags(ctx context.Context, input *elbv2.AddTagsInput, op
 	panic("Not implemented")
 }
 
+// RemoveTags is not implemented but is required for interface conformance
+func (elb *FakeELBV2) RemoveTags(ctx context.Context, input *elbv2.RemoveTagsInput, optFns ...func(*elbv2.Options)) (*elbv2.RemoveTagsOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeTags is not implemented but is required for interface conformance
+func (elb *FakeELBV2) DescribeTags(ctx context.Context, input *elbv2.DescribeTagsInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTagsOutput, error) {
+	panic("Not implemented")
+}
+
 // CreateLoadBalancer is not implemented but is required for interface conformance
 func (elb *FakeELBV2) CreateLoadBalancer(ctx context.Context, input *elbv2.CreateLoadBalancerInput, optFns ...func(*elbv2.Options)) (*elbv2.CreateLoadBalancerOutput, error) {
 	panic("Not implemented")

--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -156,6 +156,15 @@ func (c *Cloud) ensureLoadBalancerv2(ctx context.Context, namespacedName types.N
 
 	// Get additional tags set by the user
 	tags := getKeyValuePropertiesFromAnnotation(annotations, ServiceAnnotationLoadBalancerAdditionalTags)
+
+	// Record which keys the controller owns from the annotation,
+	managedTagKeys := sets.List(sets.KeySet(tags))
+
+	// The marker is only set when the user supplies additional tags;
+	if len(managedTagKeys) > 0 {
+		tags[TagNameKubernetesManagedTags] = strings.Join(managedTagKeys, ",")
+	}
+
 	// Add default tags
 	tags[TagNameKubernetesService] = namespacedName.String()
 	tags = c.tagging.buildTags(ResourceLifecycleOwned, tags)
@@ -272,6 +281,10 @@ func (c *Cloud) ensureLoadBalancerv2(ctx context.Context, namespacedName types.N
 				nodePortTargetGroup[*targetGroup.Port] = &targetGroup
 			}
 
+			// resourceARNs collects the pre-existing resources that survive this reconcile, so
+			// their tags can be reconciled below.
+			resourceARNs := []string{aws.ToString(loadBalancer.LoadBalancerArn)}
+
 			// Handle additions/modifications
 			for _, mapping := range mappings {
 				frontendPort := mapping.FrontendPort
@@ -279,6 +292,8 @@ func (c *Cloud) ensureLoadBalancerv2(ctx context.Context, namespacedName types.N
 				nodePort := mapping.TrafficPort
 				// modifications
 				if listener, ok := actual[frontendPort][frontendProtocol]; ok {
+					// Surviving listener: reconcile its tags.
+					resourceARNs = append(resourceARNs, aws.ToString(listener.ListenerArn))
 					listenerNeedsModification := false
 
 					if listener.Protocol != mapping.FrontendProtocol {
@@ -365,6 +380,8 @@ func (c *Cloud) ensureLoadBalancerv2(ctx context.Context, namespacedName types.N
 							return nil, fmt.Errorf("error deleting old target group: %q", err)
 						}
 					} else {
+						// Surviving target group: reconcile its tags.
+						resourceARNs = append(resourceARNs, aws.ToString(targetGroup.TargetGroupArn))
 						// Run ensureTargetGroup to make sure instances in service are up-to-date
 						_, err = c.ensureTargetGroup(ctx,
 							targetGroup,
@@ -409,6 +426,11 @@ func (c *Cloud) ensureLoadBalancerv2(ctx context.Context, namespacedName types.N
 						dirty = true
 					}
 				}
+			}
+
+			// Reconcile tags on the LB and all surviving listeners and target groups collected.
+			if err := c.ensureLoadBalancerResourceTagsV2(ctx, resourceARNs, tags); err != nil {
+				return nil, err
 			}
 		}
 		if err := c.reconcileLBAttributes(ctx, aws.ToString(loadBalancer.LoadBalancerArn), annotations); err != nil {

--- a/pkg/providers/v1/aws_loadbalancer_test.go
+++ b/pkg/providers/v1/aws_loadbalancer_test.go
@@ -2503,3 +2503,303 @@ func TestCloud_ensureTargetGroupTargets(t *testing.T) {
 		})
 	}
 }
+
+// mockELBV2WithDelete extends MockedFakeELBV2 with a working DeleteListener.
+type mockELBV2WithDelete struct {
+	*MockedFakeELBV2
+}
+
+func (m *mockELBV2WithDelete) DeleteListener(ctx context.Context, input *elbv2.DeleteListenerInput, optFns ...func(*elbv2.Options)) (*elbv2.DeleteListenerOutput, error) {
+	kept := m.Listeners[:0]
+	for _, l := range m.Listeners {
+		if aws.ToString(l.ListenerArn) != aws.ToString(input.ListenerArn) {
+			kept = append(kept, l)
+		}
+	}
+	m.Listeners = kept
+	return &elbv2.DeleteListenerOutput{}, nil
+}
+
+func TestEnsureLoadBalancerv2_Annotations(t *testing.T) {
+	hasTag := func(tags []elbv2types.Tag, key, val string) bool {
+		for _, tag := range tags {
+			if aws.ToString(tag.Key) == key && aws.ToString(tag.Value) == val {
+				return true
+			}
+		}
+		return false
+	}
+
+	hasTagKey := func(tags []elbv2types.Tag, key string) bool {
+		for _, tag := range tags {
+			if aws.ToString(tag.Key) == key {
+				return true
+			}
+		}
+		return false
+	}
+
+	tagValue := func(tags []elbv2types.Tag, key string) string {
+		for _, tag := range tags {
+			if aws.ToString(tag.Key) == key {
+				return aws.ToString(tag.Value)
+			}
+		}
+		return ""
+	}
+
+	arnByPort := func(base *MockedFakeELBV2, port int32) string {
+		for _, l := range base.Listeners {
+			if aws.ToInt32(l.Port) == port {
+				return aws.ToString(l.ListenerArn)
+			}
+		}
+		return ""
+	}
+
+	targetGroupARNs := func(base *MockedFakeELBV2) []string {
+		arns := make([]string, 0, len(base.TargetGroups))
+		for _, tg := range base.TargetGroups {
+			arns = append(arns, aws.ToString(tg.TargetGroupArn))
+		}
+		return arns
+	}
+
+	newServices := func(t *testing.T, elbv2Client ELBV2) (*Cloud, *FakeAWSServices) {
+		t.Helper()
+		awsServices := newMockedFakeAWSServices(TestClusterID)
+		awsServices.elbv2 = elbv2Client
+		c, _ := newAWSCloud(config.CloudConfig{}, awsServices)
+		awsServices.ec2.(*MockedFakeEC2).Subnets = []ec2types.Subnet{
+			{
+				AvailabilityZone: aws.String("us-west-2a"),
+				SubnetId:         aws.String("subnet-abc123de"),
+				Tags:             []ec2types.Tag{{Key: aws.String(c.tagging.clusterTagKey()), Value: aws.String("owned")}},
+			},
+		}
+		awsServices.ec2.(*MockedFakeEC2).RouteTables = []ec2types.RouteTable{
+			{
+				Associations: []ec2types.RouteTableAssociation{{
+					Main:                    aws.Bool(true),
+					RouteTableAssociationId: aws.String("rtbassoc-abc123def456abc78"),
+					RouteTableId:            aws.String("rtb-abc123def456abc78"),
+					SubnetId:                aws.String("subnet-abc123de"),
+				}},
+				RouteTableId: aws.String("rtb-abc123def456abc78"),
+				Routes: []ec2types.Route{{
+					DestinationCidrBlock: aws.String("0.0.0.0/0"),
+					GatewayId:            aws.String("igw-abc123def456abc78"),
+					State:                ec2types.RouteStateActive,
+				}},
+			},
+		}
+		awsServices.ec2.(*MockedFakeEC2).maybeExpectDescribeSecurityGroups(TestClusterID, "k8s-elb-aid")
+		return c, awsServices
+	}
+
+	tests := []struct {
+		name        string
+		ports       []v1.ServicePort
+		annotations map[string]string
+
+		// Optional second "update" reconcile. When both are empty, only the
+		// initial create reconcile runs.
+		updatePorts       []v1.ServicePort
+		updateAnnotations map[string]string
+
+		// Optional hook run between the create and update reconciles, e.g. to
+		// simulate tags added out-of-band directly on the AWS resources.
+		beforeUpdate func(t *testing.T, base *MockedFakeELBV2)
+
+		assert func(t *testing.T, base *MockedFakeELBV2)
+	}{
+		{
+			name:  "update existing tag and add new tag on update",
+			ports: []v1.ServicePort{{Name: "http", Port: 8080, NodePort: 31173, Protocol: v1.ProtocolTCP}},
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "mykey=oldval",
+			},
+			updateAnnotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "mykey=newval,env=prod",
+			},
+			assert: func(t *testing.T, base *MockedFakeELBV2) {
+				lbARN := aws.ToString(base.LoadBalancers[0].LoadBalancerArn)
+				listenerARN := aws.ToString(base.Listeners[0].ListenerArn)
+				// Existing tag updated to its new value on both LB and listener.
+				assert.True(t, hasTag(base.Tags[lbARN], "mykey", "newval"), "LB missing updated tag value")
+				assert.True(t, hasTag(base.Tags[listenerARN], "mykey", "newval"), "listener missing updated tag value")
+				// New tag added on both LB and listener.
+				assert.True(t, hasTag(base.Tags[lbARN], "env", "prod"), "LB missing newly added tag")
+				assert.True(t, hasTag(base.Tags[listenerARN], "env", "prod"), "listener missing newly added tag")
+			},
+		},
+		{
+			name: "tag survives listener delete",
+			ports: []v1.ServicePort{
+				{Name: "http", Port: 80, NodePort: 31173, Protocol: v1.ProtocolTCP},
+				{Name: "alt", Port: 8080, NodePort: 31174, Protocol: v1.ProtocolTCP},
+			},
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "env=staging",
+			},
+			updatePorts: []v1.ServicePort{{Name: "alt", Port: 8080, NodePort: 31174, Protocol: v1.ProtocolTCP}},
+			assert: func(t *testing.T, base *MockedFakeELBV2) {
+				lbARN := aws.ToString(base.LoadBalancers[0].LoadBalancerArn)
+				assert.Empty(t, arnByPort(base, 80), "port 80 listener should be deleted")
+				assert.True(t, hasTag(base.Tags[arnByPort(base, 8080)], "env", "staging"), "port 8080 missing tag after delete")
+				assert.True(t, hasTag(base.Tags[lbARN], "env", "staging"), "LB missing tag after delete")
+			},
+		},
+		{
+			name:  "additional tags propagate to target groups on update",
+			ports: []v1.ServicePort{{Name: "http", Port: 80, NodePort: 31173, Protocol: v1.ProtocolTCP}},
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "team=infra",
+			},
+			updateAnnotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "team=infra,env=prod",
+			},
+			assert: func(t *testing.T, base *MockedFakeELBV2) {
+				require.NotEmpty(t, base.TargetGroups, "expected at least one target group")
+				for _, tgARN := range targetGroupARNs(base) {
+					assert.True(t, hasTag(base.Tags[tgARN], "team", "infra"), "target group %s missing tag team=infra", tgARN)
+					assert.True(t, hasTag(base.Tags[tgARN], "env", "prod"), "target group %s missing newly added tag env=prod", tgARN)
+				}
+			},
+		},
+		{
+			name:  "removing a tag key removes it from LB, listeners, and target groups",
+			ports: []v1.ServicePort{{Name: "http", Port: 80, NodePort: 31173, Protocol: v1.ProtocolTCP}},
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "keep=yes,drop=bye",
+			},
+			beforeUpdate: func(t *testing.T, base *MockedFakeELBV2) {
+				// A tag added directly on the AWS resources, not by the controller.
+				outOfBand := elbv2types.Tag{Key: aws.String("external"), Value: aws.String("keep")}
+				arns := []string{aws.ToString(base.LoadBalancers[0].LoadBalancerArn)}
+				for _, l := range base.Listeners {
+					arns = append(arns, aws.ToString(l.ListenerArn))
+				}
+				arns = append(arns, targetGroupARNs(base)...)
+				for _, arn := range arns {
+					base.Tags[arn] = append(base.Tags[arn], outOfBand)
+				}
+			},
+			updateAnnotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "keep=yes",
+			},
+			assert: func(t *testing.T, base *MockedFakeELBV2) {
+				arns := []string{aws.ToString(base.LoadBalancers[0].LoadBalancerArn)}
+				for _, l := range base.Listeners {
+					arns = append(arns, aws.ToString(l.ListenerArn))
+				}
+				arns = append(arns, targetGroupARNs(base)...)
+				require.Greater(t, len(arns), 2, "expected LB, listener, and target group ARNs")
+				for _, arn := range arns {
+					assert.False(t, hasTagKey(base.Tags[arn], "drop"), "removed key 'drop' should be gone from %s", arn)
+					assert.True(t, hasTag(base.Tags[arn], "keep", "yes"), "kept tag missing from %s", arn)
+					// Out-of-band tag is preserved.
+					assert.True(t, hasTag(base.Tags[arn], "external", "keep"), "out-of-band tag should survive on %s", arn)
+					// Marker reflects only the still-managed key.
+					assert.Equal(t, "keep", tagValue(base.Tags[arn], TagNameKubernetesManagedTags), "marker mismatch on %s", arn)
+					// Controller/system tags are preserved.
+					assert.True(t, hasTag(base.Tags[arn], TagNameKubernetesService, "default/myservice"), "service tag missing on %s", arn)
+					assert.True(t, hasTag(base.Tags[arn], TagNameKubernetesClusterPrefix+TestClusterID, "owned"), "cluster tag missing on %s", arn)
+				}
+			},
+		},
+		{
+			name:  "clearing all additional tags removes the marker and managed tags",
+			ports: []v1.ServicePort{{Name: "http", Port: 80, NodePort: 31173, Protocol: v1.ProtocolTCP}},
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "only=one",
+			},
+			updateAnnotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "",
+			},
+			assert: func(t *testing.T, base *MockedFakeELBV2) {
+				lbARN := aws.ToString(base.LoadBalancers[0].LoadBalancerArn)
+				assert.False(t, hasTagKey(base.Tags[lbARN], "only"), "managed tag 'only' should be removed")
+				assert.False(t, hasTagKey(base.Tags[lbARN], TagNameKubernetesManagedTags), "marker should be removed when no managed tags remain")
+				// System tags survive.
+				assert.True(t, hasTag(base.Tags[lbARN], TagNameKubernetesService, "default/myservice"), "service tag missing")
+				assert.True(t, hasTag(base.Tags[lbARN], TagNameKubernetesClusterPrefix+TestClusterID, "owned"), "cluster tag missing")
+			},
+		},
+		{
+			name:  "repeated reconcile with no changes is idempotent",
+			ports: []v1.ServicePort{{Name: "http", Port: 80, NodePort: 31173, Protocol: v1.ProtocolTCP}},
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "env=prod",
+			},
+			// Re-running with identical ports and annotations must not create extra resources or
+			// churn tags.
+			updatePorts: []v1.ServicePort{{Name: "http", Port: 80, NodePort: 31173, Protocol: v1.ProtocolTCP}},
+			updateAnnotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "env=prod",
+			},
+			assert: func(t *testing.T, base *MockedFakeELBV2) {
+				require.Len(t, base.Listeners, 1, "no extra listener should be created")
+				require.Len(t, base.TargetGroups, 1, "no extra target group should be created")
+				lbARN := aws.ToString(base.LoadBalancers[0].LoadBalancerArn)
+				listenerARN := aws.ToString(base.Listeners[0].ListenerArn)
+				tgARN := aws.ToString(base.TargetGroups[0].TargetGroupArn)
+				for _, arn := range []string{lbARN, listenerARN, tgARN} {
+					assert.True(t, hasTag(base.Tags[arn], "env", "prod"), "tag env=prod missing on %s", arn)
+					assert.Equal(t, "env", tagValue(base.Tags[arn], TagNameKubernetesManagedTags), "marker mismatch on %s", arn)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := &MockedFakeELBV2{
+				Tags:                   make(map[string][]elbv2types.Tag),
+				RegisteredInstances:    make(map[string][]string),
+				LoadBalancerAttributes: make(map[string]map[string]string),
+			}
+			c, awsServices := newServices(t, &mockELBV2WithDelete{MockedFakeELBV2: base})
+			nodes := []*v1.Node{makeNamedNode(awsServices, 0, "a")}
+
+			annotations := map[string]string{ServiceAnnotationLoadBalancerType: "nlb"}
+			for k, v := range tt.annotations {
+				annotations[k] = v
+			}
+			svc := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myservice", UID: "id", Namespace: "default",
+					Annotations: annotations,
+				},
+				Spec: v1.ServiceSpec{
+					Ports:           tt.ports,
+					SessionAffinity: v1.ServiceAffinityNone,
+				},
+			}
+
+			// Create.
+			_, err := c.EnsureLoadBalancer(t.Context(), TestClusterName, svc, nodes)
+			require.NoError(t, err)
+
+			if tt.beforeUpdate != nil {
+				tt.beforeUpdate(t, base)
+			}
+
+			// Optional update reconcile (annotation and/or port changes).
+			if tt.updatePorts != nil || tt.updateAnnotations != nil {
+				if tt.updatePorts != nil {
+					svc.Spec.Ports = tt.updatePorts
+				}
+				for k, v := range tt.updateAnnotations {
+					svc.Annotations[k] = v
+				}
+				_, err = c.EnsureLoadBalancer(t.Context(), TestClusterName, svc, nodes)
+				require.NoError(t, err)
+			}
+
+			if tt.assert != nil {
+				tt.assert(t, base)
+			}
+		})
+	}
+}

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -2497,14 +2497,69 @@ type MockedFakeELBV2 struct {
 	RegisteredInstances    map[string][]string // value is list of instance IDs
 }
 
+// recordTags appends creation-time tags to the in-memory store.
+// Mirrors AWS persisting tags supplied at resource creation.
+func (m *MockedFakeELBV2) recordTags(arn string, tags []elbv2types.Tag) {
+	if len(tags) == 0 {
+		return
+	}
+	if m.Tags == nil {
+		m.Tags = make(map[string][]elbv2types.Tag)
+	}
+	m.Tags[arn] = append(m.Tags[arn], tags...)
+}
+
 func (m *MockedFakeELBV2) AddTags(ctx context.Context, input *elbv2.AddTagsInput, optFns ...func(*elbv2.Options)) (*elbv2.AddTagsOutput, error) {
 	for _, arn := range input.ResourceArns {
 		for _, tag := range input.Tags {
-			m.Tags[arn] = append(m.Tags[arn], tag)
+			// Upsert: replace the value if the key already exists, mirroring the AWS API.
+			replaced := false
+			for i, existing := range m.Tags[arn] {
+				if aws.ToString(existing.Key) == aws.ToString(tag.Key) {
+					m.Tags[arn][i] = tag
+					replaced = true
+					break
+				}
+			}
+			if !replaced {
+				m.Tags[arn] = append(m.Tags[arn], tag)
+			}
 		}
 	}
 
 	return &elbv2.AddTagsOutput{}, nil
+}
+
+func (m *MockedFakeELBV2) RemoveTags(ctx context.Context, input *elbv2.RemoveTagsInput, optFns ...func(*elbv2.Options)) (*elbv2.RemoveTagsOutput, error) {
+	if m.Tags == nil {
+		return &elbv2.RemoveTagsOutput{}, nil
+	}
+	for _, arn := range input.ResourceArns {
+		remove := make(map[string]bool, len(input.TagKeys))
+		for _, key := range input.TagKeys {
+			remove[key] = true
+		}
+		kept := m.Tags[arn][:0]
+		for _, tag := range m.Tags[arn] {
+			if !remove[aws.ToString(tag.Key)] {
+				kept = append(kept, tag)
+			}
+		}
+		m.Tags[arn] = kept
+	}
+
+	return &elbv2.RemoveTagsOutput{}, nil
+}
+
+func (m *MockedFakeELBV2) DescribeTags(ctx context.Context, input *elbv2.DescribeTagsInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTagsOutput, error) {
+	descriptions := make([]elbv2types.TagDescription, 0, len(input.ResourceArns))
+	for _, arn := range input.ResourceArns {
+		descriptions = append(descriptions, elbv2types.TagDescription{
+			ResourceArn: aws.String(arn),
+			Tags:        m.Tags[arn],
+		})
+	}
+	return &elbv2.DescribeTagsOutput{TagDescriptions: descriptions}, nil
 }
 
 func (m *MockedFakeELBV2) CreateLoadBalancer(ctx context.Context, input *elbv2.CreateLoadBalancerInput, optFns ...func(*elbv2.Options)) (*elbv2.CreateLoadBalancerOutput, error) {
@@ -2535,6 +2590,7 @@ func (m *MockedFakeELBV2) CreateLoadBalancer(ctx context.Context, input *elbv2.C
 	}
 
 	m.LoadBalancers = append(m.LoadBalancers, &newLB)
+	m.recordTags(arn, input.Tags)
 
 	return &elbv2.CreateLoadBalancerOutput{
 		LoadBalancers: []elbv2types.LoadBalancer{newLB},
@@ -2647,6 +2703,7 @@ func (m *MockedFakeELBV2) CreateTargetGroup(ctx context.Context, input *elbv2.Cr
 	}
 
 	m.TargetGroups = append(m.TargetGroups, &newTG)
+	m.recordTags(arn, input.Tags)
 
 	return &elbv2.CreateTargetGroupOutput{
 		TargetGroups: []elbv2types.TargetGroup{newTG},
@@ -2860,6 +2917,7 @@ func (m *MockedFakeELBV2) CreateListener(ctx context.Context, input *elbv2.Creat
 	}
 
 	m.Listeners = append(m.Listeners, &newListener)
+	m.recordTags(arn, input.Tags)
 
 	for _, tg := range m.TargetGroups {
 		for _, action := range input.DefaultActions {

--- a/pkg/providers/v1/aws_validations.go
+++ b/pkg/providers/v1/aws_validations.go
@@ -90,6 +90,13 @@ func validateServiceAnnotations(v *awsValidationInput) error {
 			return err
 		}
 	}
+
+	// ServiceAnnotationLoadBalancerAdditionalTags
+	if _, present := v.annotations[ServiceAnnotationLoadBalancerAdditionalTags]; present {
+		if err := validateServiceAnnotationAdditionalTags(v); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -137,6 +144,32 @@ func validateServiceAnnotationTargetGroupAttributes(v *awsValidationInput) error
 
 		default:
 			return fmt.Errorf("%s: the attribute %q is not supported by the controller or is invalid", errPrefix, attrKey)
+		}
+	}
+
+	return nil
+}
+
+// validateServiceAnnotationAdditionalTags validates that additional tags do not override controller-managed tags.
+// Annotation: service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags
+//
+// input:
+// v: awsValidationInput containing the required configuration to validate the Service object.
+//
+// returns:
+// - error: validation errors.
+func validateServiceAnnotationAdditionalTags(v *awsValidationInput) error {
+	errPrefix := "error validating load balancer additional tags"
+
+	// tags are in format key=value separated by comma.
+	annotationAdditionalTags := getKeyValuePropertiesFromAnnotation(v.annotations, ServiceAnnotationLoadBalancerAdditionalTags)
+
+	for key := range annotationAdditionalTags {
+		if strings.HasPrefix(key, TagNameKubernetesClusterPrefix) {
+			return fmt.Errorf("%s: tag with prefix %q is managed by the controller and cannot be overridden", errPrefix, key)
+		}
+		if key == TagNameKubernetesClusterLegacy || key == TagNameKubernetesService || key == TagNameKubernetesManagedTags {
+			return fmt.Errorf("%s: tag %q is managed by the controller and cannot be overridden", errPrefix, key)
 		}
 	}
 

--- a/pkg/providers/v1/aws_validations_test.go
+++ b/pkg/providers/v1/aws_validations_test.go
@@ -523,3 +523,70 @@ func TestValidateServiceAnnotations(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateServiceAnnotationAdditionalTags(t *testing.T) {
+	tests := []struct {
+		name          string
+		annotations   map[string]string
+		expectedError string
+	}{
+		{
+			name:          "no annotation",
+			annotations:   map[string]string{},
+			expectedError: "",
+		},
+		{
+			name: "valid custom tags",
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "env=prod,team=platform",
+			},
+			expectedError: "",
+		},
+		{
+			name: "cluster prefix tag is blocked",
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "kubernetes.io/cluster/my-cluster=owned",
+			},
+			expectedError: "kubernetes.io/cluster/my-cluster\" is managed by the controller",
+		},
+		{
+			name: "legacy cluster tag is blocked",
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "KubernetesCluster=my-cluster",
+			},
+			expectedError: "\"KubernetesCluster\" is managed by the controller",
+		},
+		{
+			name: "service name tag is blocked",
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "kubernetes.io/service-name=ns/svc",
+			},
+			expectedError: "\"kubernetes.io/service-name\" is managed by the controller",
+		},
+		{
+			name: "managed-tags marker is blocked",
+			annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: TagNameKubernetesManagedTags + "=keep",
+			},
+			expectedError: "\"" + TagNameKubernetesManagedTags + "\" is managed by the controller",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &awsValidationInput{
+				apiService:  &v1.Service{},
+				annotations: tt.annotations,
+			}
+
+			err := validateServiceAnnotationAdditionalTags(input)
+
+			if tt.expectedError == "" {
+				assert.NoError(t, err, "Expected no error for test case: %s", tt.name)
+			} else {
+				assert.Error(t, err, "Expected error for test case: %s", tt.name)
+				assert.Contains(t, err.Error(), tt.expectedError, "Error message should contain expected text for test case: %s", tt.name)
+			}
+		})
+	}
+}

--- a/tests/e2e/loadbalancer.go
+++ b/tests/e2e/loadbalancer.go
@@ -48,6 +48,7 @@ const (
 	annotationLBTargetNodeLabels      = "service.beta.kubernetes.io/aws-load-balancer-target-node-labels"
 	annotationLBTargetGroupAttributes = "service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"
 	annotationLBSecurityGroups        = "service.beta.kubernetes.io/aws-load-balancer-security-groups"
+	annotationLBAdditionalTags        = "service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags"
 )
 
 var (
@@ -290,6 +291,66 @@ var nlbTests = []loadBalancerTestCases{
 			}
 			lbDNS := cfg.svc.Status.LoadBalancer.Ingress[0].Hostname
 			framework.ExpectNoError(getLBTargetCount(cfg.ctx, lbDNS, cfg.nodeCount), "AWS LB target count validation failed")
+		},
+	},
+	{
+		name:           "NLB should reconcile additional tags and preserve out-of-band tags",
+		resourceSuffix: "nlb-tags",
+		extraAnnotations: map[string]string{
+			annotationLBType:           "nlb",
+			annotationLBAdditionalTags: "e2e-tag=one,drop-tag=temp",
+		},
+		hookPreTest: func(cfg *e2eTestConfig) {
+			lbDNS := cfg.svc.Status.LoadBalancer.Ingress[0].Hostname
+			elbClient, err := getAWSClientLoadBalancer(cfg.ctx)
+			framework.ExpectNoError(err)
+
+			foundLB, err := getAWSLoadBalancerFromDNSName(cfg.ctx, elbClient, lbDNS)
+			framework.ExpectNoError(err)
+			lbARN := aws.ToString(foundLB.LoadBalancerArn)
+
+			listenerARNs, err := getLBListenerARNs(cfg.ctx, elbClient, lbARN)
+			framework.ExpectNoError(err)
+			targetGroupARNs, err := getLBTargetGroupARNs(cfg.ctx, elbClient, lbARN)
+			framework.ExpectNoError(err)
+			arns := append([]string{lbARN}, listenerARNs...)
+			arns = append(arns, targetGroupARNs...)
+
+			framework.Logf("verifying initial tags e2e-tag=one,drop-tag=temp on LB, listeners and target groups")
+			framework.ExpectNoError(verifyResourceTags(cfg.ctx, elbClient, arns, map[string]string{"e2e-tag": "one", "drop-tag": "temp"}, nil))
+
+			// A tag applied directly on the AWS resources, outside the controller's knowledge. It
+			// must survive every later reconcile, since the controller only manages keys it set.
+			framework.Logf("adding out-of-band tag e2e-external=manual directly via the AWS API")
+			_, err = elbClient.AddTags(cfg.ctx, &elbv2.AddTagsInput{
+				ResourceArns: arns,
+				Tags:         []elbv2types.Tag{{Key: aws.String("e2e-external"), Value: aws.String("manual")}},
+			})
+			framework.ExpectNoError(err)
+
+			framework.Logf("updating annotation to e2e-tag=two (dropping drop-tag)")
+			updated, err := cfg.LBJig.UpdateService(cfg.ctx, func(s *v1.Service) {
+				s.Annotations[annotationLBAdditionalTags] = "e2e-tag=two"
+			})
+			framework.ExpectNoError(err)
+			cfg.svc = updated
+
+			framework.Logf("verifying e2e-tag=two present, drop-tag removed, and out-of-band tag preserved")
+			framework.ExpectNoError(verifyResourceTags(cfg.ctx, elbClient, arns,
+				map[string]string{"e2e-tag": "two", "e2e-external": "manual"}, []string{"drop-tag"}))
+
+			framework.Logf("clearing all additional tags via annotation")
+			updated, err = cfg.LBJig.UpdateService(cfg.ctx, func(s *v1.Service) {
+				s.Annotations[annotationLBAdditionalTags] = ""
+			})
+			framework.ExpectNoError(err)
+			cfg.svc = updated
+
+			// The controller drops only the keys it managed (tracked via the managed-tags marker)
+			// and leaves the out-of-band tag untouched.
+			framework.Logf("verifying managed tag e2e-tag removed but out-of-band tag preserved after clear")
+			framework.ExpectNoError(verifyResourceTags(cfg.ctx, elbClient, arns,
+				map[string]string{"e2e-external": "manual"}, []string{"e2e-tag"}))
 		},
 	},
 	// Hairpining traffic test for NLB.
@@ -1444,4 +1505,78 @@ func getSecurityGroup(ctx context.Context, securityGroupID string) (*ec2types.Se
 	}
 
 	return &result.SecurityGroups[0], nil
+}
+
+func getLBListenerARNs(ctx context.Context, elbClient *elbv2.Client, lbARN string) ([]string, error) {
+	out, err := elbClient.DescribeListeners(ctx, &elbv2.DescribeListenersInput{
+		LoadBalancerArn: aws.String(lbARN),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe listeners for LB %s: %v", lbARN, err)
+	}
+	arns := make([]string, 0, len(out.Listeners))
+	for _, l := range out.Listeners {
+		arns = append(arns, aws.ToString(l.ListenerArn))
+	}
+	return arns, nil
+}
+
+func getLBTargetGroupARNs(ctx context.Context, elbClient *elbv2.Client, lbARN string) ([]string, error) {
+	out, err := elbClient.DescribeTargetGroups(ctx, &elbv2.DescribeTargetGroupsInput{
+		LoadBalancerArn: aws.String(lbARN),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe target groups for LB %s: %v", lbARN, err)
+	}
+	arns := make([]string, 0, len(out.TargetGroups))
+	for _, tg := range out.TargetGroups {
+		arns = append(arns, aws.ToString(tg.TargetGroupArn))
+	}
+	return arns, nil
+}
+
+func verifyResourceTags(ctx context.Context, elbClient *elbv2.Client, arns []string, expectedTags map[string]string, absentKeys []string) error {
+
+	// the function is called on already created LB & Listeners, where AWS tags show up in sub-seconds.
+	// the 10m timeout is enough to cover multiple reconcile attempts in the backoff cycle in failure case.
+	tagPollInterval := 15 * time.Second
+	tagPollTimeout := 10 * time.Minute
+	maxAttempts := int(tagPollTimeout/tagPollInterval) + 1
+	attempt := 0
+
+	return wait.PollUntilContextTimeout(ctx, tagPollInterval, tagPollTimeout, true, func(ctx context.Context) (bool, error) {
+		attempt++
+		// MaxLimit = 20 Resources per DescribeTags call.
+		out, err := elbClient.DescribeTags(ctx, &elbv2.DescribeTagsInput{
+			ResourceArns: arns,
+		})
+		if err != nil {
+			framework.Logf("verifyResourceTags: attempt %d/%d : DescribeTags transient error: %v",
+				attempt, maxAttempts, err)
+			return false, nil
+		}
+		for _, desc := range out.TagDescriptions {
+			actual := map[string]string{}
+			for _, t := range desc.Tags {
+				actual[aws.ToString(t.Key)] = aws.ToString(t.Value)
+			}
+			for k, v := range expectedTags {
+				if actual[k] != v {
+					framework.Logf("verifyResourceTags: attempt %d/%d : tag %q on %s not yet propagated: want %q got %q",
+						attempt, maxAttempts, k, aws.ToString(desc.ResourceArn), v, actual[k])
+					return false, nil
+				}
+			}
+			for _, k := range absentKeys {
+				if _, present := actual[k]; present {
+					framework.Logf("verifyResourceTags: attempt %d/%d : tag %q on %s not yet removed",
+						attempt, maxAttempts, k, aws.ToString(desc.ResourceArn))
+					return false, nil
+				}
+			}
+		}
+		framework.Logf("verifyResourceTags: attempt %d/%d : tags reconciled (present=%d absent=%d)",
+			attempt, maxAttempts, len(expectedTags), len(absentKeys))
+		return true, nil
+	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags was only applied to the NLB at creation time (via `CreateLoadBalancer` input tags). Annotation changes never propagated on later reconciles, and removed tags were never cleaned up.

This reconciles additional tags on every `ensureLoadBalancerv2` update across the load balancer, all surviving listeners, and target groups ,adding/updating to match the annotation and removing keys the controller previously applied but no longer wants.

Two tag keys are involved:

- `service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags` : existing user annotation, now propagated on update.
- `kubernetes.io/cloud-controller/managed-tags` : new marker tag recording which keys the controller owns, so removed keys are reconciled away while out-of-band and system tags are preserved.


**Which issue(s) this PR fixes**:

Fixes #1334 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Propagate `service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags` to the NLB, its listeners, and target groups on update; previously tags were only applied to the load balancer at creation. Tag removals are now reconciled, and a `kubernetes.io/cloud-controller/managed-tags` marker preserves tags added out-of-band.
```