### PR TITLE
Classify terminal AWS API throttling responses

### DIFF
--- a/pkg/providers/v1/aws_api_metrics_test.go
+++ b/pkg/providers/v1/aws_api_metrics_test.go
@@ -25,31 +25,38 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/component-base/metrics/testutil"
 )
 
-// respErr builds an *awshttp.ResponseError carrying the given HTTP status code, as the
-// SDK produces when an API call fails terminally with an HTTP response.
-func respErr(statusCode int) error {
+// respErr builds an *awshttp.ResponseError carrying the given HTTP status and
+// optional API error code, as the SDK does for a terminal HTTP error.
+func respErr(statusCode int, errorCode string) error {
+	var err error = fmt.Errorf("api error")
+	if errorCode != "" {
+		err = &smithy.GenericAPIError{Code: errorCode, Message: "api error"}
+	}
+
 	return &awshttp.ResponseError{
 		ResponseError: &smithyhttp.ResponseError{
 			Response: &smithyhttp.Response{Response: &http.Response{StatusCode: statusCode}},
-			Err:      fmt.Errorf("api error"),
+			Err:      err,
 		},
 	}
 }
 
-// statusCounterValue returns the recorded count for a status code (empty
-// service/operation, as produced by the test middleware chain).
-func statusCounterValue(t *testing.T, statusCode string) float64 {
+// statusCounterValue returns the recorded count for a status and error type
+// (empty service/operation, as produced by the test middleware chain).
+func statusCounterValue(t *testing.T, statusCode, errorType string) float64 {
 	t.Helper()
 	v, err := testutil.GetCounterMetricValue(awsAPIResponseStatusTotal.With(map[string]string{
 		"service":     "",
 		"operation":   "",
 		"status_code": statusCode,
+		"error_type":  errorType,
 	}))
 	assert.NoError(t, err)
 	return v
@@ -62,16 +69,33 @@ func TestAWSAPIMetricsMiddleware(t *testing.T) {
 		name             string
 		err              error
 		expectStatusCode string // "" means expect nothing recorded
+		expectErrorType  string
 	}{
 		{
 			name:             "terminal 4xx records status code",
-			err:              respErr(403),
+			err:              respErr(403, ""),
 			expectStatusCode: "403",
 		},
 		{
 			name:             "terminal 5xx records status code",
-			err:              respErr(500),
+			err:              respErr(500, ""),
 			expectStatusCode: "500",
+		},
+		{
+			name:             "terminal RequestLimitExceeded 503 records throttle error type",
+			err:              respErr(503, "RequestLimitExceeded"),
+			expectStatusCode: "503",
+			expectErrorType:  "throttle",
+		},
+		{
+			name:             "terminal 503 without API error records empty error type",
+			err:              respErr(503, ""),
+			expectStatusCode: "503",
+		},
+		{
+			name:             "terminal ThrottlingException 400 records empty error type",
+			err:              respErr(400, "ThrottlingException"),
+			expectStatusCode: "400",
 		},
 		{
 			name: "success records nothing",
@@ -99,7 +123,7 @@ func TestAWSAPIMetricsMiddleware(t *testing.T) {
 			_, _, _ = mw.HandleFinalize(context.Background(), middleware.FinalizeInput{}, handler)
 
 			if tc.expectStatusCode != "" {
-				assert.Equal(t, float64(1), statusCounterValue(t, tc.expectStatusCode))
+				assert.Equal(t, float64(1), statusCounterValue(t, tc.expectStatusCode, tc.expectErrorType))
 			}
 		})
 	}
@@ -138,26 +162,26 @@ func TestAWSAPIMetricsMiddlewareWithRetries(t *testing.T) {
 			middleware.FinalizeOutput, middleware.Metadata, error) {
 			calls++
 			if calls == 1 {
-				return middleware.FinalizeOutput{}, middleware.Metadata{}, respErr(503)
+				return middleware.FinalizeOutput{}, middleware.Metadata{}, respErr(503, "RequestLimitExceeded")
 			}
 			return middleware.FinalizeOutput{}, middleware.Metadata{}, nil // recovered
 		}))
 		assert.NoError(t, err, "expected success after retry")
 		assert.Equal(t, 2, calls, "expected 2 attempts (1 fail + 1 success)")
-		assert.Equal(t, float64(0), statusCounterValue(t, "503"), "retried-away 503 should not be counted")
+		assert.Equal(t, float64(0), statusCounterValue(t, "503", "throttle"), "retried-away 503 should not be counted")
 	})
 
