### PR TITLE
Fix duplicate NLB target group attribute validation

### DIFF
--- a/pkg/providers/v1/aws_validations.go
+++ b/pkg/providers/v1/aws_validations.go
@@ -104,17 +104,12 @@ func validateServiceAnnotations(v *awsValidationInput) error {
 func validateServiceAnnotationTargetGroupAttributes(v *awsValidationInput) error {
 	errPrefix := "error validating target group attributes"
 
-	// Attributes are in format key=value separated by comma.
-	annotationGroupAttributes := getKeyValuePropertiesFromAnnotation(v.annotations, ServiceAnnotationLoadBalancerTargetGroupAttributes)
-	targetGroupAttributes := make(map[string]string, len(annotationGroupAttributes))
+	targetGroupAttributes, err := getTargetGroupAttributesFromAnnotation(v.annotations)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errPrefix, err)
+	}
 
-	for attrKey, attrValue := range annotationGroupAttributes {
-		if _, ok := targetGroupAttributes[attrKey]; ok {
-			return fmt.Errorf("%s: %q is set twice in the annotation", errPrefix, attrKey)
-		}
-		if len(attrValue) == 0 {
-			return fmt.Errorf("%s: attribute value is empty for %q", errPrefix, attrKey)
-		}
+	for attrKey, attrValue := range targetGroupAttributes {
 
 		switch attrKey {
 		case targetGroupAttributePreserveClientIPEnabled:
@@ -141,4 +136,40 @@ func validateServiceAnnotationTargetGroupAttributes(v *awsValidationInput) error
 	}
 
 	return nil
+}
+
+// getTargetGroupAttributesFromAnnotation returns target group attributes from the
+// target group attributes annotation. It rejects duplicate attributes and empty
+// attribute values so validation does not silently overwrite user input.
+func getTargetGroupAttributesFromAnnotation(annotations map[string]string) (map[string]string, error) {
+	targetGroupAttributes := make(map[string]string)
+	annotationValue, ok := annotations[ServiceAnnotationLoadBalancerTargetGroupAttributes]
+	if !ok {
+		return targetGroupAttributes, nil
+	}
+
+	for _, rawAttribute := range strings.Split(strings.TrimSpace(annotationValue), ",") {
+		rawAttribute = strings.TrimSpace(rawAttribute)
+		if rawAttribute == "" {
+			continue
+		}
+
+		attrParts := strings.SplitN(rawAttribute, "=", 2)
+		attrKey := attrParts[0]
+		attrValue := ""
+		if len(attrParts) == 2 {
+			attrValue = attrParts[1]
+		}
+
+		if _, ok := targetGroupAttributes[attrKey]; ok {
+			return nil, fmt.Errorf("%q is set twice in the annotation", attrKey)
+		}
+		if attrValue == "" {
+			return nil, fmt.Errorf("attribute value is empty for %q", attrKey)
+		}
+
+		targetGroupAttributes[attrKey] = attrValue
+	}
+
+	return targetGroupAttributes, nil
 }

--- a/pkg/providers/v1/aws_validations_test.go
+++ b/pkg/providers/v1/aws_validations_test.go
@@ -24,6 +24,50 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestGetTargetGroupAttributesFromAnnotation(t *testing.T) {
+	tests := []struct {
+		name               string
+		annotationValue    string
+		expectedAttributes map[string]string
+		expectedError      string
+	}{
+		{
+			name:            "valid attributes",
+			annotationValue: "preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=false",
+			expectedAttributes: map[string]string{
+				"preserve_client_ip.enabled": "true",
+				"proxy_protocol_v2.enabled":  "false",
+			},
+		},
+		{
+			name:            "duplicate attribute",
+			annotationValue: "preserve_client_ip.enabled=true,preserve_client_ip.enabled=false",
+			expectedError:   "\"preserve_client_ip.enabled\" is set twice in the annotation",
+		},
+		{
+			name:            "empty attribute value",
+			annotationValue: "preserve_client_ip.enabled=",
+			expectedError:   "attribute value is empty for \"preserve_client_ip.enabled\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attributes, err := getTargetGroupAttributesFromAnnotation(map[string]string{
+				ServiceAnnotationLoadBalancerTargetGroupAttributes: tt.annotationValue,
+			})
+
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedAttributes, attributes)
+		})
+	}
+}
+
 func TestValidateServiceAnnotationTargetGroupAttributes(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -100,14 +144,14 @@ func TestValidateServiceAnnotationTargetGroupAttributes(t *testing.T) {
 			expectedError: "",
 		},
 		{
-			name: "duplicate attribute in annotation (last one wins - no error expected)",
+			name: "duplicate attribute in annotation",
 			annotations: map[string]string{
 				ServiceAnnotationLoadBalancerTargetGroupAttributes: "preserve_client_ip.enabled=true,preserve_client_ip.enabled=false",
 			},
 			servicePorts: []v1.ServicePort{
 				{Port: 80, Protocol: v1.ProtocolTCP},
 			},
-			expectedError: "", // getKeyValuePropertiesFromAnnotation overwrites, so no duplicate detection
+			expectedError: "\"preserve_client_ip.enabled\" is set twice in the annotation",
 		},
 		{
 			name: "empty attribute value",


### PR DESCRIPTION
What type of PR is this?

/kind bug
/kind failing-test

What this PR does / why we need it:

Reject duplicate entries in `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes`.
Before this, `preserve_client_ip.enabled=true,preserve_client_ip.enabled=false` got collapsed by the generic parser and the last value won, so the duplicate check never fired. Pretty sneaky bug, ngl.

Which issue(s) this PR fixes:

Related to #1214

Special notes for your reviewer:

Repro:
1. Create an NLB Service with `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,preserve_client_ip.enabled=false`
2. Before this patch, validation accepts it and silently keeps `false`
3. With this patch, validation returns `"preserve_client_ip.enabled" is set twice in the annotation`

Does this PR introduce a user-facing change?:

```release-note
Fixed validation for `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes` so duplicate attributes are rejected instead of silently using the last value.
```
