### PR TITLE
e2e: increase BYO SG deletion timeout from 2 to 6 minutes

### DIFF
--- a/tests/e2e/loadbalancer.go
+++ b/tests/e2e/loadbalancer.go
@@ -425,7 +425,7 @@ var managedSgModeNLBTests = []loadBalancerTestCases{
 					framework.Logf("Waiting for ENIs to be detached from security group...")
 					gomega.Eventually(ctx, func() error {
 						return deleteSecurityGroup(ctx, cfg.byoSecurityGroupID)
-					}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed(), "Failed to delete BYO security group")
+					}, 6*time.Minute, 10*time.Second).Should(gomega.Succeed(), "Failed to delete BYO security group")
 					framework.Logf("✓ Deleted BYO security group: %s", cfg.byoSecurityGroupID)
 				}
 			})
@@ -485,7 +485,7 @@ var managedSgModeNLBTests = []loadBalancerTestCases{
 					framework.Logf("Waiting for ENIs to be detached from security group...")
 					gomega.Eventually(ctx, func() error {
 						return deleteSecurityGroup(ctx, cfg.byoSecurityGroupID)
-					}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed(), "Failed to delete BYO security group after waiting for ENI detachment")
+					}, 6*time.Minute, 10*time.Second).Should(gomega.Succeed(), "Failed to delete BYO security group after waiting for ENI detachment")
 					framework.Logf("✓ Deleted BYO security group: %s", cfg.byoSecurityGroupID)
 				}
 			})
@@ -567,7 +567,7 @@ var managedSgModeNLBTests = []loadBalancerTestCases{
 					framework.Logf("Waiting for ENIs to be detached from security group...")
 					gomega.Eventually(ctx, func() error {
 						return deleteSecurityGroup(ctx, cfg.byoSecurityGroupID)
-					}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed(), "Failed to delete BYO security group after waiting for ENI detachment")
+					}, 6*time.Minute, 10*time.Second).Should(gomega.Succeed(), "Failed to delete BYO security group after waiting for ENI detachment")
 					framework.Logf("✓ Deleted BYO security group: %s", cfg.byoSecurityGroupID)
 				}
 			})


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

The BYO security group e2e tests delete the test security group in a `DeferCleanup` block using `gomega.Eventually` with a 2-minute timeout. This timeout is occasionally insufficient in loaded CI environments.

When an NLB is deleted, AWS does not immediately release the ENIs it created in the VPC. Those ENIs hold a reference to the security group, causing `DeleteSecurityGroup` to return `DependencyViolation` until the ENIs are fully detached. While `WaitForLoadBalancerDestroy` confirms the NLB endpoint is unreachable, ENI detachment can lag by several minutes
after that point. The 2-minute retry window was not always enough to bridge this gap in our CI environments, causing sporadic test failures unrelated to the feature under test.

We observed this in OpenShift CI ([sippy link](https://sippy.dptools.openshift.org/sippy-ng/jobs/5.0/runs?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522failed_test_names%2522%252C%2522operatorValue%2522%253A%2522has%2520entry%2522%252C%2522value%2522%253A%2522%255Bcloud-provider-aws-e2e%255D%2520loadbalancer%2520NLB%2520created%2520with%2520BYO%2520Security%2520Group%2520should%2520have%2520BYO%2520Security%2520Group%2520associated%2520%255BSuite%253Aopenshift%252Fconformance%252Fparallel%255D%2522%257D%252C%257B%2522columnField%2522%253A%2522timestamp%2522%252C%2522operatorValue%2522%253A%2522%253E%2522%252C%2522value%2522%253A%25221785678703459%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522has%2520entry%2522%252C%2522value%2522%253A%2522never-stable%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522has%2520entry%2522%252C%2522value%2522%253A%2522aggregated%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D&page=0&pageSize=100&sort=desc&sortField=timestamp)) with a failure evident in approximately 0.5% of test runs based on our estimations ([example failed job](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-aws-ovn-conformance/2085772617955938304))


This PR increases the `Eventually` timeout from 2 minutes to 6 minutes and the poll interval from 5s to 10s across all three BYO SG cleanup blocks. 

**Which issue(s) this PR fixes**:

_Not applicable — flake identified via Sippy CI analysis, no tracking issue._

**Special notes for your reviewer**:

This is a test-only change with no impact on production code. The three affected `Eventually` blocks are all in `DeferCleanup` handlers in `tests/e2e/loadbalancer.go` and are only reached during cleanup of BYO security group e2e tests.

**Does this PR introduce a user-facing change?**: 
No