-	t.Run("retry-exhausted 503 is counted once", func(t *testing.T) {
+	t.Run("retry-exhausted RequestLimitExceeded 503 is counted once as throttle", func(t *testing.T) {
 		awsAPIResponseStatusTotal.Reset()
 		calls := 0
 		err := run(middleware.FinalizeHandlerFunc(func(ctx context.Context, in middleware.FinalizeInput) (
 			middleware.FinalizeOutput, middleware.Metadata, error) {
 			calls++
-			return middleware.FinalizeOutput{}, middleware.Metadata{}, respErr(503)
+			return middleware.FinalizeOutput{}, middleware.Metadata{}, respErr(503, "RequestLimitExceeded")
 		}))
 		assert.Error(t, err, "expected terminal error after exhausting retries")
 		assert.Equal(t, 3, calls, "expected 3 attempts (max)")
-		assert.Equal(t, float64(1), statusCounterValue(t, "503"), "retry-exhausted 503 should be counted exactly once")
+		assert.Equal(t, float64(1), statusCounterValue(t, "503", "throttle"), "retry-exhausted 503 should be counted exactly once")
 	})
 
 	t.Run("non-retryable 400 is counted once on first attempt", func(t *testing.T) {
@@ -166,9 +190,9 @@ func TestAWSAPIMetricsMiddlewareWithRetries(t *testing.T) {
 		err := run(middleware.FinalizeHandlerFunc(func(ctx context.Context, in middleware.FinalizeInput) (
 			middleware.FinalizeOutput, middleware.Metadata, error) {
 			calls++
-			return middleware.FinalizeOutput{}, middleware.Metadata{}, respErr(400)
+			return middleware.FinalizeOutput{}, middleware.Metadata{}, respErr(400, "")
 		}))
 		assert.Error(t, err, "expected terminal error for 400")
-		assert.Equal(t, float64(1), statusCounterValue(t, "400"), "terminal 400 should be counted exactly once")
+		assert.Equal(t, float64(1), statusCounterValue(t, "400", ""), "terminal 400 should be counted exactly once")
 	})
 }

--- a/pkg/providers/v1/aws_api_metrics_test.go
+++ b/pkg/providers/v1/aws_api_metrics_test.go
@@ -75,27 +75,43 @@ func TestAWSAPIMetricsMiddleware(t *testing.T) {
 			name:             "terminal 4xx records status code",
 			err:              respErr(403, ""),
 			expectStatusCode: "403",
+			expectErrorType:  awsAPIErrorTypeOther,
 		},
 		{
 			name:             "terminal 5xx records status code",
 			err:              respErr(500, ""),
 			expectStatusCode: "500",
+			expectErrorType:  awsAPIErrorTypeOther,
 		},
 		{
 			name:             "terminal RequestLimitExceeded 503 records throttle error type",
 			err:              respErr(503, "RequestLimitExceeded"),
 			expectStatusCode: "503",
-			expectErrorType:  "throttle",
+			expectErrorType:  awsAPIErrorTypeThrottle,
 		},
 		{
-			name:             "terminal 503 without API error records empty error type",
+			name:             "terminal 503 without API error records other error type",
 			err:              respErr(503, ""),
 			expectStatusCode: "503",
+			expectErrorType:  awsAPIErrorTypeOther,
 		},
 		{
-			name:             "terminal ThrottlingException 400 records empty error type",
+			name:             "terminal ThrottlingException 400 records throttle error type",
 			err:              respErr(400, "ThrottlingException"),
 			expectStatusCode: "400",
+			expectErrorType:  awsAPIErrorTypeThrottle,
+		},
+		{
+			name:             "terminal 429 without API error records throttle error type",
+			err:              respErr(429, ""),
+			expectStatusCode: "429",
+			expectErrorType:  awsAPIErrorTypeThrottle,
+		},
+		{
+			name:             "terminal non-throttle API error records other error type",
+			err:              respErr(400, "ValidationException"),
+			expectStatusCode: "400",
+			expectErrorType:  awsAPIErrorTypeOther,
 		},
 		{
 			name: "success records nothing",
@@ -168,7 +184,7 @@ func TestAWSAPIMetricsMiddlewareWithRetries(t *testing.T) {
 		}))
 		assert.NoError(t, err, "expected success after retry")
 		assert.Equal(t, 2, calls, "expected 2 attempts (1 fail + 1 success)")
-		assert.Equal(t, float64(0), statusCounterValue(t, "503", "throttle"), "retried-away 503 should not be counted")
+		assert.Equal(t, float64(0), statusCounterValue(t, "503", awsAPIErrorTypeThrottle), "retried-away 503 should not be counted")
 	})
 
 	t.Run("retry-exhausted RequestLimitExceeded 503 is counted once as throttle", func(t *testing.T) {
@@ -181,7 +197,7 @@ func TestAWSAPIMetricsMiddlewareWithRetries(t *testing.T) {
 		}))
 		assert.Error(t, err, "expected terminal error after exhausting retries")
 		assert.Equal(t, 3, calls, "expected 3 attempts (max)")
