### PR TITLE
Add terminal AWS API error metric (count per logical call, not per attempt)

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -41,7 +41,6 @@ import (
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/smithy-go"
-	smithymiddleware "github.com/aws/smithy-go/middleware"
 	"gopkg.in/gcfg.v1"
 
 	v1 "k8s.io/api/core/v1"
@@ -520,9 +519,7 @@ func init() {
 		var creds *stscreds.AssumeRoleProvider
 		if cfg.Global.RoleARN != "" {
 			stsClient, err := services.NewStsClient(ctx, regionName, cfg.Global.RoleARN, cfg.Global.SourceARN,
-				func(stack *smithymiddleware.Stack) error {
-					return stack.Deserialize.Add(awsAPIMetricsMiddleware(), smithymiddleware.After)
-				},
+				addAWSAPIMetricsMiddleware,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("unable to create sts v2 client: %v", err)

--- a/pkg/providers/v1/aws_api_metrics_test.go
+++ b/pkg/providers/v1/aws_api_metrics_test.go
@@ -21,48 +21,65 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
-	"github.com/aws/smithy-go"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/component-base/metrics/testutil"
 )
 
+// respErr builds an *awshttp.ResponseError carrying the given HTTP status code, as the
+// SDK produces when an API call fails terminally with an HTTP response.
+func respErr(statusCode int) error {
+	return &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{Response: &http.Response{StatusCode: statusCode}},
+			Err:      fmt.Errorf("api error"),
+		},
+	}
+}
+
+// statusCounterValue returns the recorded count for a status code (empty
+// service/operation, as produced by the test middleware chain).
+func statusCounterValue(t *testing.T, statusCode string) float64 {
+	t.Helper()
+	v, err := testutil.GetCounterMetricValue(awsAPIResponseStatusTotal.With(map[string]string{
+		"service":     "",
+		"operation":   "",
+		"status_code": statusCode,
+	}))
+	assert.NoError(t, err)
+	return v
+}
+
 func TestAWSAPIMetricsMiddleware(t *testing.T) {
 	registerMetrics()
 
 	tests := []struct {
 		name             string
-		statusCode       int
 		err              error
-		expectStatusCode string
+		expectStatusCode string // "" means expect nothing recorded
 	}{
 		{
-			name:             "4xx response records status code",
-			statusCode:       403,
+			name:             "terminal 4xx records status code",
+			err:              respErr(403),
 			expectStatusCode: "403",
 		},
 		{
-			name:             "5xx response records status code",
-			statusCode:       500,
+			name:             "terminal 5xx records status code",
+			err:              respErr(500),
 			expectStatusCode: "500",
 		},
 		{
-			name:       "2xx response does not record",
-			statusCode: 200,
+			name: "success records nothing",
+			err:  nil,
 		},
 		{
-			name:             "4xx with API error records status code",
-			statusCode:       400,
-			err:              &smithy.GenericAPIError{Code: "ThrottlingException", Message: "rate exceeded"},
-			expectStatusCode: "400",
-		},
-		{
-			name:             "5xx with non-API error records status code",
-			statusCode:       500,
-			err:              fmt.Errorf("connection reset"),
-			expectStatusCode: "500",
+			name: "terminal error without HTTP response records nothing",
+			err:  fmt.Errorf("connection reset"),
 		},
 	}
 
@@ -71,29 +88,87 @@ func TestAWSAPIMetricsMiddleware(t *testing.T) {
 			awsAPIResponseStatusTotal.Reset()
 
 			mw := awsAPIMetricsMiddleware()
-			handler := middleware.DeserializeHandlerFunc(
-				func(ctx context.Context, in middleware.DeserializeInput) (
-					middleware.DeserializeOutput, middleware.Metadata, error,
+			handler := middleware.FinalizeHandlerFunc(
+				func(ctx context.Context, in middleware.FinalizeInput) (
+					middleware.FinalizeOutput, middleware.Metadata, error,
 				) {
-					return middleware.DeserializeOutput{
-						RawResponse: &smithyhttp.Response{
-							Response: &http.Response{StatusCode: tc.statusCode},
-						},
-					}, middleware.Metadata{}, tc.err
+					return middleware.FinalizeOutput{}, middleware.Metadata{}, tc.err
 				},
 			)
 
-			_, _, _ = mw.HandleDeserialize(context.Background(), middleware.DeserializeInput{}, handler)
+			_, _, _ = mw.HandleFinalize(context.Background(), middleware.FinalizeInput{}, handler)
 
 			if tc.expectStatusCode != "" {
-				val, err := testutil.GetCounterMetricValue(awsAPIResponseStatusTotal.With(map[string]string{
-					"service":     "",
-					"operation":   "",
-					"status_code": tc.expectStatusCode,
-				}))
-				assert.NoError(t, err)
-				assert.Equal(t, float64(1), val)
+				assert.Equal(t, float64(1), statusCounterValue(t, tc.expectStatusCode))
 			}
 		})
 	}
+}
+
+// TestAWSAPIMetricsMiddlewareWithRetries asserts that transient failures the
+// retryer recovers from are NOT counted (the point of counting at Finalize,
+// before Retry, rather than at Deserialize), while a failure that exhausts
+// retries is counted exactly once.
+func TestAWSAPIMetricsMiddlewareWithRetries(t *testing.T) {
+	registerMetrics()
+
+	// Standard retryer: 3 attempts, zero backoff so the test is fast.
+	retryer := retry.NewStandard(func(o *retry.StandardOptions) {
+		o.MaxAttempts = 3
+		o.Backoff = retry.BackoffDelayerFunc(func(int, error) (time.Duration, error) { return 0, nil })
+	})
+	attempt := retry.NewAttemptMiddleware(retryer, func(i interface{}) interface{} { return i })
+	metricsMW := awsAPIMetricsMiddleware()
+
+	run := func(inner middleware.FinalizeHandler) error {
+		// Adapt the attempt middleware into a FinalizeHandler that drives the retry loop
+		// over inner, so metricsMW (inserted before Retry) sees only the terminal result.
+		retryHandler := middleware.FinalizeHandlerFunc(func(ctx context.Context, in middleware.FinalizeInput) (
+			middleware.FinalizeOutput, middleware.Metadata, error) {
+			return attempt.HandleFinalize(ctx, in, inner)
+		})
+		_, _, err := metricsMW.HandleFinalize(context.Background(), middleware.FinalizeInput{}, retryHandler)
+		return err
+	}
+
+	t.Run("transient 503 then success is not counted", func(t *testing.T) {
+		awsAPIResponseStatusTotal.Reset()
+		calls := 0
+		err := run(middleware.FinalizeHandlerFunc(func(ctx context.Context, in middleware.FinalizeInput) (
+			middleware.FinalizeOutput, middleware.Metadata, error) {
+			calls++
+			if calls == 1 {
+				return middleware.FinalizeOutput{}, middleware.Metadata{}, respErr(503)
+			}
+			return middleware.FinalizeOutput{}, middleware.Metadata{}, nil // recovered
+		}))
+		assert.NoError(t, err, "expected success after retry")
+		assert.Equal(t, 2, calls, "expected 2 attempts (1 fail + 1 success)")
+		assert.Equal(t, float64(0), statusCounterValue(t, "503"), "retried-away 503 should not be counted")
+	})
+
+	t.Run("retry-exhausted 503 is counted once", func(t *testing.T) {
+		awsAPIResponseStatusTotal.Reset()
+		calls := 0
+		err := run(middleware.FinalizeHandlerFunc(func(ctx context.Context, in middleware.FinalizeInput) (
+			middleware.FinalizeOutput, middleware.Metadata, error) {
+			calls++
+			return middleware.FinalizeOutput{}, middleware.Metadata{}, respErr(503)
+		}))
+		assert.Error(t, err, "expected terminal error after exhausting retries")
+		assert.Equal(t, 3, calls, "expected 3 attempts (max)")
+		assert.Equal(t, float64(1), statusCounterValue(t, "503"), "retry-exhausted 503 should be counted exactly once")
+	})
+
+	t.Run("non-retryable 400 is counted once on first attempt", func(t *testing.T) {
+		awsAPIResponseStatusTotal.Reset()
+		calls := 0
+		err := run(middleware.FinalizeHandlerFunc(func(ctx context.Context, in middleware.FinalizeInput) (
+			middleware.FinalizeOutput, middleware.Metadata, error) {
+			calls++
+			return middleware.FinalizeOutput{}, middleware.Metadata{}, respErr(400)
+		}))
+		assert.Error(t, err, "expected terminal error for 400")
+		assert.Equal(t, float64(1), statusCounterValue(t, "400"), "terminal 400 should be counted exactly once")
+	})
 }

--- a/pkg/providers/v1/aws_metrics.go
+++ b/pkg/providers/v1/aws_metrics.go
@@ -18,11 +18,12 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"sync"
 
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/smithy-go/middleware"
-	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -52,11 +53,15 @@ var (
 		},
 		[]string{"operation_name"})
 
