### PR TITLE
feat: expose service account annotations

### DIFF
--- a/charts/aws-cloud-controller-manager/templates/serviceaccount.yaml
+++ b/charts/aws-cloud-controller-manager/templates/serviceaccount.yaml
@@ -6,4 +6,8 @@ metadata:
   namespace: {{.Values.namespace}}
   labels:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---

--- a/charts/aws-cloud-controller-manager/values.yaml
+++ b/charts/aws-cloud-controller-manager/values.yaml
@@ -149,6 +149,9 @@ roleBindingName: cloud-controller-manager:apiserver-authentication-reader
 
 serviceAccountName: cloud-controller-manager
 
+serviceAccount:
+  annotations: {}
+
 roleName: extension-apiserver-authentication-reader
 
 extraVolumes: []


### PR DESCRIPTION
Very small change, only propagates service account annotations, so we can avoid doing nasty tricks, to manually replicate what the webhook would inject by configuring a projected serviceAccountToken volume with audience = sts.amazonaws.com, mounting it at the expected path, and setting AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE manually.

**What type of PR is this?**
> /kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1448 

**Special notes for your reviewer**:
Not much, simple chart addition.