-		assert.Equal(t, float64(1), statusCounterValue(t, "503", "throttle"), "retry-exhausted 503 should be counted exactly once")
+		assert.Equal(t, float64(1), statusCounterValue(t, "503", awsAPIErrorTypeThrottle), "retry-exhausted 503 should be counted exactly once")
 	})
 
 	t.Run("non-retryable 400 is counted once on first attempt", func(t *testing.T) {
@@ -193,6 +209,6 @@ func TestAWSAPIMetricsMiddlewareWithRetries(t *testing.T) {
 			return middleware.FinalizeOutput{}, middleware.Metadata{}, respErr(400, "")
 		}))
 		assert.Error(t, err, "expected terminal error for 400")
-		assert.Equal(t, float64(1), statusCounterValue(t, "400", ""), "terminal 400 should be counted exactly once")
+		assert.Equal(t, float64(1), statusCounterValue(t, "400", awsAPIErrorTypeOther), "terminal 400 should be counted exactly once")
 	})
 }

--- a/pkg/providers/v1/aws_metrics.go
+++ b/pkg/providers/v1/aws_metrics.go
@@ -19,10 +19,12 @@ package aws
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strconv"
 	"sync"
 
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/middleware"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -61,10 +63,10 @@ var (
 	awsAPIResponseStatusTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Name:           "cloudprovider_aws_api_response_status_total",
