### PR TITLE
FrontendProtocol is ProtocolEnumTls,producing the invalid IP protocol tls changed to tcp.

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -2321,6 +2321,18 @@ func (c *Cloud) ensureNLBSecurityGroup(ctx context.Context, clusterName string, 
 	return []string{securityGroupID}, true, nil // Managed SG: attach rules
 }
 
+// nlbListenerIPProtocol maps an NLB listener protocol to the IP protocol used
+// for EC2 security group ingress rules. NLB listeners are TCP, UDP, or TLS;
+// TLS runs over TCP, so anything that is not UDP maps to tcp. This avoids
+// passing "tls" to AuthorizeSecurityGroupIngress, which EC2 rejects with
+// "Invalid value 'tls' for IP protocol".
+func nlbListenerIPProtocol(protocol elbv2types.ProtocolEnum) string {
+	if protocol == elbv2types.ProtocolEnumUdp {
+		return "udp"
+	}
+	return "tcp"
+}
+
 // ensureNLBSecurityGroupRules ensures the NLB frontend security group rules are created and configured
 // based on the load balancer port mappings (Load Balancer listeners), allowing traffic from the
 // specified source ranges.
@@ -2344,7 +2356,7 @@ func (c *Cloud) ensureNLBSecurityGroupRules(ctx context.Context, securityGroupID
 		ingressRules.Insert(ec2types.IpPermission{
 			FromPort:   aws.Int32(int32(mapping.FrontendPort)),
 			ToPort:     aws.Int32(int32(mapping.FrontendPort)),
-			IpProtocol: aws.String(strings.ToLower(string((mapping.FrontendProtocol)))),
+			IpProtocol: aws.String(nlbListenerIPProtocol(mapping.FrontendProtocol)),
 			IpRanges:   ec2SourceRanges,
 		})
 	}

--- a/pkg/providers/v1/aws_test.go
+++ b/pkg/providers/v1/aws_test.go
@@ -4472,6 +4472,39 @@ func TestCreateSecurityGroupRules(t *testing.T) {
 	}
 }
 
+// TestNLBListenerIPProtocol guards against OCPBUGS-115250: an NLB TLS listener
+// must map to IP protocol "tcp" for security group ingress rules, since EC2
+// rejects "tls" as an IP protocol with "Invalid value 'tls' for IP protocol".
+func TestNLBListenerIPProtocol(t *testing.T) {
+	testCases := []struct {
+		name     string
+		protocol elbv2types.ProtocolEnum
+		expected string
+	}{
+		{
+			name:     "TCP listener maps to tcp",
+			protocol: elbv2types.ProtocolEnumTcp,
+			expected: "tcp",
+		},
+		{
+			name:     "UDP listener maps to udp",
+			protocol: elbv2types.ProtocolEnumUdp,
+			expected: "udp",
+		},
+		{
+			name:     "TLS listener maps to tcp",
+			protocol: elbv2types.ProtocolEnumTls,
+			expected: "tcp",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, nlbListenerIPProtocol(tc.protocol))
+		})
+	}
+}
+
 func TestCreateSecurityGroup(t *testing.T) {
 	awsServices := newMockedFakeAWSServices(TestClusterID)
 	cfg := config.CloudConfig{}


### PR DESCRIPTION
/kind bug 

This PR adds a nlbListenerIPProtocol helper that maps the NLB listener protocol to a valid IP protocol for SG ingress rules — udp for UDP, tcp otherwise (so TLS → tcp) — and uses it in ensureNLBSecurityGroupRules. This mirrors the convention already used by the worker-node path (updateInstanceSecurityGroupsForNLB), keeping both NLB SG paths consistent. FrontendProtocol itself is left as TLS since it is still required for listener creation. checkProtocol restricts NLB ports to TCP/UDP before this mapping runs, so the helper is total over the only reachable values (TCP, UDP, TLS).
  
   *Fixes* https://issues.redhat.com/browse/OCPBUGS-115250
   
  Does this PR introduce a user-facing change?:
  
  /release-note
```
  Fixed a bug where a Service-type LoadBalancer NLB with a TLS listener failed to provision because the managed security group ingress rule was created with the listener protocol "tls" instead of the IP protocol
  "tcp", which EC2 rejected.
```

