### PR TITLE
DNM: Use SG-to-SG rules for NLB node security groups when NLB has security groups

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -2486,7 +2486,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 		}
 
 		// Create/retrieve the Security Groups to be used with the NLB (aligned with CLB pattern)
-		securityGroupIDs, isManagedSg, err := c.ensureNLBSecurityGroup(ctx, clusterName, apiService, existingLB)
+		nlbSecurityGroupIDs, isManagedSg, err := c.ensureNLBSecurityGroup(ctx, clusterName, apiService, existingLB)
 		if err != nil {
 			return nil, fmt.Errorf("error ensuring NLB security group: %w", err)
 		}
@@ -2499,15 +2499,15 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 			discoveredSubnetIDs,
 			internalELB,
 			annotations,
-			securityGroupIDs,
+			nlbSecurityGroupIDs,
 		)
 		if err != nil {
 			return nil, err
 		}
 
 		// Ensure SG rules for cluster-owned groups, only if the LB reconciliator finished successfully.
-		if isManagedSg && len(securityGroupIDs) > 0 {
-			if err := c.ensureNLBSecurityGroupRules(ctx, securityGroupIDs[0], ec2SourceRanges, v2Mappings); err != nil {
+		if isManagedSg && len(nlbSecurityGroupIDs) > 0 {
+			if err := c.ensureNLBSecurityGroupRules(ctx, nlbSecurityGroupIDs[0], ec2SourceRanges, v2Mappings); err != nil {
 				return nil, fmt.Errorf("error ensuring NLB security group rules: %w", err)
 			}
 		}
@@ -2515,7 +2515,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 		// Cleanup old managed security groups and rules referencing them, if any
 		if existingLB != nil && len(existingLB.SecurityGroups) > 0 {
 			currentSGSet := sets.New(existingLB.SecurityGroups...)
-			expectedSGSet := sets.New(securityGroupIDs...)
+			expectedSGSet := sets.New(nlbSecurityGroupIDs...)
 			detachedSGs := currentSGSet.Difference(expectedSGSet).UnsortedList()
 			if len(detachedSGs) > 0 {
 				errs := c.removeOwnedSecurityGroups(ctx, loadBalancerName, detachedSGs)
@@ -2549,7 +2549,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 			sourceRangeCidrs = append(sourceRangeCidrs, "0.0.0.0/0")
 		}
 
-		err = c.updateInstanceSecurityGroupsForNLB(ctx, loadBalancerName, instances, subnetCidrs, sourceRangeCidrs, v2Mappings)
+		err = c.updateInstanceSecurityGroupsForNLB(ctx, loadBalancerName, instances, subnetCidrs, sourceRangeCidrs, v2Mappings, nlbSecurityGroupIDs)
 		if err != nil {
 			klog.Warningf("Error opening ingress rules for the load balancer to the instances: %q", err)
 			return nil, err
@@ -3334,7 +3334,7 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
 			}
 		}
 
-		if err = c.updateInstanceSecurityGroupsForNLB(ctx, loadBalancerName, nil, nil, nil, nil); err != nil {
+		if err = c.updateInstanceSecurityGroupsForNLB(ctx, loadBalancerName, nil, nil, nil, nil, lb.SecurityGroups); err != nil {
 			return fmt.Errorf("error deleting instance security group rules: %w", err)
 		}
 

--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -974,7 +974,7 @@ func (c *Cloud) chunkTargetDescriptions(targets []elbv2types.TargetDescription, 
 
 // updateInstanceSecurityGroupsForNLB will adjust securityGroup's settings to allow inbound traffic into instances from clientCIDRs and portMappings.
 // TIP: if either instances or clientCIDRs or portMappings are nil, then the securityGroup rules for lbName are cleared.
-func (c *Cloud) updateInstanceSecurityGroupsForNLB(ctx context.Context, lbName string, instances map[InstanceID]*ec2types.Instance, subnetCIDRs []string, clientCIDRs []string, portMappings []nlbPortMapping) error {
+func (c *Cloud) updateInstanceSecurityGroupsForNLB(ctx context.Context, lbName string, instances map[InstanceID]*ec2types.Instance, subnetCIDRs []string, clientCIDRs []string, portMappings []nlbPortMapping, nlbSecurityGroupIDs []string) error {
 	if c.cfg.Global.DisableSecurityGroupIngress {
 		return nil
 	}
@@ -1010,6 +1010,17 @@ func (c *Cloud) updateInstanceSecurityGroupsForNLB(ctx context.Context, lbName s
 			}
 			clusterSGs[sgID] = sg
 		}
+	}
+
+	if len(nlbSecurityGroupIDs) > 0 {
+		err := c.updateInstanceSecurityGroupsForNLBWithSGRules(ctx, lbName, clusterSGs, desiredSGIDs, nlbSecurityGroupIDs)
+		if err == nil {
+			return nil
+		}
+		if !strings.Contains(err.Error(), "RulesPerSecurityGroupLimitExceeded") {
+			return err
+		}
+		klog.Warningf("SG rule limit reached while adding SG-to-SG rules for NLB %s, falling back to CIDR-based rules: %v", lbName, err)
 	}
 
 	{
@@ -1061,6 +1072,106 @@ func (c *Cloud) updateInstanceSecurityGroupsForNLB(ctx context.Context, lbName s
 			}
 		}
 	}
+	return nil
+}
+
+// updateInstanceSecurityGroupsForNLBWithSGRules manages SG-to-SG rules on instance security
+// groups, referencing the NLB's security group(s) as the traffic source. This mirrors the CLB
+// behavior in updateInstanceSecurityGroupsForLoadBalancer. It also cleans up any legacy
+// CIDR-based rules that may have been created before the NLB had security groups.
+//
+// SG-to-SG rules are applied first so traffic keeps flowing during the transition from
+// CIDR-based rules. The peak rule count is N+1 during the window between adding the
+// SG-to-SG rule and removing the CIDR rules.
+func (c *Cloud) updateInstanceSecurityGroupsForNLBWithSGRules(ctx context.Context, lbName string, clusterSGs map[string]*ec2types.SecurityGroup, desiredSGIDs sets.String, nlbSecurityGroupIDs []string) error {
+	// Apply SG-to-SG rules for each NLB security group
+	for _, nlbSGID := range nlbSecurityGroupIDs {
+		if err := c.updateInstanceSecurityGroupForNLBBySGRef(ctx, nlbSGID, clusterSGs, desiredSGIDs); err != nil {
+			return err
+		}
+	}
+
+	// Clean up legacy CIDR-based rules from all cluster SGs (handles transition).
+	// Runs after SG-to-SG rules are in place so traffic keeps flowing.
+	clientRuleAnnotation := fmt.Sprintf("%s=%s", NLBClientRuleDescription, lbName)
+	healthRuleAnnotation := fmt.Sprintf("%s=%s", NLBHealthCheckRuleDescription, lbName)
+	for sgID, sg := range clusterSGs {
+		sgPerms := NewIPPermissionSet(sg.IpPermissions...).Ungroup()
+		if err := c.updateInstanceSecurityGroupForNLBTraffic(ctx, sgID, sgPerms, healthRuleAnnotation, "tcp", nil, nil); err != nil {
+			return err
+		}
+		if err := c.updateInstanceSecurityGroupForNLBTraffic(ctx, sgID, sgPerms, clientRuleAnnotation, "tcp", nil, nil); err != nil {
+			return err
+		}
+		if err := c.updateInstanceSecurityGroupForNLBMTU(ctx, sgID, sgPerms); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// updateInstanceSecurityGroupForNLBBySGRef reconciles SG-to-SG ingress rules on instance security
+// groups for a single NLB security group. It adds all-protocols rules to instance SGs that need
+// them and removes rules from instance SGs that no longer need them.
+func (c *Cloud) updateInstanceSecurityGroupForNLBBySGRef(ctx context.Context, nlbSGID string, clusterSGs map[string]*ec2types.SecurityGroup, desiredSGIDs sets.String) error {
+	actualGroups, _, err := c.buildSecurityGroupRuleReferences(ctx, nlbSGID)
+	if err != nil {
+		return fmt.Errorf("error building security group rule references: %w", err)
+	}
+
+	// Map of instance SG ID -> true=add, false=remove
+	instanceSGChanges := map[string]bool{}
+
+	for sgID := range desiredSGIDs {
+		instanceSGChanges[sgID] = true
+	}
+
+	for actualGroup, hasClusterTag := range actualGroups {
+		actualGroupID := aws.ToString(actualGroup.GroupId)
+		if actualGroupID == "" {
+			klog.Warning("Ignoring group without ID: ", actualGroup)
+			continue
+		}
+
+		adding, found := instanceSGChanges[actualGroupID]
+		if found && adding {
+			delete(instanceSGChanges, actualGroupID)
+		} else {
+			if hasClusterTag || len(desiredSGIDs) == 0 {
+				instanceSGChanges[actualGroupID] = false
+			}
+		}
+	}
+
+	allProtocols := "-1"
+	permission := ec2types.IpPermission{
+		IpProtocol:       &allProtocols,
+		UserIdGroupPairs: []ec2types.UserIdGroupPair{{GroupId: &nlbSGID}},
+	}
+	permissions := []ec2types.IpPermission{permission}
+
+	for instanceSGID, add := range instanceSGChanges {
+		if add {
+			klog.V(2).Infof("Adding rule for traffic from the NLB (%s) to instances (%s)", nlbSGID, instanceSGID)
+			changed, err := c.addSecurityGroupIngress(ctx, instanceSGID, permissions)
+			if err != nil {
+				return err
+			}
+			if !changed {
+				klog.Warning("Allowing ingress was not needed; concurrent change? groupId=", instanceSGID)
+			}
+		} else {
+			klog.V(2).Infof("Removing rule for traffic from the NLB (%s) to instance (%s)", nlbSGID, instanceSGID)
+			changed, err := c.removeSecurityGroupIngress(ctx, instanceSGID, permissions)
+			if err != nil {
+				return err
+			}
+			if !changed {
+				klog.Warning("Revoking ingress was not needed; concurrent change? groupId=", instanceSGID)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/providers/v1/aws_loadbalancer_test.go
+++ b/pkg/providers/v1/aws_loadbalancer_test.go
@@ -2503,3 +2503,461 @@ func TestCloud_ensureTargetGroupTargets(t *testing.T) {
 		})
 	}
 }
+
+func TestCloud_updateInstanceSecurityGroupsForNLB(t *testing.T) {
+	clusterTag := ec2types.Tag{
+		Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+		Value: aws.String("owned"),
+	}
+
+	makeInstance := func(instanceID, sgID string) *ec2types.Instance {
+		return &ec2types.Instance{
+			InstanceId: aws.String(instanceID),
+			SecurityGroups: []ec2types.GroupIdentifier{
+				{GroupId: aws.String(sgID)},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                string
+		lbName              string
+		instances           map[InstanceID]*ec2types.Instance
+		nlbSecurityGroupIDs []string
+		setupMocks          func(*MockedFakeEC2)
+		expectError         bool
+	}{
+		{
+			name:   "NLB with SGs creates SG-to-SG rules on node SGs",
+			lbName: "test-nlb",
+			instances: map[InstanceID]*ec2types.Instance{
+				"i-1": makeInstance("i-1", "sg-node"),
+			},
+			nlbSecurityGroupIDs: []string{"sg-nlb"},
+			setupMocks: func(m *MockedFakeEC2) {
+				// getTaggedSecurityGroups: return the node SG
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{}).Return(
+					[]ec2types.SecurityGroup{
+						{GroupId: aws.String("sg-node"), Tags: []ec2types.Tag{clusterTag}},
+					}, nil)
+
+				// CIDR cleanup: updateInstanceSecurityGroupForNLBTraffic calls removeSecurityGroupIngress
+				// (no existing CIDR rules to remove, so no calls needed)
+
+				// buildSecurityGroupRuleReferences: find existing SG-to-SG refs for sg-nlb
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					Filters: []ec2types.Filter{newEc2Filter("ip-permission.group-id", "sg-nlb")},
+				}).Return([]ec2types.SecurityGroup{}, nil)
+
+				// addSecurityGroupIngress -> findSecurityGroup for sg-node
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					GroupIds: []string{"sg-node"},
+				}).Return([]ec2types.SecurityGroup{
+					{GroupId: aws.String("sg-node"), Tags: []ec2types.Tag{clusterTag}},
+				}, nil)
+
+				// addSecurityGroupIngress -> AuthorizeSecurityGroupIngress
+				m.On("AuthorizeSecurityGroupIngress", mock.MatchedBy(func(input *ec2.AuthorizeSecurityGroupIngressInput) bool {
+					return aws.ToString(input.GroupId) == "sg-node" &&
+						len(input.IpPermissions) == 1 &&
+						aws.ToString(input.IpPermissions[0].IpProtocol) == "-1" &&
+						len(input.IpPermissions[0].UserIdGroupPairs) == 1 &&
+						aws.ToString(input.IpPermissions[0].UserIdGroupPairs[0].GroupId) == "sg-nlb"
+				})).Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name:                "NLB with SGs delete path revokes SG-to-SG references",
+			lbName:              "test-nlb",
+			instances:           nil,
+			nlbSecurityGroupIDs: []string{"sg-nlb"},
+			setupMocks: func(m *MockedFakeEC2) {
+				// getTaggedSecurityGroups
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{}).Return(
+					[]ec2types.SecurityGroup{
+						{
+							GroupId: aws.String("sg-node"),
+							Tags:    []ec2types.Tag{clusterTag},
+							IpPermissions: []ec2types.IpPermission{
+								{
+									IpProtocol: aws.String("-1"),
+									UserIdGroupPairs: []ec2types.UserIdGroupPair{
+										{GroupId: aws.String("sg-nlb")},
+									},
+								},
+							},
+						},
+					}, nil)
+
+				// findSecurityGroup for sg-node (called by removeSecurityGroupIngress during CIDR cleanup
+				// and by revokeSecurityGroupReferences)
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					GroupIds: []string{"sg-node"},
+				}).Return([]ec2types.SecurityGroup{
+					{
+						GroupId: aws.String("sg-node"),
+						Tags:    []ec2types.Tag{clusterTag},
+						IpPermissions: []ec2types.IpPermission{
+							{
+								IpProtocol: aws.String("-1"),
+								UserIdGroupPairs: []ec2types.UserIdGroupPair{
+									{GroupId: aws.String("sg-nlb")},
+								},
+							},
+						},
+					},
+				}, nil)
+
+				// buildSecurityGroupRuleReferences for revokeSecurityGroupReferences
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					Filters: []ec2types.Filter{newEc2Filter("ip-permission.group-id", "sg-nlb")},
+				}).Return([]ec2types.SecurityGroup{
+					{
+						GroupId: aws.String("sg-node"),
+						Tags:    []ec2types.Tag{clusterTag},
+						IpPermissions: []ec2types.IpPermission{
+							{
+								IpProtocol: aws.String("-1"),
+								UserIdGroupPairs: []ec2types.UserIdGroupPair{
+									{GroupId: aws.String("sg-nlb")},
+								},
+							},
+						},
+					},
+				}, nil)
+
+				// revokeSecurityGroupReferences -> RevokeSecurityGroupIngress
+				m.On("RevokeSecurityGroupIngress", mock.MatchedBy(func(input *ec2.RevokeSecurityGroupIngressInput) bool {
+					return aws.ToString(input.GroupId) == "sg-node"
+				})).Return(&ec2.RevokeSecurityGroupIngressOutput{}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name:   "NLB without SGs falls back to CIDR-based rules",
+			lbName: "test-nlb",
+			instances: map[InstanceID]*ec2types.Instance{
+				"i-1": makeInstance("i-1", "sg-node"),
+			},
+			nlbSecurityGroupIDs: nil,
+			setupMocks: func(m *MockedFakeEC2) {
+				// getTaggedSecurityGroups
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{}).Return(
+					[]ec2types.SecurityGroup{
+						{GroupId: aws.String("sg-node"), Tags: []ec2types.Tag{clusterTag}},
+					}, nil)
+
+				// findSecurityGroup for sg-node (called by addSecurityGroupIngress)
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					GroupIds: []string{"sg-node"},
+				}).Return([]ec2types.SecurityGroup{
+					{GroupId: aws.String("sg-node"), Tags: []ec2types.Tag{clusterTag}},
+				}, nil)
+
+				// AuthorizeSecurityGroupIngress for CIDR-based client rules
+				m.On("AuthorizeSecurityGroupIngress", mock.MatchedBy(func(input *ec2.AuthorizeSecurityGroupIngressInput) bool {
+					if aws.ToString(input.GroupId) != "sg-node" || len(input.IpPermissions) == 0 {
+						return false
+					}
+					// Should be CIDR-based, not SG-based
+					return len(input.IpPermissions[0].IpRanges) > 0 &&
+						len(input.IpPermissions[0].UserIdGroupPairs) == 0
+				})).Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).Maybe()
+			},
+			expectError: false,
+		},
+		{
+			name:   "Transition from CIDR to SG-to-SG cleans up old CIDR rules",
+			lbName: "test-nlb",
+			instances: map[InstanceID]*ec2types.Instance{
+				"i-1": makeInstance("i-1", "sg-node"),
+			},
+			nlbSecurityGroupIDs: []string{"sg-nlb"},
+			setupMocks: func(m *MockedFakeEC2) {
+				// getTaggedSecurityGroups: return sg-node with existing CIDR rules
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{}).Return(
+					[]ec2types.SecurityGroup{
+						{
+							GroupId: aws.String("sg-node"),
+							Tags:    []ec2types.Tag{clusterTag},
+							IpPermissions: []ec2types.IpPermission{
+								{
+									IpProtocol: aws.String("tcp"),
+									FromPort:   aws.Int32(30000),
+									ToPort:     aws.Int32(30000),
+									IpRanges: []ec2types.IpRange{
+										{CidrIp: aws.String("0.0.0.0/0"), Description: aws.String("kubernetes.io/rule/nlb/client=test-nlb")},
+									},
+								},
+								{
+									IpProtocol: aws.String("tcp"),
+									FromPort:   aws.Int32(30000),
+									ToPort:     aws.Int32(30000),
+									IpRanges: []ec2types.IpRange{
+										{CidrIp: aws.String("10.0.1.0/24"), Description: aws.String("kubernetes.io/rule/nlb/health=test-nlb")},
+									},
+								},
+							},
+						},
+					}, nil)
+
+				// removeSecurityGroupIngress -> findSecurityGroup for CIDR cleanup
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					GroupIds: []string{"sg-node"},
+				}).Return([]ec2types.SecurityGroup{
+					{
+						GroupId: aws.String("sg-node"),
+						Tags:    []ec2types.Tag{clusterTag},
+						IpPermissions: []ec2types.IpPermission{
+							{
+								IpProtocol: aws.String("tcp"),
+								FromPort:   aws.Int32(30000),
+								ToPort:     aws.Int32(30000),
+								IpRanges: []ec2types.IpRange{
+									{CidrIp: aws.String("0.0.0.0/0"), Description: aws.String("kubernetes.io/rule/nlb/client=test-nlb")},
+								},
+							},
+							{
+								IpProtocol: aws.String("tcp"),
+								FromPort:   aws.Int32(30000),
+								ToPort:     aws.Int32(30000),
+								IpRanges: []ec2types.IpRange{
+									{CidrIp: aws.String("10.0.1.0/24"), Description: aws.String("kubernetes.io/rule/nlb/health=test-nlb")},
+								},
+							},
+						},
+					},
+				}, nil)
+
+				// RevokeSecurityGroupIngress for old CIDR rules
+				m.On("RevokeSecurityGroupIngress", mock.MatchedBy(func(input *ec2.RevokeSecurityGroupIngressInput) bool {
+					return aws.ToString(input.GroupId) == "sg-node" &&
+						len(input.IpPermissions) > 0 &&
+						len(input.IpPermissions[0].IpRanges) > 0
+				})).Return(&ec2.RevokeSecurityGroupIngressOutput{}, nil)
+
+				// buildSecurityGroupRuleReferences for sg-nlb
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					Filters: []ec2types.Filter{newEc2Filter("ip-permission.group-id", "sg-nlb")},
+				}).Return([]ec2types.SecurityGroup{}, nil)
+
+				// AuthorizeSecurityGroupIngress for new SG-to-SG rule
+				m.On("AuthorizeSecurityGroupIngress", mock.MatchedBy(func(input *ec2.AuthorizeSecurityGroupIngressInput) bool {
+					return aws.ToString(input.GroupId) == "sg-node" &&
+						len(input.IpPermissions) == 1 &&
+						aws.ToString(input.IpPermissions[0].IpProtocol) == "-1" &&
+						len(input.IpPermissions[0].UserIdGroupPairs) == 1 &&
+						aws.ToString(input.IpPermissions[0].UserIdGroupPairs[0].GroupId) == "sg-nlb"
+				})).Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name:   "Multiple NLB SGs create SG-to-SG rules for each",
+			lbName: "test-nlb",
+			instances: map[InstanceID]*ec2types.Instance{
+				"i-1": makeInstance("i-1", "sg-node"),
+			},
+			nlbSecurityGroupIDs: []string{"sg-byo1", "sg-byo2"},
+			setupMocks: func(m *MockedFakeEC2) {
+				// getTaggedSecurityGroups
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{}).Return(
+					[]ec2types.SecurityGroup{
+						{GroupId: aws.String("sg-node"), Tags: []ec2types.Tag{clusterTag}},
+					}, nil)
+
+				// buildSecurityGroupRuleReferences for each NLB SG
+				for _, sgID := range []string{"sg-byo1", "sg-byo2"} {
+					m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+						Filters: []ec2types.Filter{newEc2Filter("ip-permission.group-id", sgID)},
+					}).Return([]ec2types.SecurityGroup{}, nil)
+				}
+
+				// findSecurityGroup for sg-node (called by addSecurityGroupIngress)
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					GroupIds: []string{"sg-node"},
+				}).Return([]ec2types.SecurityGroup{
+					{GroupId: aws.String("sg-node"), Tags: []ec2types.Tag{clusterTag}},
+				}, nil)
+
+				// AuthorizeSecurityGroupIngress for each NLB SG
+				m.On("AuthorizeSecurityGroupIngress", mock.MatchedBy(func(input *ec2.AuthorizeSecurityGroupIngressInput) bool {
+					if aws.ToString(input.GroupId) != "sg-node" || len(input.IpPermissions) != 1 {
+						return false
+					}
+					perm := input.IpPermissions[0]
+					return aws.ToString(perm.IpProtocol) == "-1" &&
+						len(perm.UserIdGroupPairs) == 1 &&
+						(aws.ToString(perm.UserIdGroupPairs[0].GroupId) == "sg-byo1" ||
+							aws.ToString(perm.UserIdGroupPairs[0].GroupId) == "sg-byo2")
+				})).Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name:   "SG rule limit exceeded falls back to CIDR-based rules",
+			lbName: "test-nlb",
+			instances: map[InstanceID]*ec2types.Instance{
+				"i-1": makeInstance("i-1", "sg-node"),
+			},
+			nlbSecurityGroupIDs: []string{"sg-nlb"},
+			setupMocks: func(m *MockedFakeEC2) {
+				// getTaggedSecurityGroups
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{}).Return(
+					[]ec2types.SecurityGroup{
+						{GroupId: aws.String("sg-node"), Tags: []ec2types.Tag{clusterTag}},
+					}, nil)
+
+				// buildSecurityGroupRuleReferences for sg-nlb
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					Filters: []ec2types.Filter{newEc2Filter("ip-permission.group-id", "sg-nlb")},
+				}).Return([]ec2types.SecurityGroup{}, nil)
+
+				// findSecurityGroup for sg-node (called by addSecurityGroupIngress, then again by CIDR fallback)
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					GroupIds: []string{"sg-node"},
+				}).Return([]ec2types.SecurityGroup{
+					{GroupId: aws.String("sg-node"), Tags: []ec2types.Tag{clusterTag}},
+				}, nil)
+
+				// AuthorizeSecurityGroupIngress fails with RulesPerSecurityGroupLimitExceeded
+				m.On("AuthorizeSecurityGroupIngress", mock.MatchedBy(func(input *ec2.AuthorizeSecurityGroupIngressInput) bool {
+					return aws.ToString(input.GroupId) == "sg-node" &&
+						len(input.IpPermissions) == 1 &&
+						aws.ToString(input.IpPermissions[0].IpProtocol) == "-1"
+				})).Return(&ec2.AuthorizeSecurityGroupIngressOutput{},
+					fmt.Errorf("api error RulesPerSecurityGroupLimitExceeded: The maximum number of rules per security group has been reached"))
+
+				// CIDR fallback: AuthorizeSecurityGroupIngress for CIDR-based rules
+				m.On("AuthorizeSecurityGroupIngress", mock.MatchedBy(func(input *ec2.AuthorizeSecurityGroupIngressInput) bool {
+					if aws.ToString(input.GroupId) != "sg-node" || len(input.IpPermissions) == 0 {
+						return false
+					}
+					return len(input.IpPermissions[0].IpRanges) > 0
+				})).Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).Maybe()
+			},
+			expectError: false,
+		},
+		{
+			name:   "Node removed: SG-to-SG reference revoked from old node SG",
+			lbName: "test-nlb",
+			instances: map[InstanceID]*ec2types.Instance{
+				"i-new": makeInstance("i-new", "sg-node-new"),
+			},
+			nlbSecurityGroupIDs: []string{"sg-nlb"},
+			setupMocks: func(m *MockedFakeEC2) {
+				// getTaggedSecurityGroups: return both old and new SGs
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{}).Return(
+					[]ec2types.SecurityGroup{
+						{GroupId: aws.String("sg-node-new"), Tags: []ec2types.Tag{clusterTag}},
+						{GroupId: aws.String("sg-node-old"), Tags: []ec2types.Tag{clusterTag}},
+					}, nil)
+
+				// buildSecurityGroupRuleReferences: sg-node-old has existing SG-to-SG ref
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					Filters: []ec2types.Filter{newEc2Filter("ip-permission.group-id", "sg-nlb")},
+				}).Return([]ec2types.SecurityGroup{
+					{
+						GroupId: aws.String("sg-node-old"),
+						Tags:    []ec2types.Tag{clusterTag},
+						IpPermissions: []ec2types.IpPermission{
+							{
+								IpProtocol: aws.String("-1"),
+								UserIdGroupPairs: []ec2types.UserIdGroupPair{
+									{GroupId: aws.String("sg-nlb")},
+								},
+							},
+						},
+					},
+				}, nil)
+
+				// findSecurityGroup for sg-node-new (addSecurityGroupIngress)
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					GroupIds: []string{"sg-node-new"},
+				}).Return([]ec2types.SecurityGroup{
+					{GroupId: aws.String("sg-node-new"), Tags: []ec2types.Tag{clusterTag}},
+				}, nil)
+
+				// AuthorizeSecurityGroupIngress for new node SG
+				m.On("AuthorizeSecurityGroupIngress", mock.MatchedBy(func(input *ec2.AuthorizeSecurityGroupIngressInput) bool {
+					return aws.ToString(input.GroupId) == "sg-node-new" &&
+						len(input.IpPermissions) == 1 &&
+						aws.ToString(input.IpPermissions[0].IpProtocol) == "-1" &&
+						len(input.IpPermissions[0].UserIdGroupPairs) == 1 &&
+						aws.ToString(input.IpPermissions[0].UserIdGroupPairs[0].GroupId) == "sg-nlb"
+				})).Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil)
+
+				// findSecurityGroup for sg-node-old (removeSecurityGroupIngress)
+				m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					GroupIds: []string{"sg-node-old"},
+				}).Return([]ec2types.SecurityGroup{
+					{
+						GroupId: aws.String("sg-node-old"),
+						Tags:    []ec2types.Tag{clusterTag},
+						IpPermissions: []ec2types.IpPermission{
+							{
+								IpProtocol: aws.String("-1"),
+								UserIdGroupPairs: []ec2types.UserIdGroupPair{
+									{GroupId: aws.String("sg-nlb")},
+								},
+							},
+						},
+					},
+				}, nil)
+
+				// RevokeSecurityGroupIngress for old node SG
+				m.On("RevokeSecurityGroupIngress", mock.MatchedBy(func(input *ec2.RevokeSecurityGroupIngressInput) bool {
+					return aws.ToString(input.GroupId) == "sg-node-old"
+				})).Return(&ec2.RevokeSecurityGroupIngressOutput{}, nil)
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockedEC2 := &MockedFakeEC2{}
+			tt.setupMocks(mockedEC2)
+
+			cloud := &Cloud{
+				ec2: mockedEC2,
+				cfg: &config.CloudConfig{},
+				tagging: awsTagging{
+					ClusterID: "test-cluster",
+				},
+			}
+
+			ctx := context.Background()
+
+			// Provide port mappings and CIDRs when instances are present.
+			// These are used by the CIDR path (either directly or as fallback
+			// when SG-to-SG hits the rule limit).
+			var subnetCIDRs, clientCIDRs []string
+			var portMappings []nlbPortMapping
+			if tt.instances != nil {
+				subnetCIDRs = []string{"10.0.1.0/24"}
+				clientCIDRs = []string{"0.0.0.0/0"}
+				portMappings = []nlbPortMapping{
+					{
+						TrafficPort:     30000,
+						TrafficProtocol: elbv2types.ProtocolEnumTcp,
+						HealthCheckConfig: healthCheckConfig{
+							Port: defaultHealthCheckPort,
+						},
+					},
+				}
+			}
+
+			err := cloud.updateInstanceSecurityGroupsForNLB(ctx, tt.lbName, tt.instances, subnetCIDRs, clientCIDRs, portMappings, tt.nlbSecurityGroupIDs)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockedEC2.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -95,6 +95,16 @@ func (m *MockedFakeEC2) expectDescribeSecurityGroupsByFilter(clusterID, filterNa
 	}}).Return([]ec2types.SecurityGroup{{Tags: tags}})
 }
 
