### PR TITLE
fix: invalid/deleted instance handling hardening

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -3455,6 +3455,11 @@ func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, serv
 func (c *Cloud) getInstanceByID(ctx context.Context, instanceID string) (*ec2types.Instance, error) {
 	instances, err := c.getInstancesByIDs(ctx, []string{instanceID})
 	if err != nil {
+		// A DescribeInstances by ID for an instance that no longer exists returns
+		// an InvalidInstanceID.NotFound error rather than an empty result.
+		if IsAWSErrorInstanceNotFound(err) {
+			return nil, cloudprovider.InstanceNotFound
+		}
 		return nil, err
 	}
 

--- a/pkg/providers/v1/instances_v2.go
+++ b/pkg/providers/v1/instances_v2.go
@@ -22,6 +22,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"k8s.io/cloud-provider-aws/pkg/providers/v1/variant"
 	"strconv"
@@ -50,6 +51,12 @@ func (c *Cloud) getProviderID(ctx context.Context, node *v1.Node) (string, error
 func (c *Cloud) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
 	providerID, err := c.getProviderID(ctx, node)
 	if err != nil {
+		// If the node has no providerID set, getProviderID falls back to looking up
+		// the instance by node name. A deleted instance yields InstanceNotFound, which
+		// means the node no longer exists in the cloud provider.
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
+			return false, nil
+		}
 		return false, err
 	}
 
@@ -61,6 +68,9 @@ func (c *Cloud) InstanceExists(ctx context.Context, node *v1.Node) (bool, error)
 func (c *Cloud) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
 	providerID, err := c.getProviderID(ctx, node)
 	if err != nil {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
+			return false, nil
+		}
 		return false, err
 	}
 

--- a/pkg/providers/v1/instances_v2_test.go
+++ b/pkg/providers/v1/instances_v2_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cloud-provider-aws/pkg/services"
 )
 
@@ -116,6 +117,84 @@ func TestInstanceExists(t *testing.T) {
 			} else {
 				assert.False(t, result)
 			}
+		})
+	}
+}
+
+func TestInstanceExistsNoProviderIDInstanceGone(t *testing.T) {
+	// Only the self-instance exists in the cloud; the node under test has no
+	// providerID and no backing instance, mirroring an instance deleted before
+	// its providerID was ever set. Its name doesn't match any live instance's
+	// private DNS name, so the node-name lookup in getProviderID resolves to
+	// InstanceNotFound.
+	self := makeInstance("i-self", "192.168.0.1", "1.2.3.4", "ip-172-20-0-100.ec2.internal", "", nil, true)
+	c, _ := mockInstancesResp(&self, []*ec2types.Instance{&self})
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "ip-172-20-9-9.ec2.internal"},
+		Spec:       v1.NodeSpec{},
+	}
+
+	exists, err := c.InstanceExists(context.TODO(), node)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
+	shutdown, err := c.InstanceShutdown(context.TODO(), node)
+	assert.NoError(t, err)
+	assert.False(t, shutdown)
+}
+
+func TestInstanceExistsNoProviderIDRBNInstanceGone(t *testing.T) {
+	// The mocked EC2 API returns InvalidInstanceID.NotFound for every describe,
+	// mirroring a purged instance looked up by ID.
+	c := getCloudWithMockedDescribeInstances(false, "", "i-0123456789abcdef0")
+	// InstanceID dereferences selfAWSInstance; set it to a different node so the
+	// lookup falls through to the by-ID path rather than the self short-circuit.
+	c.selfAWSInstance = &awsInstance{nodeName: "i-self"}
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "i-0123456789abcdef0"},
+		Spec:       v1.NodeSpec{},
+	}
+
+	exists, err := c.InstanceExists(context.TODO(), node)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
+	shutdown, err := c.InstanceShutdown(context.TODO(), node)
+	assert.NoError(t, err)
+	assert.False(t, shutdown)
+}
+
+func TestInstanceExistsNoProviderIDInvalidIDNotDeleted(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		apiErr string
+	}{
+		{"malformed instance ID from DescribeInstances", "InvalidInstanceID.Malformed: The specified instance ID is malformed"},
+		{"invalid resource ID", "InvalidID: The ID 'i-kwok-fake' is not valid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockedEC2API := newMockedEC2API()
+			mockedEC2API.On("DescribeInstances", mock.Anything).Return(&ec2.DescribeInstancesOutput{}, errors.New(tc.apiErr))
+			c := &Cloud{
+				ec2:                     &awsSdkEC2{ec2: mockedEC2API},
+				describeInstanceBatcher: newdescribeInstanceBatcher(context.Background(), &awsSdkEC2{ec2: mockedEC2API}),
+				selfAWSInstance:         &awsInstance{nodeName: "i-self"},
+			}
+
+			node := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "i-kwok-fake"},
+				Spec:       v1.NodeSpec{},
+			}
+
+			exists, err := c.InstanceExists(context.TODO(), node)
+			assert.Error(t, err)
+			assert.False(t, exists)
+
+			shutdown, err := c.InstanceShutdown(context.TODO(), node)
+			assert.Error(t, err)
+			assert.False(t, shutdown)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
adds logic to handle notready nodes with no provider id properly to not requeue indefinitely
- also mirrors the existing logic that is in instances v1

while looking at that issue also found a gap where if we get back from aws that the instance is not found for an id that we described, we should properly delete the node

also added regression tests for the original issue outlined in the issue, the secondary issue that was found, and a test for kwok

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1471

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