-	// awsAPIResponseStatusTotal counts AWS API responses by status code.
+	// awsAPIResponseStatusTotal counts AWS API responses with an error status code
+	// (>= 400). It is recorded by a Finalize middleware inserted before the SDK's
+	// "Retry" middleware, so it counts the terminal status of each logical call
+	// once (after retries are exhausted) rather than once per attempt — a response
+	// that is retried and then succeeds is not counted.
 	awsAPIResponseStatusTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Name:           "cloudprovider_aws_api_response_status_total",
-			Help:           "AWS API response status code counts",
+			Help:           "AWS API error response status code counts (terminal, after retries are exhausted)",
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"service", "operation", "status_code"})
@@ -85,28 +90,40 @@ func registerMetrics() {
 	})
 }
 
-// awsAPIMetricsMiddleware returns a Deserialize middleware that records
-// AWS API response status codes as metrics.
-func awsAPIMetricsMiddleware() middleware.DeserializeMiddleware {
-	return middleware.DeserializeMiddlewareFunc(
+// awsAPIMetricsMiddleware returns a Finalize middleware that records the HTTP
+// status code of AWS API calls that fail terminally. It is inserted before the
+// SDK's "Retry" middleware so it wraps the entire retry loop and runs once per
+// logical call, recording only the terminal error status (not per attempt), so
+// a response that is retried and then succeeds is not counted.
+func awsAPIMetricsMiddleware() middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
 		"k8s/aws-api-metrics",
-		func(ctx context.Context, in middleware.DeserializeInput, next middleware.DeserializeHandler) (
-			out middleware.DeserializeOutput, metadata middleware.Metadata, err error,
+		func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (
+			out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
 		) {
-			out, metadata, err = next.HandleDeserialize(ctx, in)
+			out, metadata, err = next.HandleFinalize(ctx, in)
+			if err == nil {
+				return out, metadata, err
+			}
 
-			service := middleware.GetServiceID(ctx)
-			operation := middleware.GetOperationName(ctx)
-
-			if response, ok := out.RawResponse.(*smithyhttp.Response); ok && response.StatusCode >= 400 {
+			// The SDK surfaces every non-2xx terminal response as an error carrying
+			// an *awshttp.ResponseError; a nil error means a 2xx, which we do not count.
+			var respErr *awshttp.ResponseError
+			if errors.As(err, &respErr) && respErr.HTTPStatusCode() >= 400 {
 				awsAPIResponseStatusTotal.With(metrics.Labels{
-					"service":     service,
-					"operation":   operation,
-					"status_code": strconv.Itoa(response.StatusCode),
+					"service":     middleware.GetServiceID(ctx),
+					"operation":   middleware.GetOperationName(ctx),
+					"status_code": strconv.Itoa(respErr.HTTPStatusCode()),
 				}).Inc()
 			}
 
 			return out, metadata, err
 		},
 	)
+}
+
+// addAWSAPIMetricsMiddleware inserts the metrics middleware into the Finalize
+// step before the SDK's "Retry" middleware, so it observes only terminal outcomes.
+func addAWSAPIMetricsMiddleware(stack *middleware.Stack) error {
+	return stack.Finalize.Insert(awsAPIMetricsMiddleware(), "Retry", middleware.Before)
 }

--- a/pkg/providers/v1/aws_sdk.go
+++ b/pkg/providers/v1/aws_sdk.go
@@ -86,12 +86,8 @@ func (p *awsSDKProvider) AddMiddleware(ctx context.Context, regionName string, c
 
 	p.addAPILoggingMiddleware(cfg)
 
-	// Record AWS API response status codes and error codes as metrics.
-	cfg.APIOptions = append(cfg.APIOptions,
-		func(stack *smithymiddleware.Stack) error {
-			return stack.Deserialize.Add(awsAPIMetricsMiddleware(), smithymiddleware.After)
-		},
-	)
+	// Record the status code of AWS API calls that fail terminally as metrics.
+	cfg.APIOptions = append(cfg.APIOptions, addAWSAPIMetricsMiddleware)
 }
 
 // Adds logging middleware for AWS SDK Go V2 clients


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**

`cloudprovider_aws_api_response_status_total` is recorded by a Deserialize
middleware, which runs *inside* the AWS SDK's retry loop and reads the HTTP
status from `out.RawResponse`. As a result it increments **once per attempt**: an
API call that receives a throttling/5xx response and then succeeds on a retry
still increments the counter (once per failed attempt).

Because the SDK transparently retries and recovers from most throttling and
transient 5xx responses, this makes the metric a poor signal for the actual AWS
API error rate — it is dominated by transient responses that never surfaced as a
real failure to the caller. On busy clusters (frequent EC2 calls during node
initialization, node-lifecycle polling, and load-balancer target syncing) the
inflation is large.

This PR moves the metrics middleware from a Deserialize step to a **Finalize step
inserted before the SDK's `Retry` middleware**, so it wraps the entire retry loop
and runs **once per logical call**, recording the status only of calls that fail
**terminally** (after retries are exhausted). The terminal status is read from the
terminal error via `*awshttp.ResponseError`. A response that is retried and then
succeeds is no longer counted.

The metric name and its `{service, operation, status_code}` labels are unchanged;
only the counting semantics (per-attempt → per-terminal-outcome) and the help
text change.

**Which issue(s) this PR fixes:**
<!-- Fixes #xxxx  (link an issue if you file one) -->

**Special notes for your reviewer:**

- Metric name and labels are unchanged; this is a semantics fix to an ALPHA metric.
- The middleware is now attached via a shared `addAWSAPIMetricsMiddleware` option
  at the two existing call sites (the default SDK clients in `aws_sdk.go` and the
  STS client in `aws.go`).
- Tests in `aws_api_metrics_test.go` were updated for the Finalize-based
  middleware and extended with a retry-loop test that drives the real SDK retryer:
  it asserts that a transient 503 which succeeds on retry is **not** counted, a
  retry-exhausted 503 is counted **exactly once**, and a non-retryable 400 is
  counted once.

**Does this PR introduce a user-facing change?**

```release-note
Fixed `cloudprovider_aws_api_response_status_total` to count AWS API errors once per logical call (after the SDK's retries are exhausted) instead of once per attempt. Previously a response that was retried and then succeeded was still counted, which over-counted transient errors; the metric now reflects terminal failures only. The metric name and labels are unchanged.
```