+func (m *MockedFakeEC2) AuthorizeSecurityGroupIngress(ctx context.Context, request *ec2.AuthorizeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "AuthorizeSecurityGroupIngress" {
+			args := m.Called(request)
+			return args.Get(0).(*ec2.AuthorizeSecurityGroupIngressOutput), args.Error(1)
+		}
+	}
+	return m.FakeEC2Impl.AuthorizeSecurityGroupIngress(ctx, request, optFns...)
+}
+
 func (m *MockedFakeEC2) RevokeSecurityGroupIngress(ctx context.Context, request *ec2.RevokeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error) {
 	args := m.Called(request)
 	return args.Get(0).(*ec2.RevokeSecurityGroupIngressOutput), args.Error(1)
@@ -4226,14 +4236,10 @@ func TestEnsureLoadBalancer(t *testing.T) {
 				NextToken:  nil,
 			}).Return([]ec2types.SecurityGroup{}, nil)
 
-			awsServices.ec2.(*MockedFakeEC2).On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
-				Filters: []ec2types.Filter{
-					{
-						Name:   aws.String("ip-permission.group-id"),
-						Values: []string{fakeSecurityGroupID},
-					},
-				},
-			}).Return([]ec2types.SecurityGroup{{GroupId: aws.String(fakeSecurityGroupID)}}, nil)
+			awsServices.ec2.(*MockedFakeEC2).On("DescribeSecurityGroups", mock.MatchedBy(func(input *ec2.DescribeSecurityGroupsInput) bool {
+				return len(input.Filters) == 1 &&
+					aws.ToString(input.Filters[0].Name) == "ip-permission.group-id"
+			})).Return([]ec2types.SecurityGroup{}, nil)
 
 			awsServices.elb.(*MockedFakeELB).On("DescribeLoadBalancers", &elb.DescribeLoadBalancersInput{
 				LoadBalancerNames: []string{fakeLoadBalancerName},

--- a/tests/e2e/loadbalancer.go
+++ b/tests/e2e/loadbalancer.go
@@ -455,6 +455,20 @@ var managedSgModeNLBTests = []loadBalancerTestCases{
 				framework.Failf("Expected NLB to have BYO SG %q, got %q", cfg.byoSecurityGroupID, attachedSGs[0])
 			}
 			framework.Logf("✓ Verified: NLB has only the BYO SG attached: %s", cfg.byoSecurityGroupID)
+
+			// Verify node SGs have an SG-to-SG ingress rule referencing the BYO SG
+			framework.Logf("Verifying node security groups have SG-to-SG reference to BYO SG %s", cfg.byoSecurityGroupID)
+			gomega.Eventually(cfg.ctx, func() error {
+				nodeSGs, err := getNodeInstanceSecurityGroups(cfg.ctx, cfg)
+				if err != nil {
+					return fmt.Errorf("failed to get node security groups: %w", err)
+				}
+				if !nodeSecurityGroupHasSGReference(nodeSGs, cfg.byoSecurityGroupID) {
+					return fmt.Errorf("no node security group has an ingress rule referencing BYO SG %s", cfg.byoSecurityGroupID)
+				}
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed(), "Node SGs should reference BYO SG")
+			framework.Logf("✓ Verified: Node SGs have SG-to-SG reference to BYO SG %s", cfg.byoSecurityGroupID)
 		},
 	},
 	// Test transition of NLB from Managed Security Group to Bring Your Own (BYO) Security Group (SG)
@@ -536,6 +550,23 @@ var managedSgModeNLBTests = []loadBalancerTestCases{
 				gomega.MatchError(gomega.ContainSubstring("InvalidGroup.NotFound")),
 			), "Managed SG should be deleted after transition to BYO SG")
 			framework.Logf("✓ Verified: Managed SG %s was deleted", managedSGID)
