### PR TITLE
docs: add external load balancer management documentation

### DIFF
--- a/docs/service_controller.md
+++ b/docs/service_controller.md
@@ -86,3 +86,46 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=false,proxy_protocol_v2.enabled=true
 [...]
 ```
+
+## External Load Balancer Management
+
+The `service.beta.kubernetes.io/aws-load-balancer-type` annotation also supports values that indicate the load balancer should be managed externally rather than by the cloud provider:
+
+- **`nlb-ip`** or **`external`**: Indicates that the load balancer will be managed externally (e.g., by another controller or manually)
+
+When either of these values is set, the cloud provider controller will:
+
+- Skip load balancer creation
+- Skip load balancer updates
+- Skip load balancer deletion
+- Return no load balancer status
+
+### Use Cases
+
+This annotation is useful when transitioning load balancer management away from the cloud provider:
+
+- **Manual Management:** When you prefer to manage load balancers manually through AWS console, CLI, or Terraform, set the annotation to prevent the cloud provider from interfering with your manually managed resources.
+- **Orphaning:** When you need to keep an existing load balancer in AWS but remove it from Kubernetes management, set the annotation before removing the service finalizer and deleting the service.
+
+### Usage Example
+
+The following Service example shows how to configure a Service for external load balancer management:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: default
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: external
+spec:
+  selector:
+    app: my-app
+  ports:
+  - port: 80
+    targetPort: 8080
+  type: LoadBalancer
+```
+
+> Note: When using `nlb-ip` or `external`, the cloud provider will not create, update, or delete any AWS resources for services with these annotation values. You must ensure that the load balancer resources are managed through other means (e.g., manually through AWS console/CLI, or through IaC tools like Terraform).


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it:**

This PR adds documentation for the `nlb-ip` and `external` values of the `service.beta.kubernetes.io/aws-load-balancer-type` annotation in `docs/service_controller.md`.

**Background:**
The code has supported these values since July 2020 (introduced in kubernetes/kubernetes PR #92839 and copied to cloud-provider-aws in December 2020 via commit 093f4f1e0), but they have remained undocumented for over 5 years. The current documentation only lists `nlb` as a valid value, which is misleading.

**Why this documentation is important:**

1. **Code-Documentation Gap:** The `isLBExternal()` function in `pkg/providers/v1/aws_loadbalancer.go` has supported `nlb-ip` and `external` values since 2020, but users have no official documentation about their purpose or behavior.

2. **User Confusion:** Without documentation, users may attempt to use these values without understanding their effects, or may not know they exist at all when they need them.

3. **Valid Use Cases:** These values are necessary for:
   - **Manual Management:** When operators prefer to manage load balancers manually through AWS console/CLI or IaC tools like Terraform
   - **Orphaning:** When keeping an existing load balancer in AWS while removing it from Kubernetes management (e.g., during migrations)

4. **Clarification of Behavior:** The documentation clarifies that:
   - `nlb` is the only value that creates a load balancer managed by cloud-provider-aws
   - `nlb-ip` and `external` are not load balancer types, but flags that cause the cloud provider to skip all load balancer operations
   - When these values are set, the cloud provider will skip creation, updates, deletion, and status reporting for load balancers

5. **Safety Warning:** The documentation includes a note that users must ensure load balancer resources are managed through other means when using these values, as the cloud provider will not manage them.

**Changes:**
- Added a new section "External Load Balancer Management" to `docs/service_controller.md`
- Documented that `nlb-ip` and `external` are treated identically by the code
- Provided use cases for manual management and orphaning
- Added a usage example with YAML
- Included a warning about the need for external management

**Which issue(s) this PR fixes:**
Fixes #1459

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
