### PR TITLE
Narrow CLB BYO-SG cleanup revoke to the matching UserIdGroupPair

### DIFF
--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -1933,7 +1933,16 @@ func (c *Cloud) buildSecurityGroupRuleReferences(ctx context.Context, sgID strin
 			if rule.UserIdGroupPairs != nil {
 				for _, pair := range rule.UserIdGroupPairs {
 					if pair.GroupId != nil && aws.ToString(pair.GroupId) == sgID {
-						groupsLinkedPermissions[&sg].Insert(rule)
+						// Revoke only the UserIdGroupPair that references sgID. EC2 consolidates rules
+						// with the same protocol/port into one IpPermission with multiple pairs, so the
+						// matched rule may also carry unrelated pairs (e.g. the node SG self-reference).
+						// Build a new permission with just the matching pair so nothing else is revoked.
+						groupsLinkedPermissions[&sg].Insert(ec2types.IpPermission{
+							IpProtocol:       rule.IpProtocol,
+							FromPort:         rule.FromPort,
+							ToPort:           rule.ToPort,
+							UserIdGroupPairs: []ec2types.UserIdGroupPair{pair},
+						})
 					}
 				}
 			}

--- a/pkg/providers/v1/aws_loadbalancer_test.go
+++ b/pkg/providers/v1/aws_loadbalancer_test.go
@@ -2220,6 +2220,64 @@ func TestCloud_buildSecurityGroupRuleReferences(t *testing.T) {
 			},
 		},
 		{
+			name:          "consolidated permission is narrowed to the matching pair only",
+			targetGroupID: "sg-target",
+			setupMocks: func(mockedEC2 *MockedFakeEC2) {
+				mockedEC2.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{
+					Filters: []ec2types.Filter{
+						{
+							Name:   aws.String("ip-permission.group-id"),
+							Values: []string{"sg-target"},
+						},
+					},
+				}).Return([]ec2types.SecurityGroup{
+					{
+						GroupId: aws.String("sg-node"),
+						Tags: []ec2types.Tag{
+							{
+								Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+								Value: aws.String("owned"),
+							},
+						},
+						// A single all-traffic IpPermission that EC2 has consolidated: it
+						// contains both the node SG's own self-reference and the reference to
+						// sg-target. Only the sg-target pair should be selected for revocation;
+						// the self-reference must be preserved.
+						IpPermissions: []ec2types.IpPermission{
+							{
+								IpProtocol: aws.String("-1"),
+								UserIdGroupPairs: []ec2types.UserIdGroupPair{
+									{GroupId: aws.String("sg-node")},
+									{GroupId: aws.String("sg-target")},
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			expectError:                          false,
+			expectedGroupsWithTagsCount:          1,
+			expectedGroupsLinkedPermissionsCount: 1,
+			additionalAssertions: func(t *testing.T, groupsWithTags map[*ec2types.SecurityGroup]bool, groupsLinkedPermissions map[*ec2types.SecurityGroup]IPPermissionSet) {
+				var foundSG *ec2types.SecurityGroup
+				for sg := range groupsLinkedPermissions {
+					if aws.ToString(sg.GroupId) == "sg-node" {
+						foundSG = sg
+						break
+					}
+				}
+				require.NotNil(t, foundSG)
+
+				linked := groupsLinkedPermissions[foundSG]
+				require.Equal(t, 1, linked.Len())
+				perm := linked.List()[0]
+				// The revoke set must reference ONLY sg-target, never the node SG's
+				// self-reference (which would break intra-cluster traffic if revoked).
+				require.Len(t, perm.UserIdGroupPairs, 1)
+				assert.Equal(t, "sg-target", aws.ToString(perm.UserIdGroupPairs[0].GroupId))
+			},
+		},
+		{
 			name:          "success with non-cluster tagged security group",
 			targetGroupID: "sg-target",
 			setupMocks: func(mockedEC2 *MockedFakeEC2) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`buildSecurityGroupRuleReferences` inserted the whole EC2 `IpPermission` when any one of its `UserIdGroupPairs` referenced the security group being removed. `removeOwnedSecurityGroups` then passed that consolidated permission straight to `RevokeSecurityGroupIngress`, so a single revoke removed every pair sharing the same protocol/port tuple.

EC2 commonly consolidates the node/cluster SG's all-traffic (`-1`) self-reference and the controller's LB→node rule into one `IpPermission`, so cleaning up the managed SG on a CLB managed→BYO SG transition (via the `service.beta.kubernetes.io/aws-load-balancer-security-groups` annotation) also revoked the self-reference and broke cross-node pod traffic.

This PR narrows the linked permission to only the matching `UserIdGroupPair` (and clears the CIDR / IPv6 / prefix-list dimensions), matching the single-pair revoke granularity already used by the CLB delete and NLB paths, so unrelated pairs such as the node SG self-reference are preserved.

**Which issue(s) this PR fixes**:

Fixes #1472

**Special notes for your reviewer**:

- The bug is scoped to the CLB managed→BYO-SG cleanup path added in #1209 (first released in v1.36.0); earlier release branches don't have `removeOwnedSecurityGroups`.
- The fix narrows at the source (`buildSecurityGroupRuleReferences`) rather than calling the existing `Ungroup()` helper, because `Ungroup()` would still need per-`sgID` selection and it currently leaves non-split dimensions populated (shallow copy); clearing `IpRanges`/`Ipv6Ranges`/`PrefixListIds` here avoids that class of over-revoke.
- Added a regression case to `TestCloud_buildSecurityGroupRuleReferences`: a consolidated `-1` permission bundling the node-SG self-reference with the target SG must yield a revoke set containing only the target pair. It fails on the pre-fix code and passes after.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed a bug where transitioning a Service-managed Classic Load Balancer to a user-provided security group could revoke unrelated ingress rules (including the node security group's self-reference) on security groups that share a consolidated IP permission, breaking cross-node pod traffic.
```