+
+			// Verify node SGs now reference the BYO SG (and no longer reference the old managed SG)
+			framework.Logf("Step 4: Verifying node security groups reference BYO SG %s", cfg.byoSecurityGroupID)
+			gomega.Eventually(cfg.ctx, func() error {
+				nodeSGs, err := getNodeInstanceSecurityGroups(cfg.ctx, cfg)
+				if err != nil {
+					return fmt.Errorf("failed to get node security groups: %w", err)
+				}
+				if !nodeSecurityGroupHasSGReference(nodeSGs, cfg.byoSecurityGroupID) {
+					return fmt.Errorf("no node security group has an ingress rule referencing BYO SG %s", cfg.byoSecurityGroupID)
+				}
+				if nodeSecurityGroupHasSGReference(nodeSGs, managedSGID) {
+					return fmt.Errorf("node security group still references old managed SG %s", managedSGID)
+				}
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed(), "Node SGs should reference BYO SG after transition")
+			framework.Logf("✓ Verified: Node SGs reference BYO SG %s and no longer reference managed SG %s", cfg.byoSecurityGroupID, managedSGID)
 		},
 	},
 	// Test transition of NLB from BYO Security Group to managed Security Group (SG)
@@ -605,6 +636,7 @@ var managedSgModeNLBTests = []loadBalancerTestCases{
 
 			// Step 3: Wait for controller to process the update and verify NLB has new managed SG
 			framework.Logf("Step 3: Waiting for controller to update NLB security groups and verifying new managed SG is attached")
+			var newManagedSGID string
 			err = wait.PollUntilContextTimeout(cfg.ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 				managedSGs, err := getLoadBalancerSecurityGroups(cfg.ctx, lbDNS)
 				if err != nil {
@@ -620,6 +652,7 @@ var managedSgModeNLBTests = []loadBalancerTestCases{
 					return false, nil
 				}
 				framework.Logf("NLB %s has security groups after removing BYO annotation: %+v", lbDNS, managedSGs)
+				newManagedSGID = managedSGs[0]
 				return true, nil
 			})
 			framework.ExpectNoError(err, "Failed waiting for NLB to get new managed SG")
@@ -630,6 +663,20 @@ var managedSgModeNLBTests = []loadBalancerTestCases{
 			framework.ExpectNoError(err, "Failed to get BYO security group")
 			gomega.Expect(byoSG).ToNot(gomega.BeNil(), "BYO SG should still exist after transition to managed SG")
 			framework.Logf("✓ Verified: BYO SG %s still exists and was not deleted", cfg.byoSecurityGroupID)
+
+			// Verify node SGs now reference the new managed SG
+			framework.Logf("Step 4: Verifying node security groups reference new managed SG %s", newManagedSGID)
+			gomega.Eventually(cfg.ctx, func() error {
+				nodeSGs, err := getNodeInstanceSecurityGroups(cfg.ctx, cfg)
+				if err != nil {
+					return fmt.Errorf("failed to get node security groups: %w", err)
+				}
+				if !nodeSecurityGroupHasSGReference(nodeSGs, newManagedSGID) {
+					return fmt.Errorf("no node security group has an ingress rule referencing managed SG %s", newManagedSGID)
+				}
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed(), "Node SGs should reference new managed SG after transition")
+			framework.Logf("✓ Verified: Node SGs reference new managed SG %s", newManagedSGID)
 		},
 	},
 }