-			Help:           "AWS API error response status code counts (terminal, after retries are exhausted)",
+			Help:           "AWS API error response counts by status code and error type (terminal, after retries are exhausted)",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"service", "operation", "status_code"})
+		[]string{"service", "operation", "status_code", "error_type"})
 )
 
 func recordAWSMetric(actionName string, timeTaken float64, err error) {
@@ -110,10 +112,19 @@ func awsAPIMetricsMiddleware() middleware.FinalizeMiddleware {
 			// an *awshttp.ResponseError; a nil error means a 2xx, which we do not count.
 			var respErr *awshttp.ResponseError
 			if errors.As(err, &respErr) && respErr.HTTPStatusCode() >= 400 {
+				errorType := ""
+				if respErr.HTTPStatusCode() == http.StatusServiceUnavailable {
+					var apiErr smithy.APIError
+					if errors.As(err, &apiErr) && apiErr.ErrorCode() == "RequestLimitExceeded" {
+						errorType = "throttle"
+					}
+				}
+
 				awsAPIResponseStatusTotal.With(metrics.Labels{
 					"service":     middleware.GetServiceID(ctx),
 					"operation":   middleware.GetOperationName(ctx),
 					"status_code": strconv.Itoa(respErr.HTTPStatusCode()),
+					"error_type":  errorType,
 				}).Inc()
 			}
 

--- a/pkg/providers/v1/aws_metrics.go
+++ b/pkg/providers/v1/aws_metrics.go
@@ -23,11 +23,16 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
-	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/middleware"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	awsAPIErrorTypeOther    = "other"
+	awsAPIErrorTypeThrottle = "throttle"
 )
 
 var (
@@ -63,7 +68,7 @@ var (
 	awsAPIResponseStatusTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Name:           "cloudprovider_aws_api_response_status_total",
-			Help:           "AWS API error response counts by status code and error type (terminal, after retries are exhausted)",
+			Help:           "AWS API error response counts by status code and bounded error type (throttle or other; terminal, after retries are exhausted)",
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"service", "operation", "status_code", "error_type"})
@@ -112,12 +117,11 @@ func awsAPIMetricsMiddleware() middleware.FinalizeMiddleware {
 			// an *awshttp.ResponseError; a nil error means a 2xx, which we do not count.
 			var respErr *awshttp.ResponseError
 			if errors.As(err, &respErr) && respErr.HTTPStatusCode() >= 400 {
-				errorType := ""
-				if respErr.HTTPStatusCode() == http.StatusServiceUnavailable {
-					var apiErr smithy.APIError
-					if errors.As(err, &apiErr) && apiErr.ErrorCode() == "RequestLimitExceeded" {
-						errorType = "throttle"
-					}
+				errorType := awsAPIErrorTypeOther
+				throttleErrorCode := retry.ThrottleErrorCode{Codes: retry.DefaultThrottleErrorCodes}
+				if respErr.HTTPStatusCode() == http.StatusTooManyRequests ||
+					throttleErrorCode.IsErrorThrottle(err).Bool() {
+					errorType = awsAPIErrorTypeThrottle
 				}
 
 				awsAPIResponseStatusTotal.With(metrics.Labels{


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

AWS services can report throttling through HTTP 429 or service-specific API error codes. Some throttling errors, such as EC2 `RequestLimitExceeded`, can use HTTP 503 and are therefore indistinguishable from service-side 5xx failures in `cloudprovider_aws_api_response_status_total`.

This PR adds a bounded `error_type` label while preserving the actual HTTP `status_code`. Terminal errors use `error_type="throttle"` when the response is HTTP 429 or the API error code is included in the AWS SDK's `retry.DefaultThrottleErrorCodes`; all other terminal HTTP errors use `error_type="other"`. Because the middleware wraps the SDK retry loop, errors recovered by a retry remain uncounted.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

- The implementation references the SDK's exported throttle-code set instead of maintaining a separate list.
- Keeping `status_code` unchanged preserves its HTTP semantics and allows existing consumers to retain their current behavior while producers and consumers roll out independently.
- This metric is ALPHA. `error_type` has exactly two values: `"throttle"` and `"other"`.

Validation:
- `go test ./pkg/providers/v1 -run 'TestAWSAPIMetricsMiddleware' -count=1`
- `go test ./pkg/providers/v1 -count=1`
- `go vet ./pkg/providers/v1`
- `go build ./...`
- `./hack/verify-gofmt.sh`

**Does this PR introduce a user-facing change?**:

```release-note
The cloudprovider_aws_api_response_status_total metric now includes a bounded error_type label that classifies terminal AWS API responses as throttle or other while preserving the HTTP status code.
```