@@ -1444,4 +1491,65 @@ func getSecurityGroup(ctx context.Context, securityGroupID string) (*ec2types.Se
 	}
 
 	return &result.SecurityGroups[0], nil
+}
+
+// getNodeInstanceSecurityGroups returns the full SecurityGroup objects for all SGs attached to a node's EC2 instance.
+func getNodeInstanceSecurityGroups(ctx context.Context, cfg *e2eTestConfig) ([]ec2types.SecurityGroup, error) {
+	ec2Client, err := getAWSClientEC2(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	node, err := cfg.kubeClient.CoreV1().Nodes().Get(ctx, cfg.nodeSingleSample, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %s: %w", cfg.nodeSingleSample, err)
+	}
+
+	providerID := node.Spec.ProviderID
+	if providerID == "" {
+		return nil, fmt.Errorf("node %s has no provider ID", cfg.nodeSingleSample)
+	}
+	instanceID := providerID[strings.LastIndex(providerID, "/")+1:]
+
+	descResult, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe instance %s: %w", instanceID, err)
+	}
+	if len(descResult.Reservations) == 0 || len(descResult.Reservations[0].Instances) == 0 {
+		return nil, fmt.Errorf("instance not found: %s", instanceID)
+	}
+
+	var sgIDs []string
+	for _, sg := range descResult.Reservations[0].Instances[0].SecurityGroups {
+		sgIDs = append(sgIDs, aws.ToString(sg.GroupId))
+	}
+	if len(sgIDs) == 0 {
+		return nil, fmt.Errorf("no security groups found on instance %s", instanceID)
+	}
+
+	sgResult, err := ec2Client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		GroupIds: sgIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe security groups: %w", err)
+	}
+
+	return sgResult.SecurityGroups, nil
+}
+
+// nodeSecurityGroupHasSGReference checks whether any of the node's security groups has an
+// ingress rule with a UserIdGroupPairs entry referencing the given source security group ID.
+func nodeSecurityGroupHasSGReference(nodeSGs []ec2types.SecurityGroup, sourceSGID string) bool {
+	for _, sg := range nodeSGs {
+		for _, perm := range sg.IpPermissions {
+			for _, pair := range perm.UserIdGroupPairs {
+				if aws.ToString(pair.GroupId) == sourceSGID {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Do Not Merge / Work in Progress

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When an NLB has security groups (managed or BYO), the CCM currently creates CIDR-based ingress rules on node security groups — one rule per port per CIDR block (`P × C` rules). This can quickly exhaust the AWS default limit of 60 rules per security group and allows direct node connectivity bypassing the load balancer.

This PR changes the NLB code path to match the existing CLB behavior: when an NLB has security groups, node security groups receive a single all-protocols (`-1`) ingress rule with a `UserIdGroupPairs` entry referencing the NLB's security group, replacing all per-port/per-CIDR rules. When an NLB has no security groups, the existing CIDR-based behavior is preserved.

**Key behaviors:**
- **Zero-downtime transition**: SG-to-SG rules are added before legacy CIDR rules are removed, so traffic is never interrupted.
- **Graceful fallback**: If the node SG is at the 60-rule limit, the `+1` rule addition fails with `RulesPerSecurityGroupLimitExceeded`. The code detects this, falls back to CIDR-based rules, and retries the transition on subsequent reconciliations. This helps avoid any impact during CCM version upgrades.
- **Downgrade safety**: Reverting to an older CCM leaves SG-to-SG rules in place (the old CCM doesn't know about them). Traffic continues flowing. The old CCM re-creates CIDR rules on the next reconciliation and both rule types coexist. Note: if a Service is deleted on the old CCM, the managed NLB SG may be leaked due to `DependencyViolation` from orphaned SG-to-SG references on node SGs.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

The implementation mirrors the existing CLB SG-to-SG logic in `updateInstanceSecurityGroupsForLoadBalancer`. The new `updateInstanceSecurityGroupForNLBBySGRef` function reuses the same helpers: `buildSecurityGroupRuleReferences`, `addSecurityGroupIngress`, and `removeSecurityGroupIngress`.

The `RulesPerSecurityGroupLimitExceeded` error detection uses `strings.Contains` instead of `errors.As` because `addSecurityGroupIngress` wraps errors with `%q` (not `%w`), which breaks the error chain.

**Test coverage:**
- 7 unit tests covering: SG-to-SG create, delete, CIDR fallback, CIDR→SG-to-SG transition, multiple NLB SGs, rule limit fallback, node add/remove
- 3 existing e2e tests extended with node SG assertions (BYO SG, managed→BYO transition, BYO→managed transition)

**Does this PR introduce a user-facing change?**:

```release-note
NLB-backed Services with security groups (managed or BYO) now use SG-to-SG ingress rules on node security groups instead of per-port/per-CIDR rules, matching the existing CLB behavior. This improves scalability (one rule vs P×C rules) and prevents direct node connectivity bypassing the load balancer. The transition from CIDR to SG-to-SG rules is automatic and zero-downtime. NLBs without security groups continue using CIDR-based rules.
